### PR TITLE
expo compatible module

### DIFF
--- a/packages/otplib-expo/crypto.js
+++ b/packages/otplib-expo/crypto.js
@@ -1,0 +1,12 @@
+import crypto from "crypto";
+import randomBytes from "./randomBytes";
+
+/**
+  * Crypto replacement for expo
+  *
+  * @module otplib-expo/crypto
+  */
+export default {
+  createHmac: crypto.createHmac,
+  randomBytes
+};

--- a/packages/otplib-expo/crypto.spec.js
+++ b/packages/otplib-expo/crypto.spec.js
@@ -1,0 +1,9 @@
+import crypto from "./crypto";
+
+describe("crypto", () => {
+  test("should expose an object with a used method", () => {
+    expect(typeof crypto).toBe("object");
+    expect(typeof crypto.createHmac).toBe("function");
+    expect(typeof crypto.randomBytes).toBe("function");
+  });
+});

--- a/packages/otplib-expo/index.js
+++ b/packages/otplib-expo/index.js
@@ -1,0 +1,24 @@
+import hotp from "otplib-hotp";
+import totp from "otplib-totp";
+import authenticator from "otplib-authenticator";
+import crypto from "./crypto";
+
+/**
+ * otplib-expo
+ *
+ * One-Time Password Library for expo
+ *
+ * @module otplib-expo
+ */
+authenticator.options = { crypto };
+hotp.options = { crypto };
+totp.options = { crypto };
+
+module.exports = {
+  Authenticator: authenticator.Authenticator,
+  HOTP: hotp.HOTP,
+  TOTP: totp.TOTP,
+  authenticator,
+  hotp,
+  totp
+};

--- a/packages/otplib-expo/randomBytes.js
+++ b/packages/otplib-expo/randomBytes.js
@@ -1,0 +1,34 @@
+/**
+  * randomBytes naive implementation.
+  * 
+  * Required for expo applications that don't offer a native
+  * secure random implementaton
+  *
+  * @module otplib-expo/randomBytes
+  * @param {string} size - the size
+  * @return {string}
+  */
+function randomBytes(size) {
+  if (size > 65536) {
+    throw new Error("Requested size of random bytes is too large");
+  }
+
+  if (size < 1) {
+    throw new Error("Requested size must be more than 0");
+  }
+
+  const rawBytes = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    rawBytes[i] = randomUint8();
+  }
+
+  return new Buffer(rawBytes.buffer);
+}
+
+function randomUint8() {
+  const low = 0;
+  const high = 255;
+  return Math.floor(Math.random() * (high - low + 1) + low);
+}
+
+export default randomBytes;

--- a/packages/otplib-expo/randomBytes.spec.js
+++ b/packages/otplib-expo/randomBytes.spec.js
@@ -1,0 +1,20 @@
+import randomBytes from "./randomBytes";
+
+describe("randomBytes", () => {
+  const tooLarge = "Requested size of random bytes is too large";
+  const wrongSize = "Requested size must be more than 0";
+
+  it(`[${name}] should return a buffer`, () => {
+    const result = randomBytes(10);
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result).toHaveLength(10);
+  });
+
+  it(`[${name}] should throw when size is too big`, () => {
+    expect(() => randomBytes(65537)).toThrowError(tooLarge);
+  });
+
+  it(`[${name}] should throw when size is < 1`, () => {
+    expect(() => randomBytes(0)).toThrowError(wrongSize);
+  });
+});

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -6,9 +6,9 @@ const directory = require('./helpers/directory');
 
 const ENV = process.env.NODE_ENV;
 
-module.exports = {
+const webConfig = {
   entry: {
-    'otplib': directory.SOURCE + '/otplib-browser/index.js'
+    otplib: directory.SOURCE + '/otplib-browser/index.js'
   },
   output: {
     library: '[name]',
@@ -17,13 +17,13 @@ module.exports = {
     filename: 'otplib-browser.js'
   },
   module: {
-    rules: [{
-      test: /\.js?$/,
-      exclude: /node_modules/,
-      use: [
-        'babel-loader',
-      ]
-    }]
+    rules: [
+      {
+        test: /\.js?$/,
+        exclude: /node_modules/,
+        use: ['babel-loader']
+      }
+    ]
   },
   resolve: {
     alias: aliases
@@ -45,3 +45,41 @@ module.exports = {
   devtool: 'cheap-module-source-map',
   target: 'web'
 };
+
+const expoConfig = {
+  entry: {
+    otplib: directory.SOURCE + '/otplib-expo/index.js'
+  },
+  output: {
+    library: '[name]',
+    libraryTarget: 'umd',
+    path: directory.BUILD,
+    filename: 'otplib-expo.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js?$/,
+        exclude: /node_modules/,
+        use: ['babel-loader']
+      }
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(ENV)
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    }),
+    new webpack.BannerPlugin({
+      banner: createBanner('otplib-expo'),
+      raw: true
+    })
+  ],
+  devtool: 'cheap-module-source-map'
+};
+
+module.exports = [webConfig, expoConfig];


### PR DESCRIPTION
This is a follow up on a previous pull request to allow otplib usage within [expo](https://expo.io/) applications.

I managed to package a working module by replacing the randomBytes method (uses native secure random implementations in web and node) with a very naive non-secure version.

`createHmac` does not have to be replaced as webpack will automatically package the javascript implementation.

This is a rough draft for now. I can also update the usage section of the documentation if you consider it.