### PR TITLE
feat: standardize options passing and errors

### DIFF
--- a/packages/otplib-authenticator/Authenticator.js
+++ b/packages/otplib-authenticator/Authenticator.js
@@ -86,7 +86,7 @@ class Authenticator extends TOTP {
     if (!len) {
       return '';
     }
-    const secret = secretKey(len, this.options);
+    const secret = secretKey(len, this.optionsAll);
     return encodeKey(secret);
   }
 
@@ -96,10 +96,8 @@ class Authenticator extends TOTP {
    * @see {@link module:impl/authenticator/token}
    */
   generate(secret) {
-    return token(
-      secret || this.options.secret,
-      this.options
-    );
+    const opt = this.optionsAll;
+    return token(secret || opt.secret, opt);
   }
 
   /**
@@ -112,11 +110,8 @@ class Authenticator extends TOTP {
    * @see {@link module:impl/authenticator/check}
    */
   check(token, secret) {
-    return check(
-      token,
-      secret || this.options.secret,
-      this.options
-    );
+    const opt = this.optionsAll;
+    return check(token, secret || opt.secret, opt);
   }
 }
 
@@ -126,6 +121,6 @@ Authenticator.prototype.utils = {
   decodeKey,
   encodeKey,
   keyuri,
-  token,
+  token
 }
 export default Authenticator;

--- a/packages/otplib-authenticator/Authenticator.spec.js
+++ b/packages/otplib-authenticator/Authenticator.spec.js
@@ -30,7 +30,7 @@ describe('Authenticator', function () {
       'decodeKey',
       'encodeKey',
       'keyuri',
-      'token',
+      'token'
     ]);
   });
 
@@ -67,10 +67,11 @@ describe('Authenticator', function () {
 
   it('method: generateSecret should return an encoded secret', function () {
     const mocks = mockGenerateSecret();
+    lib.options = { epoch: 1519995424045 }
     const result = lib.generateSecret(10);
 
     expect(mocks.secretKey).toHaveBeenCalledTimes(1);
-    expect(mocks.secretKey).toHaveBeenCalledWith(10, lib.options);
+    expect(mocks.secretKey).toHaveBeenCalledWith(10, lib.optionsAll);
 
     expect(encodeKey).toHaveBeenCalledTimes(1);
     expect(encodeKey).toHaveBeenCalledWith(mocks.secret);
@@ -138,13 +139,14 @@ describe('Authenticator', function () {
 
   function methodExpectationWithOptions(methodName, mockFn, args, modifiedArgs) {
     mockFn.mockImplementation(() => testValue);
+    lib.options = { epoch: 1519995424045 }
 
     const result = lib[methodName](...args);
     const calledArgs = modifiedArgs || args;
 
     expect(result).toBe(testValue);
     expect(mockFn).toHaveBeenCalledTimes(1);
-    expect(mockFn).toHaveBeenCalledWith(...calledArgs, lib.options)
+    expect(mockFn).toHaveBeenCalledWith(...calledArgs, lib.optionsAll)
   }
 
   function mockGenerateSecret() {

--- a/packages/otplib-core/hotpCheck.js
+++ b/packages/otplib-core/hotpCheck.js
@@ -11,7 +11,7 @@ import hotpToken from './hotpToken';
  * @param {object} options - options which was used to generate it originally
  * @return {boolean}
  */
-function hotpCheck(token, secret, counter, options = {}) {
+function hotpCheck(token, secret, counter, options) {
   const systemToken = hotpToken(secret, counter, options);
 
   if (systemToken.length < 1) {

--- a/packages/otplib-core/hotpCheck.spec.js
+++ b/packages/otplib-core/hotpCheck.spec.js
@@ -1,9 +1,17 @@
 import crypto from 'crypto';
 import hotpCheck from './hotpCheck';
+import hotpSecret from './hotpSecret';
 
 describe('hotpCheck', function () {
   const secret = 'i6im0gc96j0mn00c';
   const token = '229021';
+  const options = {
+    algorithm: 'sha1',
+    createHmacSecret: hotpSecret,
+    crypto,
+    digits: 6,
+    encoding: 'ascii',
+  }
 
   it('should throw an error when option is null', function () {
     expect(() => hotpCheck(token, secret, 0, null)).toThrow(Error);
@@ -14,11 +22,11 @@ describe('hotpCheck', function () {
   });
 
   it('should return false when counter is null', function () {
-    expect(hotpCheck(token, secret, null, {crypto})).toBe(false);
+    expect(hotpCheck(token, secret, null, options)).toBe(false);
   });
 
   it('should return false when counter is undefined', function () {
-    expect(hotpCheck(token, secret, void 0, {crypto})).toBe(false);
+    expect(hotpCheck(token, secret, void 0, options)).toBe(false);
   });
 
   [
@@ -29,9 +37,8 @@ describe('hotpCheck', function () {
     ['2o9989k76ij7eh9c', 47412435, '343659']
   ].forEach((entry, idx) => {
     const [setSecret, setCounter, setToken] = entry;
-
     it(`${idx} should return true `, function () {
-      expect(hotpCheck(setToken, setSecret, setCounter, {crypto})).toBe(true);
+      expect(hotpCheck(setToken, setSecret, setCounter, options)).toBe(true);
     });
   });
 });

--- a/packages/otplib-core/hotpDigest.js
+++ b/packages/otplib-core/hotpDigest.js
@@ -1,5 +1,4 @@
 import hotpCounter from './hotpCounter';
-import hotpSecret from './hotpSecret';
 
 /**
  * Intermediate HOTP Digests
@@ -13,19 +12,20 @@ import hotpSecret from './hotpSecret';
  * @return {string} - hex string
  */
 function hotpDigest(secret, counter, options) {
-  if (typeof options !== 'object' || options == null) {
-    throw new Error('Expecting options to be an object');
-  }
-
   if (!options.crypto || typeof options.crypto.createHmac !== 'function') {
     throw new Error('Expecting options.crypto to have a createHmac function');
   }
 
-  // Allow for direct digest use without going through hotpOptions
-  const createHmacSecret = options.createHmacSecret || hotpSecret;
+  if (typeof options.createHmacSecret !== 'function') {
+    throw new Error('Expecting options.createHmacSecret to be a function')
+  }
+
+  if (typeof options.algorithm !== 'string') {
+    throw new Error('Expecting options.algorithm to be a string')
+  }
 
   // Convert secret to encoding for hmacSecret
-  const hmacSecret = createHmacSecret(secret, options);
+  const hmacSecret = options.createHmacSecret(secret, options);
 
   // Ensure counter is a buffer or string (for HMAC creation)
   const hexCounter = hotpCounter(counter);

--- a/packages/otplib-core/hotpDigest.spec.js
+++ b/packages/otplib-core/hotpDigest.spec.js
@@ -4,27 +4,44 @@ describe('hotpDigest', function () {
 
   const secret = 'test';
   const counter = 0;
+  const noop = () => {}
 
-  const noOptions = 'Expecting options to be an object';
   const noCrypto = 'Expecting options.crypto to have a createHmac function';
+  const noCreateHmacSecret = 'Expecting options.createHmacSecret to be a function';
+  const noAlgorithm = 'Expecting options.algorithm to be a string';
 
   it('should throw an error if options is null', function () {
-    expect(() => hotpDigest(secret, counter, null)).toThrowError(noOptions);
+    expect(() => hotpDigest(secret, counter, null)).toThrow(Error);
   });
 
   it('should throw an error if options is undefined', function () {
-    expect(() => hotpDigest(secret, counter)).toThrowError(noOptions);
+    expect(() => hotpDigest(secret, counter)).toThrow(Error);
   });
 
   it('should throw an error if options is not an object', function () {
-    expect(() => hotpDigest(secret, counter, 'notObject')).toThrowError(noOptions);
+    expect(() => hotpDigest(secret, counter, 'notObject')).toThrow(Error);
   });
 
-  it('should throw an error if options.crypto is not defined', function () {
+  it('should throw an error if options.crypto is undefined', function () {
     expect(() => hotpDigest(secret, counter, {})).toThrowError(noCrypto);
   });
 
-  it('should throw an error if options.crypto does not have a createHmac function', function () {
+  it('should throw an error if options.crypto.createHmac is not a function', function () {
     expect(() => hotpDigest(secret, counter, {crypto: {}})).toThrowError(noCrypto);
+  });
+
+  it('should throw an error if options.createHmacSecret is not a function', function () {
+    const options = {
+      crypto: { createHmac: noop }
+    }
+    expect(() => hotpDigest(secret, counter, options)).toThrowError(noCreateHmacSecret);
+  });
+
+  it('should throw an error if options.alogrithm is not a string', function () {
+    const options = {
+      crypto: { createHmac: noop },
+      createHmacSecret: noop
+    }
+    expect(() => hotpDigest(secret, counter, options)).toThrowError(noAlgorithm);
   });
 });

--- a/packages/otplib-core/hotpSecret.js
+++ b/packages/otplib-core/hotpSecret.js
@@ -7,6 +7,10 @@
  * @return {object}
  */
 function hotpSecret(secret, options) {
+  if (typeof options.encoding !== 'string') {
+    throw new Error('Expecting options.encoding to be a string')
+  }
+
   return new Buffer(secret, options.encoding);
 }
 

--- a/packages/otplib-core/hotpSecret.spec.js
+++ b/packages/otplib-core/hotpSecret.spec.js
@@ -1,0 +1,11 @@
+import hotpSecret from './hotpSecret';
+
+describe('hotpSecret', function () {
+  it('should throw an error when options is undefined', function () {
+    expect(() => hotpSecret('hello', {})).toThrow(Error);
+  });
+
+  it('should throw an error when options.encoding is undefined', function () {
+    expect(() => hotpSecret('hello', {})).toThrowError('Expecting options.encoding to be a string');
+  });
+});

--- a/packages/otplib-core/hotpToken.js
+++ b/packages/otplib-core/hotpToken.js
@@ -1,6 +1,5 @@
 import {leftPad} from 'otplib-utils';
 import hotpDigest from './hotpDigest';
-import hotpOptions from './hotpOptions';
 
 /**
  * Generates the OTP code
@@ -11,13 +10,16 @@ import hotpOptions from './hotpOptions';
  * @param {object} options - allowed options as specified in hotpOptions()
  * @return {string} OTP Code
  */
-function hotpToken(secret, counter, options = {}) {
+function hotpToken(secret, counter, options) {
   if (counter == null) {
-    return '';
+    return ''
   }
 
-  const opt = hotpOptions(options);
-  const digest = hotpDigest(secret, counter, opt);
+  if (typeof options.digits !== 'number') {
+    throw new Error('Expecting options.digits to be a number');
+  }
+
+  const digest = hotpDigest(secret, counter, options);
 
   const offset = digest[digest.length - 1] & 0xf;
   const binary = ((digest[offset] & 0x7f) << 24) |
@@ -26,10 +28,10 @@ function hotpToken(secret, counter, options = {}) {
     (digest[offset + 3] & 0xff);
 
   // code := truncatedHash mod 1000000
-  let token = binary % Math.pow(10, opt.digits);
+  let token = binary % Math.pow(10, options.digits);
 
   // left pad code with 0 until length of code is as defined.
-  token = leftPad(token, opt.digits);
+  token = leftPad(token, options.digits);
 
   return token;
 }

--- a/packages/otplib-core/hotpToken.spec.js
+++ b/packages/otplib-core/hotpToken.spec.js
@@ -1,8 +1,16 @@
 import crypto from 'crypto';
 import hotpToken from './hotpToken';
+import hotpSecret from './hotpSecret';
 
 describe('hotpToken', function () {
   const secret = 'i6im0gc96j0mn00c';
+  const options = {
+    algorithm: 'sha1',
+    createHmacSecret: hotpSecret,
+    crypto,
+    digits: 6,
+    encoding: 'ascii',
+  }
 
   it('should throw an error when option is null', function () {
     expect(() => hotpToken(secret, 3, null)).toThrow(Error);
@@ -12,35 +20,29 @@ describe('hotpToken', function () {
     expect(() => hotpToken(secret, 3, void 0)).toThrow(Error);
   });
 
+  it('should throw an error when option.digits is undefined', function () {
+    expect(() => hotpToken(secret, 3, {})).toThrowError('Expecting options.digits to be a number');
+  });
   it(`should return empty string when counter is null`, function () {
-    expect(hotpToken(secret, null, {crypto})).toBe('');
+    expect(hotpToken(secret, null, options)).toBe('');
   });
 
   it(`should return empty string when counter is void 0`, function () {
-    expect(hotpToken(secret, void 0, {crypto})).toBe('');
+    expect(hotpToken(secret, void 0, options)).toBe('');
   });
 
   it('should return tokens with 8 digits', function () {
-    const token = hotpToken(secret, 3, {
-      crypto,
-      digits: 8
-    });
+    const token = hotpToken(secret, 3, Object.assign({}, options, { digits: 8 }));
     expect(token).toBe('12229021');
   });
 
   it('should return correct tokens with hex secret', function () {
-    const token = hotpToken('6936696d30676339366a306d6e303063', 3, {
-      crypto,
-      encoding: 'hex'
-    });
+    const token = hotpToken('6936696d30676339366a306d6e303063', 3, Object.assign({}, options, { encoding: 'hex' }));
     expect(token).toBe('229021');
   });
 
   it('should return correct tokens with base64 secret', function () {
-    const token = hotpToken('aTZpbTBnYzk2ajBtbjAwYw==', 3, {
-      crypto,
-      encoding: 'base64'
-    });
+    const token = hotpToken('aTZpbTBnYzk2ajBtbjAwYw==', 3, Object.assign({}, options, { encoding: 'base64' }));
     expect(token).toBe('229021');
   });
 
@@ -54,7 +56,7 @@ describe('hotpToken', function () {
     const [setSecret, setCounter, setToken] = entry;
 
     it(`[${idx}] should return correct tokens`, function () {
-      const token = hotpToken(setSecret, setCounter, {crypto});
+      const token = hotpToken(setSecret, setCounter, options);
       expect(token).toBe(setToken);
     });
   });

--- a/packages/otplib-core/totpCheckWithWindow.js
+++ b/packages/otplib-core/totpCheckWithWindow.js
@@ -2,7 +2,7 @@ import totpCheck from './totpCheck';
 
 function getPrevWindowOption(options, windowCount) {
   return Object.assign(options, {
-    epoch: options.epoch - (options.step * windowCount)
+    epoch: options.epoch - (options.step * windowCount * 1000)
   });
 }
 

--- a/packages/otplib-core/totpCheckWithWindow.spec.js
+++ b/packages/otplib-core/totpCheckWithWindow.spec.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import totpCheckWithWindow from './totpCheckWithWindow';
 import totpCheck from './totpCheck';
+import totpOptions from './totpOptions';
 
 jest.mock('./totpCheck', () => jest.fn());
 const {default: totpCheckOriginal} = require.requireActual('./totpCheck');
@@ -24,22 +25,22 @@ describe('totpCheck', function() {
     }
   ];
 
-  function token(n) {
-    return timeToken[n].token;
+  function getOptions(n, win) {
+    return totpOptions({
+      crypto,
+      epoch: timeToken[n].time,
+      window: win
+    })
   }
 
-  function time(n) {
-    return timeToken[n].time;
+  function token(n) {
+    return timeToken[n].token;
   }
 
   it('should call totpCheck 1 time when window is 0', function() {
     totpCheck.mockImplementation(() => false);
 
-    totpCheckWithWindow(token(0), secret, {
-      epoch: time(0),
-      step: 30,
-      window: 0
-    });
+    totpCheckWithWindow(token(0), secret, getOptions(1, 0));
 
     expect(totpCheck).toHaveBeenCalledTimes(1);
   });
@@ -47,64 +48,39 @@ describe('totpCheck', function() {
   it('should call totpCheck 2 times when window is 1', function() {
     totpCheck.mockImplementation(() => false);
 
-    totpCheckWithWindow('', secret, {
-      epoch: time(1),
-      step: 30,
-      window: 1
-    });
+    totpCheckWithWindow('', secret, getOptions(1, 1));
 
     expect(totpCheck).toHaveBeenCalledTimes(2);
   });
 
-  it('current 3, window 1, token 0, called 2, return false', function() {
+  it('time 3, window 1, token 0, called 2, return false', function() {
     totpCheck.mockImplementation((...args) => {
       return totpCheckOriginal(...args);
     })
 
-    const opt = {
-      crypto,
-      epoch: time(2),
-      step: 30,
-      window: 1
-    };
-
-    const result = totpCheckWithWindow(token(0), secret, opt);
+    const result = totpCheckWithWindow(token(0), secret, getOptions(2, 1));
 
     expect(result).toBe(false);
     expect(totpCheck).toHaveBeenCalledTimes(2);
   });
 
-  it('current 2, window 1, token 1, called 2, return true', function() {
+  it('time 2, window 1, token 1, called 2, return true', function() {
     totpCheck.mockImplementation((...args) => {
       return totpCheckOriginal(...args);
     })
 
-    const opt = {
-      crypto,
-      epoch: time(1),
-      step: 30,
-      window: 1
-    };
-
-    const result = totpCheckWithWindow(token(0), secret, opt);
+    const result = totpCheckWithWindow(token(0), secret, getOptions(1, 1));
 
     expect(result).toBe(true);
     expect(totpCheck).toHaveBeenCalledTimes(2);
   });
 
-  it('current 3, window 2, token 1, called 2, return true', function() {
+  it('time 3, window 2, token 1, called 2, return true', function() {
     totpCheck.mockImplementation((...args) => {
       return totpCheckOriginal(...args);
     })
 
-    const opt = {
-      crypto,
-      epoch: time(2),
-      step: 30,
-      window: 2
-    };
-
-    const result = totpCheckWithWindow(token(1), secret, opt);
+    const result = totpCheckWithWindow(token(1), secret, getOptions(2, 2));
 
     expect(result).toBe(true);
     expect(totpCheck).toHaveBeenCalledTimes(2);

--- a/packages/otplib-core/totpSecret.js
+++ b/packages/otplib-core/totpSecret.js
@@ -14,6 +14,14 @@ import {padSecret} from 'otplib-utils';
  * @return {object}
  */
 function totpSecret(secret, options) {
+  if (typeof options.algorithm !== 'string') {
+    throw new Error('Expecting options.algorithm to be a string')
+  }
+
+  if (typeof options.encoding !== 'string') {
+    throw new Error('Expecting options.encoding to be a string')
+  }
+
   const encoded = new Buffer(secret, options.encoding);
   const algorithm = options.algorithm.toLowerCase();
 

--- a/packages/otplib-core/totpSecret.spec.js
+++ b/packages/otplib-core/totpSecret.spec.js
@@ -2,6 +2,14 @@ import totpSecret from './totpSecret';
 
 describe('totpSecret', function () {
 
+  it('should throw an error when options.algorithm is not defined', function () {
+    expect(() => totpSecret('hello', {})).toThrow(Error);
+  });
+
+  it('should throw an error when options.encoding is not defined', function () {
+    expect(() => totpSecret('hello', { algorithm: 'sha1' })).toThrow(Error);
+  });
+
   it('should have length 20 with sha1', function () {
     const result = totpSecret('hello', {
       encoding: 'ascii',

--- a/packages/otplib-core/totpToken.js
+++ b/packages/otplib-core/totpToken.js
@@ -1,6 +1,5 @@
 import hotpToken from './hotpToken';
 import totpCounter from './totpCounter';
-import totpOptions from './totpOptions';
 
 /**
  * Generates the OTP code
@@ -10,10 +9,17 @@ import totpOptions from './totpOptions';
  * @param {object} options - allowed options as specified in totpOptions()
  * @return {string} OTP Code
  */
-function totpToken(secret, options = {}) {
-  const opt = totpOptions(options);
-  const counter = totpCounter(opt.epoch, opt.step);
-  return hotpToken(secret, counter, opt);
+function totpToken(secret, options) {
+  if (typeof options.epoch !== 'number') {
+    throw new Error('Expecting options.epoch to be a number');
+  }
+
+  if (typeof options.step !== 'number') {
+    throw new Error('Expecting options.step to be a number');
+  }
+
+  const counter = totpCounter(options.epoch, options.step);
+  return hotpToken(secret, counter, options);
 }
 
 export default totpToken;

--- a/packages/otplib-core/totpToken.spec.js
+++ b/packages/otplib-core/totpToken.spec.js
@@ -1,31 +1,23 @@
-import hotpToken from './hotpToken';
-import totpCounter from './totpCounter';
-import totpOptions from './totpOptions';
 import totpToken from './totpToken';
 
-jest.mock('./hotpToken', () => jest.fn());
-jest.mock('./totpCounter', () => jest.fn());
-jest.mock('./totpOptions', () => jest.fn());
-
 describe('totpToken', function () {
-  const counter = 3;
-  const defaultOptions = { epoch: 60000 };
   const secret = 'i6im0gc96j0mn00c';
+  const noEpoch = 'Expecting options.epoch to be a number'
+  const noStep = 'Expecting options.step to be a number'
 
-  beforeEach(function () {
-    totpCounter.mockImplementation(() => counter);
-    totpOptions.mockImplementation((opt) => Object.assign({}, defaultOptions, opt));
+  it('should throw an error when option is undefined', function () {
+    expect(() => totpToken(secret, void 0)).toThrow(Error);
   });
 
-  it('throws an error when option is undefined', function () {
-    totpToken(secret, void 0);
-    expect(hotpToken).toHaveBeenCalledTimes(1);
-    expect(hotpToken).toHaveBeenCalledWith(secret, counter, defaultOptions);
+  it('should throw an error when option is null', function () {
+    expect(() => totpToken(secret, null)).toThrow(Error);
   });
 
-  it('throws an error when option is null', function () {
-    totpToken(secret, null);
-    expect(hotpToken).toHaveBeenCalledTimes(1);
-    expect(hotpToken).toHaveBeenCalledWith(secret, counter, defaultOptions);
-  });
+  it('should throw an error when options.epoch is undefined', function () {
+    expect(() => totpToken(secret, {})).toThrow(noEpoch)
+  })
+
+  it('should throw an error when options.step is undefined', function () {
+    expect(() => totpToken(secret, { epoch: 0 })).toThrow(noStep)
+  })
 });

--- a/packages/otplib-hotp/HOTP.js
+++ b/packages/otplib-hotp/HOTP.js
@@ -1,4 +1,4 @@
-import {hotpCheck, hotpToken} from 'otplib-core';
+import {hotpCheck, hotpToken, hotpOptions} from 'otplib-core';
 
 /**
  * HMAC-based One-time Password Algorithm
@@ -71,6 +71,16 @@ class HOTP {
   }
 
   /**
+   * Returns instance options, polyfilled with
+   * all missing library defaults
+   *
+   * @return {object}
+   */
+  get optionsAll() {
+    return hotpOptions(this._options)
+  }
+
+  /**
    * Resets options to presets
    *
    * @param {object} option object
@@ -91,11 +101,8 @@ class HOTP {
    * @see {@link module:core/hotpToken} for more information.
    */
   generate(secret, counter) {
-    return hotpToken(
-      secret || this.options.secret,
-      counter,
-      this.options
-    )
+    const opt = this.optionsAll;
+    return hotpToken(secret || opt.secret, counter, opt)
   }
 
   /**
@@ -109,12 +116,8 @@ class HOTP {
    * @see {@link module:core/hotpCheck} for more information.
    */
   check(token, secret, counter) {
-    return hotpCheck(
-      token,
-      secret || this.options.secret,
-      counter,
-      this.options
-    );
+    const opt = this.optionsAll;
+    return hotpCheck(token, secret || opt.secret, counter, opt);
   }
 
   /**

--- a/packages/otplib-hotp/HOTP.spec.js
+++ b/packages/otplib-hotp/HOTP.spec.js
@@ -123,6 +123,6 @@ describe('HOTP', function () {
 
     lib[methodName](...args);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(...args, lib.options)
+    expect(spy).toHaveBeenCalledWith(...args, lib.optionsAll)
   }
 });

--- a/packages/otplib-totp/TOTP.js
+++ b/packages/otplib-totp/TOTP.js
@@ -1,4 +1,4 @@
-import {totpCheck, totpToken} from 'otplib-core';
+import {totpCheck, totpToken, totpOptions} from 'otplib-core';
 import hotp from 'otplib-hotp';
 
 const HOTP = hotp.HOTP;
@@ -46,6 +46,16 @@ class TOTP extends HOTP {
   }
 
   /**
+   * Returns instance options, polyfilled with
+   * all missing library defaults
+   *
+   * @return {object}
+   */
+  get optionsAll() {
+    return totpOptions(this._options)
+  }
+
+  /**
    * Generates token.
    * Passes instance options to underlying core function
    *
@@ -54,10 +64,8 @@ class TOTP extends HOTP {
    * @see {@link module:core/totpToken}
    */
   generate(secret) {
-    return totpToken(
-      secret || this.options.secret,
-      this.options
-    );
+    const opt = this.optionsAll;
+    return totpToken(secret || opt.secret, opt);
   }
 
   /**
@@ -70,11 +78,8 @@ class TOTP extends HOTP {
    * @see {@link module:core/totpCheck}
    */
   check(token, secret){
-    return totpCheck(
-      token,
-      secret || this.options.secret,
-      this.options
-    );
+    const opt = this.optionsAll;
+    return totpCheck(token, secret || opt.secret, opt);
   }
 
   /**

--- a/packages/otplib-totp/TOTP.spec.js
+++ b/packages/otplib-totp/TOTP.spec.js
@@ -80,11 +80,13 @@ describe('TOTP', function () {
   }
 
   function methodExpectationWithOptions(methodName, coreName, args) {
+    lib.options = { epoch: 1519995424045 }
+
     const spy = jest.spyOn(core, coreName)
       .mockImplementation(() => 'result');
 
     lib[methodName](...args);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(...args, lib.options);
+    expect(spy).toHaveBeenCalledWith(...args, lib.optionsAll);
   }
 });

--- a/packages/tests/issues.spec.js
+++ b/packages/tests/issues.spec.js
@@ -4,23 +4,31 @@ import crypto from 'crypto';
 
 describe('issues', function () {
 
-  function getOptions(epoch) {
-    return {
-      crypto,
-      epoch,
-      encoding: 'hex',
-    }
-  }
-
   test('#7.1', function () {
     const secret = 'xbja vgc6 gv4i i4qq h5ct 6stz ytcp ksiz'.replace(/\ /g, '');
-    const result = Authenticator.utils.token(secret, getOptions(1507953809));
+    const auth = new Authenticator.Authenticator;
+
+    auth.options = {
+      crypto,
+      epoch: 1507953809,
+    }
+
+    const result = auth.generate(secret);
+
     expect(result).toBe('849140');
   })
 
   test('#7.2', function () {
     const secret = 'SVT52XEZE2TWC2MU';
-    const result = Authenticator.utils.token(secret, getOptions(1507908269));
+    const auth = new Authenticator.Authenticator;
+
+    auth.options = {
+      crypto,
+      epoch: 1507908269,
+    }
+
+    const result = auth.generate(secret);
+
     expect(result).toBe('334156');
   });
 });

--- a/packages/tests/rfc4226.spec.js
+++ b/packages/tests/rfc4226.spec.js
@@ -1,16 +1,16 @@
 import crypto from 'crypto';
-import {hotpDigest, hotpToken} from 'otplib-core';
+import {hotpDigest, hotpToken, hotpOptions} from 'otplib-core';
 import rfc4226 from './rfc4226';
 
 describe('RFC 4226', function () {
 
   rfc4226.digests.forEach((digest, counter) => {
     test(`[${counter}] expected intermediate HMAC value`, function () {
-      const result = hotpDigest(rfc4226.secret, counter, {
+      const result = hotpDigest(rfc4226.secret, counter, hotpOptions({
         crypto,
         encoding: 'ascii',
         algorithm: 'sha1'
-      });
+      }));
 
       expect(result.toString('hex')).toBe(digest);
     });
@@ -18,9 +18,9 @@ describe('RFC 4226', function () {
 
   rfc4226.tokens.forEach((token, counter) => {
     test(`[${counter}] ${token} token`, function () {
-      const result = hotpToken(rfc4226.secret, counter, {
+      const result = hotpToken(rfc4226.secret, counter, hotpOptions({
         crypto
-      });
+      }));
 
       expect(result).toBe(token);
     });

--- a/packages/tests/rfc6238.spec.js
+++ b/packages/tests/rfc6238.spec.js
@@ -1,5 +1,5 @@
 
-import {hotpCounter, totpCounter, totpToken} from 'otplib-core';
+import {hotpCounter, totpCounter, totpToken, totpOptions} from 'otplib-core';
 import crypto from 'crypto';
 import rfc6238 from './rfc6238';
 
@@ -13,13 +13,13 @@ describe('RFC 6238', function () {
     });
 
     test(`[${id}] ${row.token} token`, function () {
-        const result = totpToken(rfc6238.secret, {
+        const result = totpToken(rfc6238.secret, totpOptions({
           crypto,
           algorithm: row.algorithm,
           digits: 8,
           epoch: row.epoch,
           step: 30
-        });
+        }));
 
         expect(result).toBe(row.token);
     });


### PR DESCRIPTION
In all core functions, options that are passed in are assumed to be a result of hotpOptions and totpOptions. 

The library will not apply the aforementioned functions on options passed in. This makes things more explicit in use.

No change in behaviour is expected with the classes

