### PR TITLE
fix: add testURL to jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "setupFiles": [],
     "testPathIgnorePatterns": [
       "/node_modules/"
-    ]
+    ],
+    "testURL": "http://localhost"
   },
   "repl": [
     {


### PR DESCRIPTION
addresses:
https://circleci.com/gh/yeojz/otplib/1217 failed build

due to:
https://github.com/facebook/jest/issues/6766
https://github.com/jsdom/jsdom/issues/2304