### PR TITLE
Add perameters to keyuri

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,13 @@ instead of manually entering the secret. Google Authenticator and similar apps
 take in a QR code that holds a URL with the protocol `otpauth://`,
 which you get from `otplib.authenticator.keyuri`.
 
+Google Authenticator will ignore the `algorithm`, `digits`, and `step` options.
+See the [documentation](https://github.com/google/google-authenticator/wiki/Key-Uri-Format)
+for more information.
+
+If you are using a different authenticator app, check the documentation
+for that app if the token provided does not work.
+
 While this library provides the "otpauth" uri, you'll need a library to generate the QR Code image.
 
 An example is shown below:

--- a/packages/otplib-authenticator/Authenticator.js
+++ b/packages/otplib-authenticator/Authenticator.js
@@ -73,10 +73,15 @@ class Authenticator extends TOTP {
   }
 
   /**
+   * @param {string} user - the name/id of your user
+   * @param {string} service - the name of your service
+   * @param {string} secret - your secret that is used to generate the token
+   * @return {string} otpauth uri. Example: otpauth://totp/user:localhost?secret=NKEIBAOUFA
    * @see {@link module:impl/authenticator/keyuri}
    */
-  keyuri(...args) {
-    return keyuri(...args);
+  keyuri(user = 'user', service = 'service', secret = '') {
+    const opt = this.optionsAll;
+    return keyuri(user, service, secret, opt);
   }
 
   /**

--- a/packages/otplib-authenticator/Authenticator.spec.js
+++ b/packages/otplib-authenticator/Authenticator.spec.js
@@ -63,7 +63,16 @@ describe('Authenticator', () => {
   });
 
   it('method: keyuri => keyuri', () => {
-    methodExpectation('keyuri', keyuri, ['123']);
+    methodExpectationWithOptions('keyuri', keyuri, ['123', '456', '789']);
+  });
+
+  it('method: keyuri should use default params on undefined params', () => {
+    methodExpectationWithOptions(
+      'keyuri',
+      keyuri,
+      [void 0, void 0, void 0],
+      ['user', 'service', '']
+    );
   });
 
   it('method: generateSecret returns empty string on falsy len params', () => {

--- a/packages/otplib-authenticator/keyuri.js
+++ b/packages/otplib-authenticator/keyuri.js
@@ -1,4 +1,4 @@
-const data = '{service}:{user}?secret={secret}&issuer={service}';
+const data = '{service}:{user}?secret={secret}&issuer={service}&algorithm={algorithm}&digits={digits}&period={period}';
 
 /**
  * Generates an otpauth uri
@@ -11,14 +11,18 @@ const data = '{service}:{user}?secret={secret}&issuer={service}';
  * @param {string} user - the name/id of your user
  * @param {string} service - the name of your service
  * @param {string} secret - your secret that is used to generate the token
+ * @param {object} options - additional options.
  * @return {string} otpauth uri. Example: otpauth://totp/user:localhost?secret=NKEIBAOUFA
  */
-function keyuri(user = 'user', service = 'service', secret = '') {
+function keyuri(user, service, secret, options) {
   const protocol = 'otpauth://totp/';
   const value = data
     .replace('{user}', encodeURIComponent(user))
     .replace('{secret}', secret)
-    .replace(/{service}/g, encodeURIComponent(service));
+    .replace(/{service}/g, encodeURIComponent(service))
+    .replace('{algorithm}', options.algorithm)
+    .replace('{digits}', options.digits)
+    .replace('{period}', options.step);
 
   return protocol + value;
 }

--- a/packages/otplib-authenticator/keyuri.js
+++ b/packages/otplib-authenticator/keyuri.js
@@ -1,4 +1,5 @@
-const data = '{service}:{user}?secret={secret}&issuer={service}&algorithm={algorithm}&digits={digits}&period={period}';
+const data =
+  '{service}:{user}?secret={secret}&issuer={service}&algorithm={algorithm}&digits={digits}&period={period}';
 
 /**
  * Generates an otpauth uri

--- a/packages/otplib-authenticator/keyuri.spec.js
+++ b/packages/otplib-authenticator/keyuri.spec.js
@@ -1,20 +1,43 @@
 import keyuri from './keyuri';
 
 describe('keyuri', () => {
+  const opts = {
+    algorithm: 'sha1',
+    digits: 6,
+    step: 30
+  };
   [
-    ['otpauth://totp/test:me?secret=123&issuer=test', 'me', 'test', '123'],
-    ['otpauth://totp/null:null?secret=null&issuer=null', null, null, null],
     [
-      'otpauth://totp/service:user?secret=&issuer=service',
-      void 0,
-      void 0,
-      void 0
+      'otpauth://totp/test:me?secret=123&issuer=test&algorithm=sha1&digits=6&period=30',
+      'me',
+      'test',
+      '123',
+      opts
     ],
     [
-      'otpauth://totp/test%20got%20space:me%20got%20space?secret=123&issuer=test%20got%20space',
+      'otpauth://totp/null:null?secret=null&issuer=null&algorithm=sha1&digits=6&period=30',
+      null,
+      null,
+      null,
+      opts
+    ],
+    [
+      'otpauth://totp/test%20got%20space:me%20got%20space?secret=123&issuer=test%20got%20space&algorithm=sha1&digits=6&period=30',
       'me got space',
       'test got space',
-      '123'
+      '123',
+      opts
+    ],
+    [
+      'otpauth://totp/test:me?secret=123&issuer=test&algorithm=alg&digits=1&period=2',
+      'me',
+      'test',
+      '123',
+      {
+        algorithm: 'alg',
+        digits: 1,
+        step: 2
+      }
     ]
   ].forEach((entry, idx) => {
     const [url, ...args] = entry;


### PR DESCRIPTION
Adds the `algorithm`, `digits`, and `period` parameters to the keyuri based on the format in https://github.com/google/google-authenticator/wiki/Key-Uri-Format

### TODO:
- [x] Fix tests
- [x] Add new tests
- [x] Add documentation about authenticator apps not accepting all parameters