### PR TITLE
Update correct links

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -8,9 +8,9 @@ import styles from './index.module.css';
 const Hero = () => (
   <h2 className={styles.hero}>
     otplib is a pluggable JavaScript One-Time Password (OTP) library with
-    support for <a href="/api/classes/hotp.html">HOTP</a>,{' '}
-    <a href="/api/classes/totp.html">TOTP</a> and{' '}
-    <a href="/api/classes/authenticator.html">Google Authenticator</a>.
+    support for <a href="https://github.com/yeojz/otplib/blob/master/README.md#hotp-options">HOTP</a>,{' '}
+    <a href="https://github.com/yeojz/otplib/blob/master/README.md#totp-options">TOTP</a> and{' '}
+    <a href="https://github.com/yeojz/otplib/blob/master/README.md#google-authenticator">Google Authenticator</a>.
   </h2>
 );
 


### PR DESCRIPTION
Updated a few older links. Also https://otplib.yeojz.dev/api do not exists but it is referred on the website and in [docs](https://github.com/yeojz/otplib/blob/master/README.md#api--demo-website) Should it be completely removed? I can update that as well.