### PR TITLE
Fix broken homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Gerald Yeo <contact@fusedthought.com>",
   "license": "MIT",
   "bugs": "https://github.com/yeojz/otplib/issues",
-  "homepage": "https://yeojz.otplib.dev",
+  "homepage": "https://otplib.yeojz.dev",
   "scripts": {
     "ci:node8": "./scripts/ci-node8.sh",
     "build:site": "./scripts/build-site.sh",


### PR DESCRIPTION
broken https://yeojz.otplib.dev/ to
![image](https://user-images.githubusercontent.com/16307013/118921342-f99a9580-b972-11eb-9138-31f654e69526.png)

A link from github https://otplib.yeojz.dev/
![image](https://user-images.githubusercontent.com/16307013/118921371-0323fd80-b973-11eb-8d24-579fca1c6369.png)
