### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/otplib-core-async/package.json
+++ b/packages/otplib-core-async/package.json
@@ -14,6 +14,11 @@
     "otplib-core",
     "async"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-core-async"
+  },
   "dependencies": {
     "@otplib/core": "^12.0.1"
   }

--- a/packages/otplib-core/package.json
+++ b/packages/otplib-core/package.json
@@ -10,6 +10,11 @@
     "build:lib": "rollup -c ../../configs/rollup.config.js",
     "build:typedef": "tsc --emitDeclarationOnly -p tsconfig.build.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-core"
+  },
   "keywords": [
     "otplib-core"
   ]

--- a/packages/otplib-plugin-base32-enc-dec/package.json
+++ b/packages/otplib-plugin-base32-enc-dec/package.json
@@ -14,6 +14,11 @@
     "otplib-plugin",
     "base32"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-plugin-base32-enc-dec"
+  },
   "dependencies": {
     "@otplib/core": "^12.0.1",
     "base32-decode": "^1.0.0",

--- a/packages/otplib-plugin-crypto-async-ronomon/package.json
+++ b/packages/otplib-plugin-crypto-async-ronomon/package.json
@@ -14,6 +14,11 @@
     "otplib-plugin",
     "crypto"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-plugin-crypto-async-ronomon"
+  },
   "dependencies": {
     "@otplib/core": "^12.0.1",
     "@ronomon/crypto-async": "^5.0.1"

--- a/packages/otplib-plugin-crypto-js/package.json
+++ b/packages/otplib-plugin-crypto-js/package.json
@@ -21,6 +21,11 @@
   "devDependencies": {
     "@types/crypto-js": "^3.1.43"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-plugin-crypto-js"
+  },
   "otplib": {
     "externals": [
       "crypto-js/core",

--- a/packages/otplib-plugin-crypto/package.json
+++ b/packages/otplib-plugin-crypto/package.json
@@ -17,6 +17,11 @@
   "dependencies": {
     "@otplib/core": "^12.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-plugin-crypto"
+  },
   "devDependencies": {
     "@types/node": "^14.0.1"
   }

--- a/packages/otplib-plugin-thirty-two/package.json
+++ b/packages/otplib-plugin-thirty-two/package.json
@@ -14,6 +14,11 @@
     "otplib-plugin",
     "base32"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-plugin-thirty-two"
+  },
   "dependencies": {
     "@otplib/core": "^12.0.1",
     "thirty-two": "^1.0.2"

--- a/packages/otplib-preset-browser/package.json
+++ b/packages/otplib-preset-browser/package.json
@@ -14,6 +14,11 @@
     "otplib-preset",
     "browser"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-preset-browser"
+  },
   "devDependencies": {
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-base32-enc-dec": "^12.0.1",

--- a/packages/otplib-preset-default-async/package.json
+++ b/packages/otplib-preset-default-async/package.json
@@ -15,6 +15,11 @@
     "node",
     "async"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-preset-default-async"
+  },
   "dependencies": {
     "@otplib/core-async": "^12.0.1",
     "@otplib/plugin-crypto-async-ronomon": "^12.0.1",

--- a/packages/otplib-preset-default/package.json
+++ b/packages/otplib-preset-default/package.json
@@ -14,6 +14,11 @@
     "otplib-preset",
     "node"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-preset-default"
+  },
   "dependencies": {
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-crypto": "^12.0.1",

--- a/packages/otplib-preset-v11/package.json
+++ b/packages/otplib-preset-v11/package.json
@@ -14,6 +14,11 @@
     "otplib-preset",
     "node"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib-preset-v11"
+  },
   "dependencies": {
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-crypto": "^12.0.1",

--- a/packages/otplib/package.json
+++ b/packages/otplib/package.json
@@ -22,6 +22,11 @@
       "src/v11.ts"
     ]
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeojz/otplib.git",
+    "directory": "packages/otplib"
+  },
   "keywords": [
     "totp",
     "hotp",


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• otplib
• @otplib/core
• @otplib/core-async
• @otplib/plugin-base32-enc-dec
• @otplib/plugin-crypto
• @otplib/plugin-crypto-async-ronomon
• @otplib/plugin-crypto-js
• @otplib/plugin-thirty-two
• @otplib/preset-browser
• @otplib/preset-default
• @otplib/preset-default-async
• @otplib/preset-v11