### PR TITLE
feat(totp): add format: "detailed" option to generate

### DIFF
--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -236,23 +236,6 @@ const result = generateSync({
 
 This is particularly useful for replay protection, as shown in the next section.
 
-The `format` option also applies to `verify`. By default, `verify` returns a `VerifyResult` object. Pass `format: "plain"` to receive a simple `boolean` instead:
-
-```typescript
-import { verify } from "otplib";
-
-// Default: returns VerifyResult { valid, delta?, epoch?, timeStep? }
-const result = await verify({ secret, token, crypto });
-if (result.valid) {
-  console.log(result.timeStep);
-}
-
-// With format: "plain" — returns boolean directly
-const isValid = await verify({ secret, token, crypto, format: "plain" });
-```
-
-> **Note:** `format: "plain"` on `verify` only applies to TOTP. HOTP verify always returns a `VerifyResult` object.
-
 ### Replay Protection (TOTP)
 
 By default, TOTP codes can be reused within their validity period (determined by `epochTolerance`). To prevent replay attacks, you can track the time step from each successful verification and use the `afterTimeStep` parameter to reject previously used time steps.
@@ -464,6 +447,25 @@ if (result.valid) {
   console.log(result.epoch); // 1234578900 (Unix timestamp)
 }
 ```
+
+### Verify Format
+
+The `format` option also applies to `verify`. By default, `verify` returns a `VerifyResult` object. Pass `format: "plain"` to receive a simple `boolean` instead:
+
+```typescript
+import { verify } from "otplib";
+
+// Default: returns VerifyResult { valid, epoch?, timeStep? }
+const result = await verify({ secret, token, crypto });
+if (result.valid) {
+  console.log(result.timeStep);
+}
+
+// With format: "plain" — returns boolean directly
+const isValid = await verify({ secret, token, crypto, format: "plain" });
+```
+
+> **Note:** `format: "plain"` on `verify` only applies to TOTP. HOTP verify always returns a `VerifyResult` object.
 
 ## Configuration & formats
 

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -236,6 +236,23 @@ const result = generateSync({
 
 This is particularly useful for replay protection, as shown in the next section.
 
+The `format` option also applies to `verify`. By default, `verify` returns a `VerifyResult` object. Pass `format: "plain"` to receive a simple `boolean` instead:
+
+```typescript
+import { verify } from "otplib";
+
+// Default: returns VerifyResult { valid, delta?, epoch?, timeStep? }
+const result = await verify({ secret, token, crypto });
+if (result.valid) {
+  console.log(result.timeStep);
+}
+
+// With format: "plain" — returns boolean directly
+const isValid = await verify({ secret, token, crypto, format: "plain" });
+```
+
+> **Note:** `format: "plain"` on `verify` only applies to TOTP. HOTP verify always returns a `VerifyResult` object.
+
 ### Replay Protection (TOTP)
 
 By default, TOTP codes can be reused within their validity period (determined by `epochTolerance`). To prevent replay attacks, you can track the time step from each successful verification and use the `afterTimeStep` parameter to reject previously used time steps.

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -196,6 +196,46 @@ if (result.valid) {
 }
 ```
 
+### Detailed Generate Results
+
+By default, `generate` returns a plain token string. Pass `format: "detailed"` to receive a structured result containing the token along with the time-step metadata used to produce it:
+
+```typescript
+import { generate } from "otplib";
+
+const result = await generate({
+  secret,
+  format: "detailed",
+});
+
+result.token; // "123456" - the OTP code
+result.timeStep; // 41152263 - RFC 6238 T value (counter)
+result.epoch; // 1234567890 - period-start Unix timestamp in seconds
+```
+
+| Property   | Type     | Description                                     |
+| ---------- | -------- | ----------------------------------------------- |
+| `token`    | `string` | The OTP code (same value as the default format) |
+| `timeStep` | `number` | RFC 6238 time-step counter (T value)            |
+| `epoch`    | `number` | Period-start Unix timestamp in seconds          |
+
+The `epoch` in the result is computed as `timeStep * period + t0` and represents the start of the time period, not the input epoch. The `timeStep` and `epoch` values match those returned by `verify` for the same token.
+
+The `format` option also works with `generateSync`:
+
+```typescript
+import { generateSync } from "otplib";
+
+const result = generateSync({
+  secret,
+  format: "detailed",
+});
+```
+
+> **Note:** The `format` option only applies to TOTP generation. HOTP always returns a plain string token regardless of the `format` value.
+
+This is particularly useful for replay protection, as shown in the next section.
+
 ### Replay Protection (TOTP)
 
 By default, TOTP codes can be reused within their validity period (determined by `epochTolerance`). To prevent replay attacks, you can track the time step from each successful verification and use the `afterTimeStep` parameter to reject previously used time steps.
@@ -298,6 +338,26 @@ await verify({ secret, token, afterTimeStep: 1.5 });
 // Throws: Invalid afterTimeStep: cannot be greater than current time step plus window
 // (when current time step + window < 100)
 await verify({ secret, token, afterTimeStep: 100 });
+```
+
+#### Using Detailed Generate for Replay Protection
+
+You can also use `format: "detailed"` with `generate` to obtain the `timeStep` for server-initiated flows (e.g., sending an OTP via SMS) without an extra call:
+
+```typescript
+import { generate, verify } from "otplib";
+
+// Server generates and sends OTP
+const result = await generate({ secret, format: "detailed" });
+await sendSMS(user.phone, result.token);
+await db.saveLastTimeStep(userId, result.timeStep);
+
+// Later, verify with replay protection
+const verification = await verify({
+  secret,
+  token: userInput,
+  afterTimeStep: await db.getLastTimeStep(userId),
+});
 ```
 
 #### Complete Example with Database

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -196,16 +196,16 @@ if (result.valid) {
 }
 ```
 
-### Detailed Generate Results
+### Full Generate Results
 
-By default, `generate` returns a plain token string. Pass `format: "detailed"` to receive a structured result containing the token along with the time-step metadata used to produce it:
+By default, `generate` returns a plain token string. Pass `format: "full"` to receive a structured result containing the token along with the time-step metadata used to produce it:
 
 ```typescript
 import { generate } from "otplib";
 
 const result = await generate({
   secret,
-  format: "detailed",
+  format: "full",
 });
 
 result.token; // "123456" - the OTP code
@@ -228,7 +228,7 @@ import { generateSync } from "otplib";
 
 const result = generateSync({
   secret,
-  format: "detailed",
+  format: "full",
 });
 ```
 
@@ -340,15 +340,15 @@ await verify({ secret, token, afterTimeStep: 1.5 });
 await verify({ secret, token, afterTimeStep: 100 });
 ```
 
-#### Using Detailed Generate for Replay Protection
+#### Using Full Generate for Replay Protection
 
-You can also use `format: "detailed"` with `generate` to obtain the `timeStep` for server-initiated flows (e.g., sending an OTP via SMS) without an extra call:
+You can also use `format: "full"` with `generate` to obtain the `timeStep` for server-initiated flows (e.g., sending an OTP via SMS) without an extra call:
 
 ```typescript
 import { generate, verify } from "otplib";
 
 // Server generates and sends OTP
-const result = await generate({ secret, format: "detailed" });
+const result = await generate({ secret, format: "full" });
 await sendSMS(user.phone, result.token);
 await db.saveLastTimeStep(userId, result.timeStep);
 

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -178,7 +178,7 @@ Secrets must be at least 16 bytes (128 bits) after decoding. If you need to work
 :::
 
 ```typescript
-const token = await generate({
+const result = await generate({
   secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY", // Base32-encoded secret (required)
 
   // Optional
@@ -186,6 +186,7 @@ const token = await generate({
   digits: 6, // 6, 7, or 8 digits
   period: 30, // Time step in seconds (default: 30)
   epoch: Date.now() / 1000, // Current Unix timestamp in seconds
+  format: "detailed", // Return { token, timeStep, epoch } instead of a string
 });
 
 // Verification with tolerance
@@ -196,7 +197,24 @@ const result = await verify({
 });
 ```
 
+When `format` is `"detailed"`, `generate` returns a `TOTPGenerateResult` object instead of a plain string:
+
+```typescript
+const result = await generate({
+  secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY",
+  format: "detailed",
+});
+
+result.token; // "123456" - the OTP code
+result.timeStep; // RFC 6238 T value (counter)
+result.epoch; // Period-start Unix timestamp in seconds
+```
+
+This is useful for [replay protection](./advanced-usage#replay-protection-totp) without separate utility calls. See [Detailed Generate Results](./advanced-usage#detailed-generate-results) for more.
+
 ### HOTP Options
+
+> **Note:** The `format` option only applies to TOTP. HOTP always returns a plain string token.
 
 ```typescript
 const token = await generate({

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -186,7 +186,7 @@ const result = await generate({
   digits: 6, // 6, 7, or 8 digits
   period: 30, // Time step in seconds (default: 30)
   epoch: Date.now() / 1000, // Current Unix timestamp in seconds
-  format: "detailed", // Return { token, timeStep, epoch } instead of a string
+  format: "full", // Return { token, timeStep, epoch } instead of a string
 });
 
 // Verification with tolerance
@@ -197,12 +197,12 @@ const result = await verify({
 });
 ```
 
-When `format` is `"detailed"`, `generate` returns a `TOTPGenerateResult` object instead of a plain string:
+When `format` is `"full"`, `generate` returns a `TOTPGenerateResult` object instead of a plain string:
 
 ```typescript
 const result = await generate({
   secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY",
-  format: "detailed",
+  format: "full",
 });
 
 result.token; // "123456" - the OTP code
@@ -210,7 +210,7 @@ result.timeStep; // RFC 6238 T value (counter)
 result.epoch; // Period-start Unix timestamp in seconds
 ```
 
-This is useful for [replay protection](./advanced-usage#replay-protection-totp) without separate utility calls. See [Detailed Generate Results](./advanced-usage#detailed-generate-results) for more.
+This is useful for [replay protection](./advanced-usage#replay-protection-totp) without separate utility calls. See [Full Generate Results](./advanced-usage#full-generate-results) for more.
 
 ### HOTP Options
 

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -197,7 +197,7 @@ const result = await verify({
 });
 ```
 
-When `format` is `"full"`, `generate` returns a `TOTPGenerateResult` object instead of a plain string:
+When `format` is `"full"`, `generate` returns a `GenerateResult` object instead of a plain string:
 
 ```typescript
 const result = await generate({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type {
   OTPResult,
   OTPResultOk,
   OTPResultError,
+  OTPFormat,
+  TOTPGenerateResult,
 } from "./types.js";
 
 export type { OTPGuardrailsConfig, OTPGuardrails } from "./utils.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export type {
   OTPResultOk,
   OTPResultError,
   OTPFormat,
-  TOTPGenerateResult,
+  GenerateResult,
 } from "./types.js";
 
 export type { OTPGuardrailsConfig, OTPGuardrails } from "./utils.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,10 +183,6 @@ export type SecretOptions = {
   readonly length?: number;
 };
 
-// ============================================================================
-// Result Type for Functional Error Handling
-// ============================================================================
-
 /**
  * Success result containing a value
  */
@@ -220,3 +216,34 @@ export type OTPResultError<E> = {
  * ```
  */
 export type OTPResult<T, E = Error> = OTPResultOk<T> | OTPResultError<E>;
+
+/**
+ * Output format for TOTP generation
+ *
+ * - `"default"`: Returns a plain string token (backward compatible)
+ * - `"detailed"`: Returns a structured result with token, timeStep, and epoch
+ */
+export type OTPFormat = "default" | "detailed";
+
+/**
+ * Structured result from TOTP generation when using `format: "detailed"`
+ *
+ * Contains the token along with its computed time metadata, enabling
+ * replay protection and time-window deduplication.
+ *
+ * @example
+ * ```typescript
+ * const result = await generate({
+ *   secret, crypto,
+ *   format: "detailed",
+ * });
+ * // result.token    - the OTP string
+ * // result.timeStep - RFC 6238 T value (counter)
+ * // result.epoch    - period-start Unix timestamp in seconds
+ * ```
+ */
+export type TOTPGenerateResult = {
+  readonly token: string;
+  readonly timeStep: number;
+  readonly epoch: number;
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -218,15 +218,16 @@ export type OTPResultError<E> = {
 export type OTPResult<T, E = Error> = OTPResultOk<T> | OTPResultError<E>;
 
 /**
- * Output format for TOTP generation
+ * Output format for OTP operations
  *
- * - `"default"`: Returns a plain string token (backward compatible)
- * - `"detailed"`: Returns a structured result with token, timeStep, and epoch
+ * - `"default"`: Preserves backward-compatible behavior per method
+ * - `"plain"`: Returns the primitive value (string for generate, boolean for verify)
+ * - `"full"`: Returns a structured result object (GenerateResult for generate, VerifyResult for verify)
  */
-export type OTPFormat = "default" | "detailed";
+export type OTPFormat = "default" | "plain" | "full";
 
 /**
- * Structured result from TOTP generation when using `format: "detailed"`
+ * Structured result from TOTP generation when using `format: "full"`
  *
  * Contains the token along with its computed time metadata, enabling
  * replay protection and time-window deduplication.
@@ -235,14 +236,14 @@ export type OTPFormat = "default" | "detailed";
  * ```typescript
  * const result = await generate({
  *   secret, crypto,
- *   format: "detailed",
+ *   format: "full",
  * });
  * // result.token    - the OTP string
  * // result.timeStep - RFC 6238 T value (counter)
  * // result.epoch    - period-start Unix timestamp in seconds
  * ```
  */
-export type TOTPGenerateResult = {
+export type GenerateResult = {
   readonly token: string;
   readonly timeStep: number;
   readonly epoch: number;

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -16,6 +16,7 @@ import {
 } from "./functional.js";
 
 import type { OTPStrategy } from "./functional.js";
+import type { TOTPExtraArgs } from "./types.js";
 import type {
   CryptoPlugin,
   Digits,
@@ -23,7 +24,6 @@ import type {
   Base32Plugin,
   OTPGuardrails,
   OTPHooks,
-  OTPFormat,
   TOTPGenerateResult,
 } from "@otplib/core";
 import type { VerifyResult as HOTPVerifyResult } from "@otplib/hotp";
@@ -116,17 +116,7 @@ export type OTPGenerateOptions = {
    * Hooks for customizing token encoding and validation
    */
   hooks?: OTPHooks;
-
-  /**
-   * Output format for TOTP generation
-   *
-   * - `"default"` (or omitted): returns a plain `string` token
-   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
-   *
-   * Only applies to TOTP strategy; ignored for HOTP.
-   */
-  format?: OTPFormat;
-};
+} & TOTPExtraArgs;
 
 /**
  * Options for verifying a token with the OTP class
@@ -397,7 +387,7 @@ export class OTP {
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    });
+    } as Parameters<typeof functionalVerify>[0]);
   }
 
   /**
@@ -414,7 +404,7 @@ export class OTP {
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    });
+    } as Parameters<typeof functionalVerifySync>[0]);
   }
 
   /**

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -24,7 +24,8 @@ import type {
   Base32Plugin,
   OTPGuardrails,
   OTPHooks,
-  TOTPGenerateResult,
+  OTPFormat,
+  GenerateResult,
 } from "@otplib/core";
 import type { VerifyResult as HOTPVerifyResult } from "@otplib/hotp";
 import type { VerifyResult as TOTPVerifyResult } from "@otplib/totp";
@@ -201,6 +202,17 @@ export type OTPVerifyOptions = {
    * Hooks for customizing token encoding and validation
    */
   hooks?: OTPHooks;
+
+  /**
+   * Output format for verification
+   *
+   * - `"default"` (or omitted): returns `VerifyResult` object (same as `"full"`)
+   * - `"plain"`: returns `boolean` (true if valid, false if invalid)
+   * - `"full"`: returns `VerifyResult` object with delta, epoch, and timeStep
+   *
+   * Only used by TOTP strategy. HOTP ignores this option.
+   */
+  format?: OTPFormat;
 };
 
 /**
@@ -326,21 +338,21 @@ export class OTP {
   /**
    * Generate an OTP token based on the configured strategy
    *
-   * When `format: "detailed"` is passed with a TOTP strategy, returns
-   * `TOTPGenerateResult`. HOTP strategy ignores `format` and always
+   * When `format: "full"` is passed with a TOTP strategy, returns
+   * `GenerateResult`. HOTP strategy ignores `format` and always
    * returns a string, so the return type is widened to the union.
    *
    * @param options - Generation options
-   * @returns OTP code (string for HOTP, string or TOTPGenerateResult for TOTP with format)
+   * @returns OTP code (string for HOTP, string or GenerateResult for TOTP with format)
    */
   async generate(
-    options: OTPGenerateOptions & { format: "detailed" },
-  ): Promise<string | TOTPGenerateResult>;
+    options: OTPGenerateOptions & { format: "full" },
+  ): Promise<string | GenerateResult>;
   async generate(
-    options: Omit<OTPGenerateOptions, "format"> & { format?: "default" },
+    options: Omit<OTPGenerateOptions, "format"> & { format?: "default" | "plain" },
   ): Promise<string>;
-  async generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult>;
-  async generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult> {
+  async generate(options: OTPGenerateOptions): Promise<string | GenerateResult>;
+  async generate(options: OTPGenerateOptions): Promise<string | GenerateResult> {
     return functionalGenerate({
       ...options,
       strategy: this.strategy,
@@ -353,18 +365,20 @@ export class OTP {
   /**
    * Generate an OTP token based on the configured strategy synchronously
    *
-   * When `format: "detailed"` is passed with a TOTP strategy, returns
-   * `TOTPGenerateResult`. HOTP strategy ignores `format` and always
+   * When `format: "full"` is passed with a TOTP strategy, returns
+   * `GenerateResult`. HOTP strategy ignores `format` and always
    * returns a string, so the return type is widened to the union.
    *
    * @param options - Generation options
-   * @returns OTP code (string for HOTP, string or TOTPGenerateResult for TOTP with format)
+   * @returns OTP code (string for HOTP, string or GenerateResult for TOTP with format)
    * @throws {HMACError} If the crypto plugin doesn't support sync operations
    */
-  generateSync(options: OTPGenerateOptions & { format: "detailed" }): string | TOTPGenerateResult;
-  generateSync(options: Omit<OTPGenerateOptions, "format"> & { format?: "default" }): string;
-  generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult;
-  generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult {
+  generateSync(options: OTPGenerateOptions & { format: "full" }): string | GenerateResult;
+  generateSync(
+    options: Omit<OTPGenerateOptions, "format"> & { format?: "default" | "plain" },
+  ): string;
+  generateSync(options: OTPGenerateOptions): string | GenerateResult;
+  generateSync(options: OTPGenerateOptions): string | GenerateResult {
     return functionalGenerateSync({
       ...options,
       strategy: this.strategy,
@@ -380,7 +394,9 @@ export class OTP {
    * @param options - Verification options
    * @returns Verification result with validity and optional delta
    */
-  async verify(options: OTPVerifyOptions): Promise<VerifyResult> {
+  async verify(options: OTPVerifyOptions & { format: "plain" }): Promise<boolean>;
+  async verify(options: OTPVerifyOptions): Promise<VerifyResult>;
+  async verify(options: OTPVerifyOptions): Promise<boolean | VerifyResult> {
     return functionalVerify({
       ...options,
       strategy: this.strategy,
@@ -397,7 +413,9 @@ export class OTP {
    * @returns Verification result with validity and optional delta
    * @throws {HMACError} If the crypto plugin doesn't support sync operations
    */
-  verifySync(options: OTPVerifyOptions): VerifyResult {
+  verifySync(options: OTPVerifyOptions & { format: "plain" }): boolean;
+  verifySync(options: OTPVerifyOptions): VerifyResult;
+  verifySync(options: OTPVerifyOptions): boolean | VerifyResult {
     return functionalVerifySync({
       ...options,
       strategy: this.strategy,

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -359,7 +359,7 @@ export class OTP {
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    } as Parameters<typeof functionalGenerate>[0]);
+    } as OTPGenerateOptions);
   }
 
   /**
@@ -385,7 +385,7 @@ export class OTP {
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    } as Parameters<typeof functionalGenerateSync>[0]);
+    } as OTPGenerateOptions);
   }
 
   /**
@@ -403,7 +403,7 @@ export class OTP {
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    } as Parameters<typeof functionalVerify>[0]);
+    } as OTPVerifyOptions);
   }
 
   /**
@@ -422,7 +422,7 @@ export class OTP {
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    } as Parameters<typeof functionalVerifySync>[0]);
+    } as OTPVerifyOptions);
   }
 
   /**

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -23,6 +23,8 @@ import type {
   Base32Plugin,
   OTPGuardrails,
   OTPHooks,
+  OTPFormat,
+  TOTPGenerateResult,
 } from "@otplib/core";
 import type { VerifyResult as HOTPVerifyResult } from "@otplib/hotp";
 import type { VerifyResult as TOTPVerifyResult } from "@otplib/totp";
@@ -114,6 +116,16 @@ export type OTPGenerateOptions = {
    * Hooks for customizing token encoding and validation
    */
   hooks?: OTPHooks;
+
+  /**
+   * Output format for TOTP generation
+   *
+   * - `"default"` (or omitted): returns a plain `string` token
+   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
+   *
+   * Only applies to TOTP strategy; ignored for HOTP.
+   */
+  format?: OTPFormat;
 };
 
 /**
@@ -327,14 +339,16 @@ export class OTP {
    * @param options - Generation options
    * @returns OTP code
    */
-  async generate(options: OTPGenerateOptions): Promise<string> {
+  async generate(options: OTPGenerateOptions & { format: "detailed" }): Promise<TOTPGenerateResult>;
+  async generate(options: OTPGenerateOptions): Promise<string>;
+  async generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult> {
     return functionalGenerate({
       ...options,
       strategy: this.strategy,
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    });
+    } as Parameters<typeof functionalGenerate>[0]);
   }
 
   /**
@@ -344,14 +358,16 @@ export class OTP {
    * @returns OTP code
    * @throws {HMACError} If the crypto plugin doesn't support sync operations
    */
-  generateSync(options: OTPGenerateOptions): string {
+  generateSync(options: OTPGenerateOptions & { format: "detailed" }): TOTPGenerateResult;
+  generateSync(options: OTPGenerateOptions): string;
+  generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult {
     return functionalGenerateSync({
       ...options,
       strategy: this.strategy,
       crypto: this.crypto,
       base32: this.base32,
       guardrails: options.guardrails ?? this.guardrails,
-    });
+    } as Parameters<typeof functionalGenerateSync>[0]);
   }
 
   /**

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -336,11 +336,20 @@ export class OTP {
   /**
    * Generate an OTP token based on the configured strategy
    *
+   * When `format: "detailed"` is passed with a TOTP strategy, returns
+   * `TOTPGenerateResult`. HOTP strategy ignores `format` and always
+   * returns a string, so the return type is widened to the union.
+   *
    * @param options - Generation options
-   * @returns OTP code
+   * @returns OTP code (string for HOTP, string or TOTPGenerateResult for TOTP with format)
    */
-  async generate(options: OTPGenerateOptions & { format: "detailed" }): Promise<TOTPGenerateResult>;
-  async generate(options: OTPGenerateOptions): Promise<string>;
+  async generate(
+    options: OTPGenerateOptions & { format: "detailed" },
+  ): Promise<string | TOTPGenerateResult>;
+  async generate(
+    options: Omit<OTPGenerateOptions, "format"> & { format?: "default" },
+  ): Promise<string>;
+  async generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult>;
   async generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult> {
     return functionalGenerate({
       ...options,
@@ -354,12 +363,17 @@ export class OTP {
   /**
    * Generate an OTP token based on the configured strategy synchronously
    *
+   * When `format: "detailed"` is passed with a TOTP strategy, returns
+   * `TOTPGenerateResult`. HOTP strategy ignores `format` and always
+   * returns a string, so the return type is widened to the union.
+   *
    * @param options - Generation options
-   * @returns OTP code
+   * @returns OTP code (string for HOTP, string or TOTPGenerateResult for TOTP with format)
    * @throws {HMACError} If the crypto plugin doesn't support sync operations
    */
-  generateSync(options: OTPGenerateOptions & { format: "detailed" }): TOTPGenerateResult;
-  generateSync(options: OTPGenerateOptions): string;
+  generateSync(options: OTPGenerateOptions & { format: "detailed" }): string | TOTPGenerateResult;
+  generateSync(options: Omit<OTPGenerateOptions, "format"> & { format?: "default" }): string;
+  generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult;
   generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult {
     return functionalGenerateSync({
       ...options,

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -16,7 +16,7 @@ import {
 } from "./functional.js";
 
 import type { OTPStrategy } from "./functional.js";
-import type { TOTPExtraArgs } from "./types.js";
+import type { TOTPExtraArgs, TOTPVerifyOptions } from "./types.js";
 import type {
   CryptoPlugin,
   Digits,
@@ -394,7 +394,7 @@ export class OTP {
    * @param options - Verification options
    * @returns Verification result with validity and optional delta
    */
-  async verify(options: OTPVerifyOptions & { format: "plain" }): Promise<boolean>;
+  async verify(options: TOTPVerifyOptions & { format: "plain" }): Promise<boolean>;
   async verify(options: OTPVerifyOptions): Promise<VerifyResult>;
   async verify(options: OTPVerifyOptions): Promise<boolean | VerifyResult> {
     return functionalVerify({
@@ -413,7 +413,7 @@ export class OTP {
    * @returns Verification result with validity and optional delta
    * @throws {HMACError} If the crypto plugin doesn't support sync operations
    */
-  verifySync(options: OTPVerifyOptions & { format: "plain" }): boolean;
+  verifySync(options: TOTPVerifyOptions & { format: "plain" }): boolean;
   verifySync(options: OTPVerifyOptions): VerifyResult;
   verifySync(options: OTPVerifyOptions): boolean | VerifyResult {
     return functionalVerifySync({

--- a/packages/otplib/src/defaults.ts
+++ b/packages/otplib/src/defaults.ts
@@ -34,6 +34,7 @@ export function normalizeGenerateOptions(
     counter: options.counter,
     guardrails: options.guardrails ?? createGuardrails(),
     hooks: options.hooks,
+    format: options.format,
   };
 }
 

--- a/packages/otplib/src/defaults.ts
+++ b/packages/otplib/src/defaults.ts
@@ -10,20 +10,23 @@ import { base32 as defaultBase32 } from "@otplib/plugin-base32-scure";
 import { crypto as defaultCrypto } from "@otplib/plugin-crypto-noble";
 
 import type {
-  OTPGenerateOptions,
-  OTPVerifyOptions,
-  OTPGenerateOptionsWithDefaults,
-  OTPVerifyOptionsWithDefaults,
+  OTPGenerateCommonOptions,
+  OTPVerifyCommonOptions,
+  TOTPGenerateOptions,
+  HOTPGenerateOptions,
+  TOTPVerifyOptions,
+  HOTPVerifyOptions,
+  TOTPGenerateOptionsWithDefaults,
+  HOTPGenerateOptionsWithDefaults,
+  TOTPVerifyOptionsWithDefaults,
+  HOTPVerifyOptionsWithDefaults,
 } from "./types.js";
 
 export { defaultCrypto, defaultBase32 };
 
-export function normalizeGenerateOptions(
-  options: OTPGenerateOptions,
-): OTPGenerateOptionsWithDefaults {
+function normalizeGenerateCommonOptions(options: OTPGenerateCommonOptions) {
   return {
     secret: options.secret,
-    strategy: options.strategy ?? "totp",
     crypto: options.crypto ?? defaultCrypto,
     base32: options.base32 ?? defaultBase32,
     algorithm: options.algorithm ?? "sha1",
@@ -31,19 +34,60 @@ export function normalizeGenerateOptions(
     period: options.period ?? 30,
     epoch: options.epoch ?? Math.floor(Date.now() / 1000),
     t0: options.t0 ?? 0,
-    counter: options.counter,
     guardrails: options.guardrails ?? createGuardrails(),
     hooks: options.hooks,
-    format: options.format,
   };
 }
 
-export function normalizeVerifyOptions(options: OTPVerifyOptions): OTPVerifyOptionsWithDefaults {
+function normalizeVerifyCommonOptions(options: OTPVerifyCommonOptions) {
   return {
-    ...normalizeGenerateOptions(options),
+    ...normalizeGenerateCommonOptions(options),
     token: options.token,
     epochTolerance: options.epochTolerance ?? 0,
     counterTolerance: options.counterTolerance ?? 0,
     afterTimeStep: options.afterTimeStep,
+    format: options.format,
+  };
+}
+
+export function normalizeTOTPGenerateOptions(
+  options: TOTPGenerateOptions,
+): TOTPGenerateOptionsWithDefaults {
+  return {
+    ...normalizeGenerateCommonOptions(options),
+    strategy: "totp",
+    counter: options.counter,
+    format: options.format,
+  };
+}
+
+export function normalizeHOTPGenerateOptions(
+  options: HOTPGenerateOptions,
+): HOTPGenerateOptionsWithDefaults {
+  return {
+    ...normalizeGenerateCommonOptions(options),
+    strategy: "hotp",
+    counter: options.counter,
+    format: options.format,
+  };
+}
+
+export function normalizeTOTPVerifyOptions(
+  options: TOTPVerifyOptions,
+): TOTPVerifyOptionsWithDefaults {
+  return {
+    ...normalizeVerifyCommonOptions(options),
+    strategy: "totp",
+    counter: options.counter,
+  };
+}
+
+export function normalizeHOTPVerifyOptions(
+  options: HOTPVerifyOptions,
+): HOTPVerifyOptionsWithDefaults {
+  return {
+    ...normalizeVerifyCommonOptions(options),
+    strategy: "hotp",
+    counter: options.counter,
   };
 }

--- a/packages/otplib/src/functional.ts
+++ b/packages/otplib/src/functional.ts
@@ -26,7 +26,13 @@ import type {
   OTPStrategy,
   StrategyHandlers,
 } from "./types.js";
-import type { CryptoPlugin, Base32Plugin, Digits, HashAlgorithm } from "@otplib/core";
+import type {
+  CryptoPlugin,
+  Base32Plugin,
+  Digits,
+  HashAlgorithm,
+  TOTPGenerateResult,
+} from "@otplib/core";
 import type { VerifyResult as HOTPVerifyResult } from "@otplib/hotp";
 import type { VerifyResult as TOTPVerifyResult } from "@otplib/totp";
 
@@ -215,7 +221,11 @@ export function generateURI(options: {
  * });
  * ```
  */
-export async function generate(options: OTPGenerateOptions): Promise<string> {
+export async function generate(
+  options: OTPGenerateOptions & { format: "detailed"; strategy?: "totp" },
+): Promise<TOTPGenerateResult>;
+export async function generate(options: OTPGenerateOptions): Promise<string>;
+export async function generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult> {
   const opts = normalizeGenerateOptions(options);
   const { secret, crypto, base32, algorithm, digits, hooks } = opts;
   const commonOptions = { secret, crypto, base32, algorithm, digits, hooks };
@@ -228,7 +238,8 @@ export async function generate(options: OTPGenerateOptions): Promise<string> {
         epoch: opts.epoch,
         t0: opts.t0,
         guardrails: opts.guardrails,
-      }),
+        format: opts.format,
+      } as Parameters<typeof generateTOTP>[0]),
     hotp: (counter) =>
       generateHOTP({
         ...commonOptions,
@@ -257,7 +268,11 @@ export async function generate(options: OTPGenerateOptions): Promise<string> {
  * });
  * ```
  */
-export function generateSync(options: OTPGenerateOptions): string {
+export function generateSync(
+  options: OTPGenerateOptions & { format: "detailed"; strategy?: "totp" },
+): TOTPGenerateResult;
+export function generateSync(options: OTPGenerateOptions): string;
+export function generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult {
   const opts = normalizeGenerateOptions(options);
   const { secret, crypto, base32, algorithm, digits } = opts;
   const commonOptions = { secret, crypto, base32, algorithm, digits };
@@ -270,7 +285,8 @@ export function generateSync(options: OTPGenerateOptions): string {
         epoch: opts.epoch,
         t0: opts.t0,
         guardrails: opts.guardrails,
-      }),
+        format: opts.format,
+      } as Parameters<typeof generateTOTPSync>[0]),
     hotp: (counter) =>
       generateHOTPSync({
         ...commonOptions,

--- a/packages/otplib/src/functional.ts
+++ b/packages/otplib/src/functional.ts
@@ -231,9 +231,11 @@ export function generateURI(options: {
  * });
  * ```
  */
+// Explicit: format: "full" returns structured result
 export async function generate(
   options: TOTPGenerateOptions & { format: "full" },
 ): Promise<GenerateResult>;
+// Explicit: format: "plain" or "default" returns string (matches class-layer API)
 export async function generate(
   options: TOTPGenerateOptions & { format?: "default" | "plain" },
 ): Promise<string>;
@@ -302,7 +304,9 @@ export async function generate(options: OTPGenerateOptions): Promise<string | Ge
  * });
  * ```
  */
+// Explicit: format: "full" returns structured result
 export function generateSync(options: TOTPGenerateOptions & { format: "full" }): GenerateResult;
+// Explicit: format: "plain" or "default" returns string (matches class-layer API)
 export function generateSync(
   options: TOTPGenerateOptions & { format?: "default" | "plain" },
 ): string;

--- a/packages/otplib/src/functional.ts
+++ b/packages/otplib/src/functional.ts
@@ -234,6 +234,9 @@ export function generateURI(options: {
 export async function generate(
   options: TOTPGenerateOptions & { format: "full" },
 ): Promise<GenerateResult>;
+export async function generate(
+  options: TOTPGenerateOptions & { format?: "default" | "plain" },
+): Promise<string>;
 export async function generate(options: TOTPGenerateOptions): Promise<string>;
 export async function generate(options: HOTPGenerateOptions): Promise<string>;
 export async function generate(options: OTPGenerateOptions): Promise<string | GenerateResult> {
@@ -300,6 +303,9 @@ export async function generate(options: OTPGenerateOptions): Promise<string | Ge
  * ```
  */
 export function generateSync(options: TOTPGenerateOptions & { format: "full" }): GenerateResult;
+export function generateSync(
+  options: TOTPGenerateOptions & { format?: "default" | "plain" },
+): string;
 export function generateSync(options: TOTPGenerateOptions): string;
 export function generateSync(options: HOTPGenerateOptions): string;
 export function generateSync(options: OTPGenerateOptions): string | GenerateResult {

--- a/packages/otplib/src/functional.ts
+++ b/packages/otplib/src/functional.ts
@@ -28,13 +28,14 @@ import type {
   OTPStrategy,
   TOTPGenerateOptions,
   HOTPGenerateOptions,
+  TOTPVerifyOptions,
 } from "./types.js";
 import type {
   CryptoPlugin,
   Base32Plugin,
   Digits,
   HashAlgorithm,
-  TOTPGenerateResult,
+  GenerateResult,
 } from "@otplib/core";
 import type { VerifyResult as HOTPVerifyResult } from "@otplib/hotp";
 import type { VerifyResult as TOTPVerifyResult } from "@otplib/totp";
@@ -231,11 +232,11 @@ export function generateURI(options: {
  * ```
  */
 export async function generate(
-  options: TOTPGenerateOptions & { format: "detailed" },
-): Promise<TOTPGenerateResult>;
+  options: TOTPGenerateOptions & { format: "full" },
+): Promise<GenerateResult>;
 export async function generate(options: TOTPGenerateOptions): Promise<string>;
 export async function generate(options: HOTPGenerateOptions): Promise<string>;
-export async function generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult> {
+export async function generate(options: OTPGenerateOptions): Promise<string | GenerateResult> {
   const strategy = resolveStrategy(options.strategy);
 
   if (strategy === "hotp") {
@@ -298,12 +299,10 @@ export async function generate(options: OTPGenerateOptions): Promise<string | TO
  * });
  * ```
  */
-export function generateSync(
-  options: TOTPGenerateOptions & { format: "detailed" },
-): TOTPGenerateResult;
+export function generateSync(options: TOTPGenerateOptions & { format: "full" }): GenerateResult;
 export function generateSync(options: TOTPGenerateOptions): string;
 export function generateSync(options: HOTPGenerateOptions): string;
-export function generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult {
+export function generateSync(options: OTPGenerateOptions): string | GenerateResult {
   const strategy = resolveStrategy(options.strategy);
 
   if (strategy === "hotp") {
@@ -394,7 +393,9 @@ export function generateSync(options: OTPGenerateOptions): string | TOTPGenerate
  * });
  * ```
  */
-export async function verify(options: OTPVerifyOptions): Promise<VerifyResult> {
+export async function verify(options: TOTPVerifyOptions & { format: "plain" }): Promise<boolean>;
+export async function verify(options: OTPVerifyOptions): Promise<VerifyResult>;
+export async function verify(options: OTPVerifyOptions): Promise<boolean | VerifyResult> {
   const strategy = resolveStrategy(options.strategy);
 
   if (strategy === "hotp") {
@@ -439,6 +440,7 @@ export async function verify(options: OTPVerifyOptions): Promise<VerifyResult> {
     epochTolerance: opts.epochTolerance,
     afterTimeStep: opts.afterTimeStep,
     guardrails: opts.guardrails,
+    format: opts.format,
   });
 }
 
@@ -462,7 +464,9 @@ export async function verify(options: OTPVerifyOptions): Promise<VerifyResult> {
  * });
  * ```
  */
-export function verifySync(options: OTPVerifyOptions): VerifyResult {
+export function verifySync(options: TOTPVerifyOptions & { format: "plain" }): boolean;
+export function verifySync(options: OTPVerifyOptions): VerifyResult;
+export function verifySync(options: OTPVerifyOptions): boolean | VerifyResult {
   const strategy = resolveStrategy(options.strategy);
 
   if (strategy === "hotp") {
@@ -507,5 +511,6 @@ export function verifySync(options: OTPVerifyOptions): VerifyResult {
     epochTolerance: opts.epochTolerance,
     afterTimeStep: opts.afterTimeStep,
     guardrails: opts.guardrails,
+    format: opts.format,
   });
 }

--- a/packages/otplib/src/functional.ts
+++ b/packages/otplib/src/functional.ts
@@ -16,15 +16,18 @@ import { generateTOTP as generateTOTPURI, generateHOTP as generateHOTURI } from 
 import {
   defaultCrypto,
   defaultBase32,
-  normalizeGenerateOptions,
-  normalizeVerifyOptions,
+  normalizeTOTPGenerateOptions,
+  normalizeHOTPGenerateOptions,
+  normalizeTOTPVerifyOptions,
+  normalizeHOTPVerifyOptions,
 } from "./defaults.js";
 
 import type {
   OTPGenerateOptions,
   OTPVerifyOptions,
   OTPStrategy,
-  StrategyHandlers,
+  TOTPGenerateOptions,
+  HOTPGenerateOptions,
 } from "./types.js";
 import type {
   CryptoPlugin,
@@ -40,25 +43,22 @@ export type { OTPStrategy };
 
 export type VerifyResult = TOTPVerifyResult | HOTPVerifyResult;
 
-function executeByStrategy<T>(
-  strategy: OTPStrategy,
-  counter: number | undefined,
-  handlers: StrategyHandlers<T>,
-): T {
-  if (strategy === "totp") {
-    return handlers.totp();
-  }
-  if (strategy === "hotp") {
-    if (counter === undefined) {
-      throw new ConfigurationError(
-        "Counter is required for HOTP strategy. Example: { strategy: 'hotp', counter: 0 }",
-      );
-    }
-    return handlers.hotp(counter);
+function resolveStrategy(strategy: unknown): OTPStrategy {
+  if (strategy === undefined || strategy === "totp" || strategy === "hotp") {
+    return strategy ?? "totp";
   }
   throw new ConfigurationError(
     `Unknown OTP strategy: ${strategy}. Valid strategies are 'totp' or 'hotp'.`,
   );
+}
+
+function requireCounter(counter: number | undefined): number {
+  if (counter === undefined) {
+    throw new ConfigurationError(
+      "Counter is required for HOTP strategy. Example: { strategy: 'hotp', counter: 0 }",
+    );
+  }
+  return counter;
 }
 
 /**
@@ -164,7 +164,7 @@ export function generateURI(options: {
   counter?: number;
 }): string {
   const {
-    strategy = "totp",
+    strategy,
     issuer,
     label,
     secret,
@@ -173,10 +173,19 @@ export function generateURI(options: {
     period = 30,
     counter,
   } = options;
+  const resolvedStrategy = resolveStrategy(strategy);
 
-  return executeByStrategy(strategy, counter, {
-    totp: () => generateTOTPURI({ issuer, label, secret, algorithm, digits, period }),
-    hotp: (counter) => generateHOTURI({ issuer, label, secret, algorithm, digits, counter }),
+  if (resolvedStrategy === "totp") {
+    return generateTOTPURI({ issuer, label, secret, algorithm, digits, period });
+  }
+
+  return generateHOTURI({
+    issuer,
+    label,
+    secret,
+    algorithm,
+    digits,
+    counter: requireCounter(counter),
   });
 }
 
@@ -222,30 +231,51 @@ export function generateURI(options: {
  * ```
  */
 export async function generate(
-  options: OTPGenerateOptions & { format: "detailed"; strategy?: "totp" },
+  options: TOTPGenerateOptions & { format: "detailed" },
 ): Promise<TOTPGenerateResult>;
-export async function generate(options: OTPGenerateOptions): Promise<string>;
+export async function generate(options: TOTPGenerateOptions): Promise<string>;
+export async function generate(options: HOTPGenerateOptions): Promise<string>;
 export async function generate(options: OTPGenerateOptions): Promise<string | TOTPGenerateResult> {
-  const opts = normalizeGenerateOptions(options);
-  const { secret, crypto, base32, algorithm, digits, hooks } = opts;
-  const commonOptions = { secret, crypto, base32, algorithm, digits, hooks };
+  const strategy = resolveStrategy(options.strategy);
 
-  return executeByStrategy(opts.strategy, opts.counter, {
-    totp: () =>
-      generateTOTP({
-        ...commonOptions,
-        period: opts.period,
-        epoch: opts.epoch,
-        t0: opts.t0,
-        guardrails: opts.guardrails,
-        format: opts.format,
-      } as Parameters<typeof generateTOTP>[0]),
-    hotp: (counter) =>
-      generateHOTP({
-        ...commonOptions,
-        counter,
-        guardrails: opts.guardrails,
-      }),
+  if (strategy === "hotp") {
+    const opts = normalizeHOTPGenerateOptions({
+      ...options,
+      strategy: "hotp",
+      counter: requireCounter(options.counter),
+    });
+    const { secret, crypto, base32, algorithm, digits, hooks } = opts;
+
+    return generateHOTP({
+      secret,
+      crypto,
+      base32,
+      algorithm,
+      digits,
+      hooks,
+      counter: opts.counter,
+      guardrails: opts.guardrails,
+    });
+  }
+
+  const opts = normalizeTOTPGenerateOptions({
+    ...options,
+    strategy: "totp",
+  });
+  const { secret, crypto, base32, algorithm, digits, hooks } = opts;
+
+  return generateTOTP({
+    secret,
+    crypto,
+    base32,
+    algorithm,
+    digits,
+    hooks,
+    period: opts.period,
+    epoch: opts.epoch,
+    t0: opts.t0,
+    guardrails: opts.guardrails,
+    format: opts.format,
   });
 }
 
@@ -269,30 +299,51 @@ export async function generate(options: OTPGenerateOptions): Promise<string | TO
  * ```
  */
 export function generateSync(
-  options: OTPGenerateOptions & { format: "detailed"; strategy?: "totp" },
+  options: TOTPGenerateOptions & { format: "detailed" },
 ): TOTPGenerateResult;
-export function generateSync(options: OTPGenerateOptions): string;
+export function generateSync(options: TOTPGenerateOptions): string;
+export function generateSync(options: HOTPGenerateOptions): string;
 export function generateSync(options: OTPGenerateOptions): string | TOTPGenerateResult {
-  const opts = normalizeGenerateOptions(options);
-  const { secret, crypto, base32, algorithm, digits } = opts;
-  const commonOptions = { secret, crypto, base32, algorithm, digits };
+  const strategy = resolveStrategy(options.strategy);
 
-  return executeByStrategy(opts.strategy, opts.counter, {
-    totp: () =>
-      generateTOTPSync({
-        ...commonOptions,
-        period: opts.period,
-        epoch: opts.epoch,
-        t0: opts.t0,
-        guardrails: opts.guardrails,
-        format: opts.format,
-      } as Parameters<typeof generateTOTPSync>[0]),
-    hotp: (counter) =>
-      generateHOTPSync({
-        ...commonOptions,
-        counter,
-        guardrails: opts.guardrails,
-      }),
+  if (strategy === "hotp") {
+    const opts = normalizeHOTPGenerateOptions({
+      ...options,
+      strategy: "hotp",
+      counter: requireCounter(options.counter),
+    });
+    const { secret, crypto, base32, algorithm, digits, hooks } = opts;
+
+    return generateHOTPSync({
+      secret,
+      crypto,
+      base32,
+      algorithm,
+      digits,
+      hooks,
+      counter: opts.counter,
+      guardrails: opts.guardrails,
+    });
+  }
+
+  const opts = normalizeTOTPGenerateOptions({
+    ...options,
+    strategy: "totp",
+  });
+  const { secret, crypto, base32, algorithm, digits, hooks } = opts;
+
+  return generateTOTPSync({
+    secret,
+    crypto,
+    base32,
+    algorithm,
+    digits,
+    hooks,
+    period: opts.period,
+    epoch: opts.epoch,
+    t0: opts.t0,
+    guardrails: opts.guardrails,
+    format: opts.format,
   });
 }
 
@@ -344,28 +395,50 @@ export function generateSync(options: OTPGenerateOptions): string | TOTPGenerate
  * ```
  */
 export async function verify(options: OTPVerifyOptions): Promise<VerifyResult> {
-  const opts = normalizeVerifyOptions(options);
-  const { secret, token, crypto, base32, algorithm, digits, hooks } = opts;
-  const commonOptions = { secret, token, crypto, base32, algorithm, digits, hooks };
+  const strategy = resolveStrategy(options.strategy);
 
-  return executeByStrategy(opts.strategy, opts.counter, {
-    totp: () =>
-      verifyTOTP({
-        ...commonOptions,
-        period: opts.period,
-        epoch: opts.epoch,
-        t0: opts.t0,
-        epochTolerance: opts.epochTolerance,
-        afterTimeStep: opts.afterTimeStep,
-        guardrails: opts.guardrails,
-      }),
-    hotp: (counter) =>
-      verifyHOTP({
-        ...commonOptions,
-        counter,
-        counterTolerance: opts.counterTolerance,
-        guardrails: opts.guardrails,
-      }),
+  if (strategy === "hotp") {
+    const opts = normalizeHOTPVerifyOptions({
+      ...options,
+      strategy: "hotp",
+      counter: requireCounter(options.counter),
+    });
+    const { secret, token, crypto, base32, algorithm, digits, hooks } = opts;
+
+    return verifyHOTP({
+      secret,
+      token,
+      crypto,
+      base32,
+      algorithm,
+      digits,
+      hooks,
+      counter: opts.counter,
+      counterTolerance: opts.counterTolerance,
+      guardrails: opts.guardrails,
+    });
+  }
+
+  const opts = normalizeTOTPVerifyOptions({
+    ...options,
+    strategy: "totp",
+  });
+  const { secret, token, crypto, base32, algorithm, digits, hooks } = opts;
+
+  return verifyTOTP({
+    secret,
+    token,
+    crypto,
+    base32,
+    algorithm,
+    digits,
+    hooks,
+    period: opts.period,
+    epoch: opts.epoch,
+    t0: opts.t0,
+    epochTolerance: opts.epochTolerance,
+    afterTimeStep: opts.afterTimeStep,
+    guardrails: opts.guardrails,
   });
 }
 
@@ -390,27 +463,49 @@ export async function verify(options: OTPVerifyOptions): Promise<VerifyResult> {
  * ```
  */
 export function verifySync(options: OTPVerifyOptions): VerifyResult {
-  const opts = normalizeVerifyOptions(options);
-  const { secret, token, crypto, base32, algorithm, digits, hooks } = opts;
-  const commonOptions = { secret, token, crypto, base32, algorithm, digits, hooks };
+  const strategy = resolveStrategy(options.strategy);
 
-  return executeByStrategy(opts.strategy, opts.counter, {
-    totp: () =>
-      verifyTOTPSync({
-        ...commonOptions,
-        period: opts.period,
-        epoch: opts.epoch,
-        t0: opts.t0,
-        epochTolerance: opts.epochTolerance,
-        afterTimeStep: opts.afterTimeStep,
-        guardrails: opts.guardrails,
-      }),
-    hotp: (counter) =>
-      verifyHOTPSync({
-        ...commonOptions,
-        counter,
-        counterTolerance: opts.counterTolerance,
-        guardrails: opts.guardrails,
-      }),
+  if (strategy === "hotp") {
+    const opts = normalizeHOTPVerifyOptions({
+      ...options,
+      strategy: "hotp",
+      counter: requireCounter(options.counter),
+    });
+    const { secret, token, crypto, base32, algorithm, digits, hooks } = opts;
+
+    return verifyHOTPSync({
+      secret,
+      token,
+      crypto,
+      base32,
+      algorithm,
+      digits,
+      hooks,
+      counter: opts.counter,
+      counterTolerance: opts.counterTolerance,
+      guardrails: opts.guardrails,
+    });
+  }
+
+  const opts = normalizeTOTPVerifyOptions({
+    ...options,
+    strategy: "totp",
+  });
+  const { secret, token, crypto, base32, algorithm, digits, hooks } = opts;
+
+  return verifyTOTPSync({
+    secret,
+    token,
+    crypto,
+    base32,
+    algorithm,
+    digits,
+    hooks,
+    period: opts.period,
+    epoch: opts.epoch,
+    t0: opts.t0,
+    epochTolerance: opts.epochTolerance,
+    afterTimeStep: opts.afterTimeStep,
+    guardrails: opts.guardrails,
   });
 }

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -341,12 +341,16 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
           epoch: 1234567890,
           format: "full",
         });
-        expect(result).toEqual({
-          valid: true,
-          delta: 0,
-          epoch: expect.any(Number),
-          timeStep: expect.any(Number),
-        });
+        const verifyResult = result as {
+          valid: boolean;
+          delta: number;
+          epoch: number;
+          timeStep: number;
+        };
+        expect(verifyResult.valid).toBe(true);
+        expect(verifyResult.delta).toBe(0);
+        expect(typeof verifyResult.epoch).toBe("number");
+        expect(typeof verifyResult.timeStep).toBe("number");
       });
 
       it("should return VerifyResult when format is omitted (default)", async () => {
@@ -356,8 +360,9 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
           token,
           epoch: 1234567890,
         });
-        expect(result).toHaveProperty("valid", true);
-        expect(result).toHaveProperty("delta");
+        const verifyResult = result as { valid: boolean; delta: number };
+        expect(verifyResult.valid).toBe(true);
+        expect(typeof verifyResult.delta).toBe("number");
       });
 
       it("should return boolean when format is 'plain' (sync)", () => {
@@ -389,12 +394,16 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
           epoch: 1234567890,
           format: "full",
         });
-        expect(result).toEqual({
-          valid: true,
-          delta: 0,
-          epoch: expect.any(Number),
-          timeStep: expect.any(Number),
-        });
+        const verifyResult = result as {
+          valid: boolean;
+          delta: number;
+          epoch: number;
+          timeStep: number;
+        };
+        expect(verifyResult.valid).toBe(true);
+        expect(verifyResult.delta).toBe(0);
+        expect(typeof verifyResult.epoch).toBe("number");
+        expect(typeof verifyResult.timeStep).toBe("number");
       });
     });
 

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -287,6 +287,28 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(result).toHaveProperty("timeStep");
         expect(result).toHaveProperty("epoch");
       });
+
+      it("should return string from OTP class with HOTP strategy even with format 'detailed'", async () => {
+        const otp = new OTP({ strategy: "hotp" });
+        const result = await otp.generate({
+          secret: TEST_SECRET,
+          counter: 0,
+          format: "detailed",
+        });
+        // HOTP ignores format; always returns a string
+        expect(typeof result).toBe("string");
+      });
+
+      it("should return string from OTP class generateSync with HOTP strategy and format 'detailed'", () => {
+        const otp = new OTP({ strategy: "hotp" });
+        const result = otp.generateSync({
+          secret: TEST_SECRET,
+          counter: 0,
+          format: "detailed",
+        });
+        // HOTP ignores format; always returns a string
+        expect(typeof result).toBe("string");
+      });
     });
 
     describe("verify", () => {

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -225,11 +225,11 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
     });
 
     describe("generate format option", () => {
-      it("should return detailed result for TOTP with format 'detailed'", async () => {
+      it("should return full result for TOTP with format 'full'", async () => {
         const result = await generate({
           secret: TEST_SECRET,
           epoch: 1234567890,
-          format: "detailed",
+          format: "full",
         });
         expect(typeof result).toBe("object");
         expect(result).toHaveProperty("token");
@@ -237,22 +237,22 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(result).toHaveProperty("epoch");
       });
 
-      it("should return string for HOTP even with format 'detailed'", async () => {
+      it("should return string for HOTP even with format 'full'", async () => {
         const result = await generate({
           secret: TEST_SECRET,
           strategy: "hotp",
           counter: 0,
-          format: "detailed",
+          format: "full",
         });
         // HOTP ignores format, returns string
         expect(typeof result).toBe("string");
       });
 
-      it("should return detailed result from generateSync for TOTP", () => {
+      it("should return full result from generateSync for TOTP", () => {
         const result = generateSync({
           secret: TEST_SECRET,
           epoch: 1234567890,
-          format: "detailed",
+          format: "full",
         });
         expect(typeof result).toBe("object");
         expect(result).toHaveProperty("token");
@@ -262,12 +262,12 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
     });
 
     describe("OTP class format option", () => {
-      it("should return detailed result from OTP class with TOTP strategy", async () => {
+      it("should return full result from OTP class with TOTP strategy", async () => {
         const otp = new OTP({ strategy: "totp" });
         const result = await otp.generate({
           secret: TEST_SECRET,
           epoch: 1234567890,
-          format: "detailed",
+          format: "full",
         });
         expect(typeof result).toBe("object");
         expect(result).toHaveProperty("token");
@@ -275,12 +275,12 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(result).toHaveProperty("epoch");
       });
 
-      it("should return detailed result from OTP class generateSync", () => {
+      it("should return full result from OTP class generateSync", () => {
         const otp = new OTP({ strategy: "totp" });
         const result = otp.generateSync({
           secret: TEST_SECRET,
           epoch: 1234567890,
-          format: "detailed",
+          format: "full",
         });
         expect(typeof result).toBe("object");
         expect(result).toHaveProperty("token");
@@ -288,26 +288,113 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(result).toHaveProperty("epoch");
       });
 
-      it("should return string from OTP class with HOTP strategy even with format 'detailed'", async () => {
+      it("should return string from OTP class with HOTP strategy even with format 'full'", async () => {
         const otp = new OTP({ strategy: "hotp" });
         const result = await otp.generate({
           secret: TEST_SECRET,
           counter: 0,
-          format: "detailed",
+          format: "full",
         });
         // HOTP ignores format; always returns a string
         expect(typeof result).toBe("string");
       });
 
-      it("should return string from OTP class generateSync with HOTP strategy and format 'detailed'", () => {
+      it("should return string from OTP class generateSync with HOTP strategy and format 'full'", () => {
         const otp = new OTP({ strategy: "hotp" });
         const result = otp.generateSync({
           secret: TEST_SECRET,
           counter: 0,
-          format: "detailed",
+          format: "full",
         });
         // HOTP ignores format; always returns a string
         expect(typeof result).toBe("string");
+      });
+    });
+
+    describe("verify format options", () => {
+      it("should return boolean when format is 'plain'", async () => {
+        const token = await generate({ secret: TEST_SECRET, epoch: 1234567890 });
+        const result = await verify({
+          secret: TEST_SECRET,
+          token,
+          epoch: 1234567890,
+          format: "plain",
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should return false when format is 'plain' and token is invalid", async () => {
+        const result = await verify({
+          secret: TEST_SECRET,
+          token: "000000",
+          epoch: 1234567890,
+          format: "plain",
+        });
+        expect(result).toBe(false);
+      });
+
+      it("should return VerifyResult when format is 'full'", async () => {
+        const token = await generate({ secret: TEST_SECRET, epoch: 1234567890 });
+        const result = await verify({
+          secret: TEST_SECRET,
+          token,
+          epoch: 1234567890,
+          format: "full",
+        });
+        expect(result).toEqual({
+          valid: true,
+          delta: 0,
+          epoch: expect.any(Number),
+          timeStep: expect.any(Number),
+        });
+      });
+
+      it("should return VerifyResult when format is omitted (default)", async () => {
+        const token = await generate({ secret: TEST_SECRET, epoch: 1234567890 });
+        const result = await verify({
+          secret: TEST_SECRET,
+          token,
+          epoch: 1234567890,
+        });
+        expect(result).toHaveProperty("valid", true);
+        expect(result).toHaveProperty("delta");
+      });
+
+      it("should return boolean when format is 'plain' (sync)", () => {
+        const token = generateSync({ secret: TEST_SECRET, epoch: 1234567890 });
+        const result = verifySync({
+          secret: TEST_SECRET,
+          token,
+          epoch: 1234567890,
+          format: "plain",
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should return false when format is 'plain' and token is invalid (sync)", () => {
+        const result = verifySync({
+          secret: TEST_SECRET,
+          token: "000000",
+          epoch: 1234567890,
+          format: "plain",
+        });
+        expect(result).toBe(false);
+      });
+
+      it("should return VerifyResult when format is 'full' (sync)", () => {
+        const token = generateSync({ secret: TEST_SECRET, epoch: 1234567890 });
+        const result = verifySync({
+          secret: TEST_SECRET,
+          token,
+          epoch: 1234567890,
+          format: "full",
+        });
+        expect(result).toEqual({
+          valid: true,
+          delta: 0,
+          epoch: expect.any(Number),
+          timeStep: expect.any(Number),
+        });
       });
     });
 

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -224,6 +224,71 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
       });
     });
 
+    describe("generate format option", () => {
+      it("should return detailed result for TOTP with format 'detailed'", async () => {
+        const result = await generate({
+          secret: TEST_SECRET,
+          epoch: 1234567890,
+          format: "detailed",
+        });
+        expect(typeof result).toBe("object");
+        expect(result).toHaveProperty("token");
+        expect(result).toHaveProperty("timeStep");
+        expect(result).toHaveProperty("epoch");
+      });
+
+      it("should return string for HOTP even with format 'detailed'", async () => {
+        const result = await generate({
+          secret: TEST_SECRET,
+          strategy: "hotp",
+          counter: 0,
+          format: "detailed",
+        });
+        // HOTP ignores format, returns string
+        expect(typeof result).toBe("string");
+      });
+
+      it("should return detailed result from generateSync for TOTP", () => {
+        const result = generateSync({
+          secret: TEST_SECRET,
+          epoch: 1234567890,
+          format: "detailed",
+        });
+        expect(typeof result).toBe("object");
+        expect(result).toHaveProperty("token");
+        expect(result).toHaveProperty("timeStep");
+        expect(result).toHaveProperty("epoch");
+      });
+    });
+
+    describe("OTP class format option", () => {
+      it("should return detailed result from OTP class with TOTP strategy", async () => {
+        const otp = new OTP({ strategy: "totp" });
+        const result = await otp.generate({
+          secret: TEST_SECRET,
+          epoch: 1234567890,
+          format: "detailed",
+        });
+        expect(typeof result).toBe("object");
+        expect(result).toHaveProperty("token");
+        expect(result).toHaveProperty("timeStep");
+        expect(result).toHaveProperty("epoch");
+      });
+
+      it("should return detailed result from OTP class generateSync", () => {
+        const otp = new OTP({ strategy: "totp" });
+        const result = otp.generateSync({
+          secret: TEST_SECRET,
+          epoch: 1234567890,
+          format: "detailed",
+        });
+        expect(typeof result).toBe("object");
+        expect(result).toHaveProperty("token");
+        expect(result).toHaveProperty("timeStep");
+        expect(result).toHaveProperty("epoch");
+      });
+    });
+
     describe("verify", () => {
       it("should verify correct TOTP code", async () => {
         const epoch = 1234567890;

--- a/packages/otplib/src/index.ts
+++ b/packages/otplib/src/index.ts
@@ -30,6 +30,8 @@ export type {
   OTPResult,
   OTPGuardrails,
   OTPGuardrailsConfig,
+  OTPFormat,
+  TOTPGenerateResult,
 } from "@otplib/core";
 export type { VerifyResult } from "@otplib/totp";
 

--- a/packages/otplib/src/index.ts
+++ b/packages/otplib/src/index.ts
@@ -31,7 +31,7 @@ export type {
   OTPGuardrails,
   OTPGuardrailsConfig,
   OTPFormat,
-  TOTPGenerateResult,
+  GenerateResult,
 } from "@otplib/core";
 export type { VerifyResult } from "@otplib/totp";
 

--- a/packages/otplib/src/types.ts
+++ b/packages/otplib/src/types.ts
@@ -117,8 +117,9 @@ export type TOTPExtraArgs = {
   /**
    * Output format for TOTP generation
    *
-   * - `"default"` (or omitted): returns a plain `string` token
-   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
+   * - `"default"` (or omitted): returns a plain `string` token (same as `"plain"`)
+   * - `"plain"`: returns a plain `string` token
+   * - `"full"`: returns `{ token, timeStep, epoch }` with computed metadata
    */
   format?: OTPFormat;
 };
@@ -205,8 +206,11 @@ export type OTPVerifyCommonOptions = OTPGenerateCommonOptions & {
   /**
    * Output format for verification
    *
-   * Accepted for backward compatibility and ignored by verify operations.
-   * This will be tightened in a future major version.
+   * - `"default"` (or omitted): returns `VerifyResult` object (same as `"full"`)
+   * - `"plain"`: returns `boolean` (true if valid, false if invalid)
+   * - `"full"`: returns `VerifyResult` object with delta, epoch, and timeStep
+   *
+   * Only used by TOTP strategy. HOTP ignores this option.
    */
   format?: OTPFormat;
 };

--- a/packages/otplib/src/types.ts
+++ b/packages/otplib/src/types.ts
@@ -39,11 +39,11 @@ export type OTPAuthOptions = {
 };
 
 /**
- * Common options for OTP generation
+ * Common options for OTP generation and verification
  *
  * These options apply to both TOTP and HOTP strategies.
  */
-export type OTPGenerateOptions = {
+export type OTPGenerateCommonOptions = {
   /**
    * Base32-encoded secret key
    *
@@ -103,35 +103,77 @@ export type OTPGenerateOptions = {
   t0?: number;
 
   /**
-   * Counter value
-   * Used by HOTP strategy (required)
-   */
-  counter?: number;
-
-  /**
    * Hooks for customizing token encoding and validation.
    * Allows non-standard OTP variants (e.g., Steam Guard) to replace
    * the default numeric encoding with custom schemes.
    */
   hooks?: OTPHooks;
+};
 
+/**
+ * TOTP-specific generation options
+ */
+export type TOTPExtraArgs = {
   /**
    * Output format for TOTP generation
    *
    * - `"default"` (or omitted): returns a plain `string` token
    * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
-   *
-   * Only applies to TOTP strategy; ignored for HOTP.
    */
   format?: OTPFormat;
 };
 
 /**
- * Options for OTP verification
- *
- * Extends OTPFunctionalOptions with token and tolerance parameters.
+ * TOTP generation options
  */
-export type OTPVerifyOptions = OTPGenerateOptions & {
+export type TOTPGenerateOptions = OTPGenerateCommonOptions &
+  TOTPExtraArgs & {
+    /**
+     * OTP strategy to use (default: 'totp')
+     */
+    strategy?: "totp";
+
+    /**
+     * Counter value
+     *
+     * Accepted for backward compatibility and ignored by TOTP strategy.
+     */
+    counter?: number;
+  };
+
+/**
+ * HOTP generation options
+ */
+export type HOTPGenerateOptions = OTPGenerateCommonOptions & {
+  /**
+   * OTP strategy to use
+   */
+  strategy: "hotp";
+
+  /**
+   * Counter value
+   * Used by HOTP strategy (required)
+   */
+  counter: number;
+
+  /**
+   * Output format for generation
+   *
+   * Accepted for backward compatibility and ignored by HOTP strategy.
+   * This will be tightened in a future major version.
+   */
+  format?: OTPFormat;
+};
+
+/**
+ * Common options for OTP generation
+ */
+export type OTPGenerateOptions = TOTPGenerateOptions | HOTPGenerateOptions;
+
+/**
+ * Common options for OTP verification
+ */
+export type OTPVerifyCommonOptions = OTPGenerateCommonOptions & {
   /**
    * OTP code to verify
    */
@@ -159,31 +201,110 @@ export type OTPVerifyOptions = OTPGenerateOptions & {
    * Only used by TOTP strategy.
    */
   afterTimeStep?: number;
+
+  /**
+   * Output format for verification
+   *
+   * Accepted for backward compatibility and ignored by verify operations.
+   * This will be tightened in a future major version.
+   */
+  format?: OTPFormat;
+};
+
+/**
+ * TOTP verification options
+ */
+export type TOTPVerifyOptions = OTPVerifyCommonOptions & {
+  /**
+   * OTP strategy to use (default: 'totp')
+   */
+  strategy?: "totp";
+
+  /**
+   * Counter value
+   *
+   * Accepted for backward compatibility and ignored by TOTP strategy.
+   */
+  counter?: number;
+};
+
+/**
+ * HOTP verification options
+ */
+export type HOTPVerifyOptions = OTPVerifyCommonOptions & {
+  /**
+   * OTP strategy to use
+   */
+  strategy: "hotp";
+
+  /**
+   * Counter value
+   * Used by HOTP strategy (required)
+   */
+  counter: number;
+};
+
+/**
+ * Options for OTP verification
+ */
+export type OTPVerifyOptions = TOTPVerifyOptions | HOTPVerifyOptions;
+
+type OTPNormalizedCommonOptions = Required<Omit<OTPGenerateCommonOptions, "hooks">> & {
+  hooks?: OTPHooks;
+};
+
+/**
+ * TOTP options with all defaults applied
+ */
+export type TOTPGenerateOptionsWithDefaults = OTPNormalizedCommonOptions &
+  TOTPExtraArgs & {
+    strategy: "totp";
+    counter?: number;
+  };
+
+/**
+ * HOTP options with all defaults applied
+ */
+export type HOTPGenerateOptionsWithDefaults = OTPNormalizedCommonOptions & {
+  strategy: "hotp";
+  counter: number;
+  format?: OTPFormat;
 };
 
 /**
  * OTP options with all defaults applied
  */
-export type OTPGenerateOptionsWithDefaults = Required<
-  Omit<OTPGenerateOptions, "counter" | "hooks" | "format">
-> & {
-  counter?: number;
-  hooks?: OTPHooks;
+export type OTPGenerateOptionsWithDefaults =
+  | TOTPGenerateOptionsWithDefaults
+  | HOTPGenerateOptionsWithDefaults;
+
+type OTPVerifyNormalizedCommonOptions = OTPNormalizedCommonOptions & {
+  token: string;
+  epochTolerance: number | [number, number];
+  counterTolerance: number | [number, number];
+  afterTimeStep?: number;
   format?: OTPFormat;
+};
+
+/**
+ * TOTP verify options with all defaults applied
+ */
+export type TOTPVerifyOptionsWithDefaults = OTPVerifyNormalizedCommonOptions & {
+  strategy: "totp";
+  counter?: number;
+};
+
+/**
+ * HOTP verify options with all defaults applied
+ */
+export type HOTPVerifyOptionsWithDefaults = OTPVerifyNormalizedCommonOptions & {
+  strategy: "hotp";
+  counter: number;
 };
 
 /**
  * OTP verify options with all defaults applied
  */
-export type OTPVerifyOptionsWithDefaults = OTPGenerateOptionsWithDefaults &
-  Required<Omit<OTPVerifyOptions, keyof OTPGenerateOptions | "afterTimeStep">> & {
-    afterTimeStep?: number;
-  };
-
-/**
- * Strategy handlers for TOTP/HOTP dispatch
- */
-export type StrategyHandlers<T> = {
-  totp: () => T;
-  hotp: (counter: number) => T;
-};
+export type OTPVerifyOptionsWithDefaults =
+  | TOTPVerifyOptionsWithDefaults
+  | HOTPVerifyOptionsWithDefaults;

--- a/packages/otplib/src/types.ts
+++ b/packages/otplib/src/types.ts
@@ -9,6 +9,7 @@ import type {
   HashAlgorithm,
   OTPGuardrails,
   OTPHooks,
+  OTPFormat,
 } from "@otplib/core";
 import type { HOTPOptions } from "@otplib/hotp";
 import type { TOTPOptions } from "@otplib/totp";
@@ -113,6 +114,16 @@ export type OTPGenerateOptions = {
    * the default numeric encoding with custom schemes.
    */
   hooks?: OTPHooks;
+
+  /**
+   * Output format for TOTP generation
+   *
+   * - `"default"` (or omitted): returns a plain `string` token
+   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
+   *
+   * Only applies to TOTP strategy; ignored for HOTP.
+   */
+  format?: OTPFormat;
 };
 
 /**
@@ -154,10 +165,11 @@ export type OTPVerifyOptions = OTPGenerateOptions & {
  * OTP options with all defaults applied
  */
 export type OTPGenerateOptionsWithDefaults = Required<
-  Omit<OTPGenerateOptions, "counter" | "hooks">
+  Omit<OTPGenerateOptions, "counter" | "hooks" | "format">
 > & {
   counter?: number;
   hooks?: OTPHooks;
+  format?: OTPFormat;
 };
 
 /**

--- a/packages/totp/README.md
+++ b/packages/totp/README.md
@@ -35,9 +35,9 @@ const token = await generate({
 });
 ```
 
-#### Detailed results
+#### Full results
 
-Pass `format: "detailed"` to receive the token along with time-step metadata. This is useful for replay protection without additional utility calls.
+Pass `format: "full"` to receive the token along with time-step metadata. This is useful for replay protection without additional utility calls.
 
 ```typescript
 import { generate } from "@otplib/totp";
@@ -46,7 +46,7 @@ import { crypto } from "@otplib/plugin-crypto-node";
 const result = await generate({
   secret,
   crypto,
-  format: "detailed",
+  format: "full",
 });
 
 // result.token    - the OTP string
@@ -175,8 +175,8 @@ const secret = new Uint8Array([
 const token = generateSync({ secret, crypto });
 const result = verifySync({ secret, token, crypto });
 
-// format: "detailed" works with generateSync too
-const detailed = generateSync({ secret, crypto, format: "detailed" });
+// format: "full" works with generateSync too
+const detailed = generateSync({ secret, crypto, format: "full" });
 // detailed.token, detailed.timeStep, detailed.epoch
 ```
 

--- a/packages/totp/README.md
+++ b/packages/totp/README.md
@@ -35,6 +35,27 @@ const token = await generate({
 });
 ```
 
+#### Detailed results
+
+Pass `format: "detailed"` to receive the token along with time-step metadata. This is useful for replay protection without additional utility calls.
+
+```typescript
+import { generate } from "@otplib/totp";
+import { crypto } from "@otplib/plugin-crypto-node";
+
+const result = await generate({
+  secret,
+  crypto,
+  format: "detailed",
+});
+
+// result.token    - the OTP string
+// result.timeStep - RFC 6238 T value (counter)
+// result.epoch    - period-start Unix timestamp in seconds
+```
+
+Without `format` (or with `format: "default"`), `generate` returns a plain `string` as before.
+
 #### With Base32 secrets
 
 If your secret is a Base32 string (e.g., from Google Authenticator), provide a `base32` plugin to decode it:
@@ -153,6 +174,10 @@ const secret = new Uint8Array([
 
 const token = generateSync({ secret, crypto });
 const result = verifySync({ secret, token, crypto });
+
+// format: "detailed" works with generateSync too
+const detailed = generateSync({ secret, crypto, format: "detailed" });
+// detailed.token, detailed.timeStep, detailed.epoch
 ```
 
 ## Compatibility with Authenticator Apps

--- a/packages/totp/src/class.test.ts
+++ b/packages/totp/src/class.test.ts
@@ -139,4 +139,37 @@ describe("TOTP Class", () => {
     const token = await totp.generate({ digits: 8 });
     expect(token.length).toBe(8);
   });
+
+  it("should return string from no-arg generate regardless of instance config", async () => {
+    // format is not a constructor option, so no-arg generate always returns string
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const result = await totp.generate();
+    expect(typeof result).toBe("string");
+    expect(result.length).toBe(6);
+  });
+
+  it("should only return detailed result when format is passed at call site", async () => {
+    const epoch = 1234567890;
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    // No-arg call returns string
+    const stringResult = await totp.generate({ epoch });
+    expect(typeof stringResult).toBe("string");
+
+    // format: "detailed" at call site returns detailed result
+    const detailedResult = await totp.generate({ epoch, format: "detailed" });
+    expect(typeof detailedResult).toBe("object");
+    expect(detailedResult).toHaveProperty("token");
+    expect(detailedResult).toHaveProperty("timeStep");
+    expect(detailedResult).toHaveProperty("epoch");
+  });
 });

--- a/packages/totp/src/class.test.ts
+++ b/packages/totp/src/class.test.ts
@@ -96,7 +96,7 @@ describe("TOTP Class", () => {
     expect(totp).toBeInstanceOf(TOTP);
   });
 
-  it("should return detailed result when format is 'detailed'", async () => {
+  it("should return full result when format is 'full'", async () => {
     const epoch = 1234567890;
     const totp = new TOTP({
       secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
@@ -171,5 +171,65 @@ describe("TOTP Class", () => {
     expect(detailedResult).toHaveProperty("token");
     expect(detailedResult).toHaveProperty("timeStep");
     expect(detailedResult).toHaveProperty("epoch");
+  });
+
+  it("should return boolean when verify format is 'plain'", async () => {
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const epoch = 1234567890;
+    const token = await totp.generate({ epoch });
+    const result = await totp.verify(token, { epoch, format: "plain" });
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false when verify format is 'plain' and token is invalid", async () => {
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const result = await totp.verify("000000", { epoch: 1234567890, format: "plain" });
+
+    expect(result).toBe(false);
+  });
+
+  it("should return VerifyResult when verify format is 'full'", async () => {
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const epoch = 1234567890;
+    const token = await totp.generate({ epoch });
+    const result = await totp.verify(token, { epoch, format: "full" });
+
+    expect(result).toEqual({
+      valid: true,
+      delta: 0,
+      epoch: expect.any(Number),
+      timeStep: expect.any(Number),
+    });
+  });
+
+  it("should return VerifyResult when verify format is omitted (default)", async () => {
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const epoch = 1234567890;
+    const token = await totp.generate({ epoch });
+    const result = await totp.verify(token, { epoch });
+
+    expect(result).toHaveProperty("valid", true);
+    expect(result).toHaveProperty("delta");
   });
 });

--- a/packages/totp/src/class.test.ts
+++ b/packages/totp/src/class.test.ts
@@ -104,7 +104,7 @@ describe("TOTP Class", () => {
       base32,
     });
 
-    const result = await totp.generate({ epoch, format: "detailed" });
+    const result = await totp.generate({ epoch, format: "full" });
 
     expect(result).toHaveProperty("token");
     expect(result).toHaveProperty("timeStep");
@@ -165,8 +165,8 @@ describe("TOTP Class", () => {
     const stringResult = await totp.generate({ epoch });
     expect(typeof stringResult).toBe("string");
 
-    // format: "detailed" at call site returns detailed result
-    const detailedResult = await totp.generate({ epoch, format: "detailed" });
+    // format: "full" at call site returns detailed result
+    const detailedResult = await totp.generate({ epoch, format: "full" });
     expect(typeof detailedResult).toBe("object");
     expect(detailedResult).toHaveProperty("token");
     expect(detailedResult).toHaveProperty("timeStep");

--- a/packages/totp/src/class.test.ts
+++ b/packages/totp/src/class.test.ts
@@ -96,6 +96,37 @@ describe("TOTP Class", () => {
     expect(totp).toBeInstanceOf(TOTP);
   });
 
+  it("should return detailed result when format is 'detailed'", async () => {
+    const epoch = 1234567890;
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const result = await totp.generate({ epoch, format: "detailed" });
+
+    expect(result).toHaveProperty("token");
+    expect(result).toHaveProperty("timeStep");
+    expect(result).toHaveProperty("epoch");
+    expect(typeof result.token).toBe("string");
+    expect(result.token.length).toBe(6);
+    expect(result.epoch).toBe(result.timeStep * 30 + 0);
+  });
+
+  it("should return string when format is not specified (backward compat)", async () => {
+    const totp = new TOTP({
+      secret: "GHDHB5FUNZ2Z4OT7PB2BUPHBIDR2J337",
+      crypto,
+      base32,
+    });
+
+    const result = await totp.generate();
+
+    expect(typeof result).toBe("string");
+    expect(result.length).toBe(6);
+  });
+
   it("should allow options override with partial options in generate", async () => {
     const totp = new TOTP({
       secret: TEST_SECRET_HOTP_BASE32,

--- a/packages/totp/src/class.ts
+++ b/packages/totp/src/class.ts
@@ -19,7 +19,7 @@ import { generateTOTP as generateTOTPURI } from "@otplib/uri";
 import { generate as generateCode, verify as verifyCode } from "./index.js";
 
 import type { VerifyResult, TOTPOptions, TOTPVerifyOptions } from "./types.js";
-import type { OTPGuardrails, OTPFormat, TOTPGenerateResult } from "@otplib/core";
+import type { OTPGuardrails, OTPFormat, GenerateResult } from "@otplib/core";
 
 /**
  * TOTP class for time-based one-time password generation
@@ -72,15 +72,15 @@ export class TOTP {
    * @returns The TOTP code
    */
   async generate(
-    options: Partial<TOTPOptions> & { format: "detailed" },
-  ): Promise<TOTPGenerateResult>;
-  async generate(options?: Partial<TOTPOptions> & { format?: "default" }): Promise<string>;
+    options: Partial<TOTPOptions> & { format: "full" },
+  ): Promise<GenerateResult>;
+  async generate(options?: Partial<TOTPOptions> & { format?: "default" | "plain" }): Promise<string>;
   async generate(
     options: Partial<TOTPOptions> & { format?: OTPFormat },
-  ): Promise<string | TOTPGenerateResult>;
+  ): Promise<string | GenerateResult>;
   async generate(
     options?: Partial<TOTPOptions> & { format?: OTPFormat },
-  ): Promise<string | TOTPGenerateResult> {
+  ): Promise<string | GenerateResult> {
     const mergedOptions = { ...this.options, ...options };
     const {
       secret,
@@ -124,8 +124,16 @@ export class TOTP {
    */
   async verify(
     token: string,
+    options: Partial<Omit<TOTPVerifyOptions, "token">> & { format: "plain" },
+  ): Promise<boolean>;
+  async verify(
+    token: string,
+    options?: Partial<Omit<TOTPVerifyOptions, "token">> & { format?: "default" | "full" },
+  ): Promise<VerifyResult>;
+  async verify(
+    token: string,
     options?: Partial<Omit<TOTPVerifyOptions, "token">>,
-  ): Promise<VerifyResult> {
+  ): Promise<boolean | VerifyResult> {
     const mergedOptions = { ...this.options, ...options };
     const {
       secret,
@@ -139,6 +147,7 @@ export class TOTP {
       epochTolerance = 0,
       afterTimeStep,
     } = mergedOptions;
+    const format = options?.format;
 
     requireSecret(secret);
     requireCryptoPlugin(crypto);
@@ -160,7 +169,8 @@ export class TOTP {
       base32,
       guardrails,
       hooks: mergedOptions.hooks,
-    });
+      format,
+    } as Parameters<typeof verifyCode>[0]);
   }
 
   /**

--- a/packages/totp/src/class.ts
+++ b/packages/totp/src/class.ts
@@ -19,7 +19,7 @@ import { generateTOTP as generateTOTPURI } from "@otplib/uri";
 import { generate as generateCode, verify as verifyCode } from "./index.js";
 
 import type { VerifyResult, TOTPOptions, TOTPVerifyOptions } from "./types.js";
-import type { OTPGuardrails, TOTPGenerateResult } from "@otplib/core";
+import type { OTPGuardrails, OTPFormat, TOTPGenerateResult } from "@otplib/core";
 
 /**
  * TOTP class for time-based one-time password generation
@@ -68,14 +68,19 @@ export class TOTP {
   /**
    * Generate a TOTP code
    *
-   * @param options - Optional overrides
+   * @param options - Optional overrides (format is per-call only, not inherited from constructor)
    * @returns The TOTP code
    */
   async generate(
     options: Partial<TOTPOptions> & { format: "detailed" },
   ): Promise<TOTPGenerateResult>;
-  async generate(options?: Partial<TOTPOptions>): Promise<string>;
-  async generate(options?: Partial<TOTPOptions>): Promise<string | TOTPGenerateResult> {
+  async generate(options?: Partial<TOTPOptions> & { format?: "default" }): Promise<string>;
+  async generate(
+    options: Partial<TOTPOptions> & { format?: OTPFormat },
+  ): Promise<string | TOTPGenerateResult>;
+  async generate(
+    options?: Partial<TOTPOptions> & { format?: OTPFormat },
+  ): Promise<string | TOTPGenerateResult> {
     const mergedOptions = { ...this.options, ...options };
     const {
       secret,
@@ -86,8 +91,8 @@ export class TOTP {
       period = 30,
       epoch,
       t0 = 0,
-      format,
     } = mergedOptions;
+    const format = options?.format;
 
     requireSecret(secret);
     requireCryptoPlugin(crypto);

--- a/packages/totp/src/class.ts
+++ b/packages/totp/src/class.ts
@@ -19,7 +19,7 @@ import { generateTOTP as generateTOTPURI } from "@otplib/uri";
 import { generate as generateCode, verify as verifyCode } from "./index.js";
 
 import type { VerifyResult, TOTPOptions, TOTPVerifyOptions } from "./types.js";
-import type { OTPGuardrails } from "@otplib/core";
+import type { OTPGuardrails, TOTPGenerateResult } from "@otplib/core";
 
 /**
  * TOTP class for time-based one-time password generation
@@ -71,7 +71,11 @@ export class TOTP {
    * @param options - Optional overrides
    * @returns The TOTP code
    */
-  async generate(options?: Partial<TOTPOptions>): Promise<string> {
+  async generate(
+    options: Partial<TOTPOptions> & { format: "detailed" },
+  ): Promise<TOTPGenerateResult>;
+  async generate(options?: Partial<TOTPOptions>): Promise<string>;
+  async generate(options?: Partial<TOTPOptions>): Promise<string | TOTPGenerateResult> {
     const mergedOptions = { ...this.options, ...options };
     const {
       secret,
@@ -82,6 +86,7 @@ export class TOTP {
       period = 30,
       epoch,
       t0 = 0,
+      format,
     } = mergedOptions;
 
     requireSecret(secret);
@@ -101,7 +106,8 @@ export class TOTP {
       base32,
       guardrails,
       hooks: mergedOptions.hooks,
-    });
+      format,
+    } as Parameters<typeof generateCode>[0]);
   }
 
   /**

--- a/packages/totp/src/class.ts
+++ b/packages/totp/src/class.ts
@@ -18,7 +18,7 @@ import { generateTOTP as generateTOTPURI } from "@otplib/uri";
 
 import { generate as generateCode, verify as verifyCode } from "./index.js";
 
-import type { VerifyResult, TOTPOptions, TOTPVerifyOptions } from "./types.js";
+import type { VerifyResult, TOTPOptions, TOTPGenerateOptions, TOTPVerifyOptions } from "./types.js";
 import type { OTPGuardrails, OTPFormat, GenerateResult } from "@otplib/core";
 
 /**
@@ -112,7 +112,7 @@ export class TOTP {
       guardrails,
       hooks: mergedOptions.hooks,
       format,
-    } as Parameters<typeof generateCode>[0]);
+    } as TOTPGenerateOptions);
   }
 
   /**
@@ -170,7 +170,7 @@ export class TOTP {
       guardrails,
       hooks: mergedOptions.hooks,
       format,
-    } as Parameters<typeof verifyCode>[0]);
+    } as TOTPVerifyOptions);
   }
 
   /**

--- a/packages/totp/src/class.ts
+++ b/packages/totp/src/class.ts
@@ -71,10 +71,10 @@ export class TOTP {
    * @param options - Optional overrides (format is per-call only, not inherited from constructor)
    * @returns The TOTP code
    */
+  async generate(options: Partial<TOTPOptions> & { format: "full" }): Promise<GenerateResult>;
   async generate(
-    options: Partial<TOTPOptions> & { format: "full" },
-  ): Promise<GenerateResult>;
-  async generate(options?: Partial<TOTPOptions> & { format?: "default" | "plain" }): Promise<string>;
+    options?: Partial<TOTPOptions> & { format?: "default" | "plain" },
+  ): Promise<string>;
   async generate(
     options: Partial<TOTPOptions> & { format?: OTPFormat },
   ): Promise<string | GenerateResult>;

--- a/packages/totp/src/index-test.ts
+++ b/packages/totp/src/index-test.ts
@@ -276,6 +276,141 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
       });
     });
 
+    describe("generate format option", () => {
+      it("should return string when format is omitted", async () => {
+        const result = await generate({
+          secret,
+          epoch: 1234567890,
+          crypto,
+        });
+        expect(typeof result).toBe("string");
+      });
+
+      it("should return string when format is 'default'", async () => {
+        const result = await generate({
+          secret,
+          epoch: 1234567890,
+          crypto,
+          format: "default",
+        });
+        expect(typeof result).toBe("string");
+      });
+
+      it("should return detailed result when format is 'detailed'", async () => {
+        const result = await generate({
+          secret,
+          epoch: 1234567890,
+          crypto,
+          format: "detailed",
+        });
+        expect(typeof result).toBe("object");
+        expect(result).toHaveProperty("token");
+        expect(result).toHaveProperty("timeStep");
+        expect(result).toHaveProperty("epoch");
+        expect(typeof result.token).toBe("string");
+        expect(typeof result.timeStep).toBe("number");
+        expect(typeof result.epoch).toBe("number");
+      });
+
+      it("should have matching token in detailed and default results", async () => {
+        const plain = await generate({
+          secret,
+          epoch: 1234567890,
+          crypto,
+        });
+        const detailed = await generate({
+          secret,
+          epoch: 1234567890,
+          crypto,
+          format: "detailed",
+        });
+        expect(detailed.token).toBe(plain);
+      });
+
+      it("should compute epoch as timeStep * period + t0", async () => {
+        const result = await generate({
+          secret,
+          epoch: 1234567890,
+          period: 30,
+          t0: 0,
+          crypto,
+          format: "detailed",
+        });
+        expect(result.epoch).toBe(result.timeStep * 30 + 0);
+      });
+
+      it("should reflect custom t0 in epoch computation", async () => {
+        const t0 = 100;
+        const result = await generate({
+          secret,
+          epoch: 1234567890,
+          period: 30,
+          t0,
+          crypto,
+          format: "detailed",
+        });
+        expect(result.epoch).toBe(result.timeStep * 30 + t0);
+      });
+
+      it("should have timeStep and epoch matching verify result", async () => {
+        const epoch = 1234567890;
+        const detailed = await generate({
+          secret,
+          epoch,
+          crypto,
+          format: "detailed",
+        });
+        const verifyResult = await verify({
+          secret,
+          token: detailed.token,
+          epoch,
+          crypto,
+        });
+        expect(verifyResult.valid).toBe(true);
+        if (verifyResult.valid) {
+          expect(verifyResult.timeStep).toBe(detailed.timeStep);
+          expect(verifyResult.epoch).toBe(detailed.epoch);
+        }
+      });
+
+      it("should return string from generateSync when format is omitted", () => {
+        const result = generateSync({
+          secret,
+          epoch: 1234567890,
+          crypto,
+        });
+        expect(typeof result).toBe("string");
+      });
+
+      it("should return detailed result from generateSync when format is 'detailed'", () => {
+        const result = generateSync({
+          secret,
+          epoch: 1234567890,
+          crypto,
+          format: "detailed",
+        });
+        expect(typeof result).toBe("object");
+        expect(result).toHaveProperty("token");
+        expect(result).toHaveProperty("timeStep");
+        expect(result).toHaveProperty("epoch");
+      });
+
+      it("should have matching token in sync detailed and default results", () => {
+        const plain = generateSync({
+          secret,
+          epoch: 1234567890,
+          crypto,
+        });
+        const detailed = generateSync({
+          secret,
+          epoch: 1234567890,
+          crypto,
+          format: "detailed",
+        });
+        expect(detailed.token).toBe(plain);
+      });
+    });
+
     describe("verify", () => {
       it("should verify valid TOTP code", async () => {
         const epoch = 59;

--- a/packages/totp/src/index-test.ts
+++ b/packages/totp/src/index-test.ts
@@ -296,7 +296,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
         expect(typeof result).toBe("string");
       });
 
-      it("should return detailed result when format is 'detailed'", async () => {
+      it("should return full result when format is 'full'", async () => {
         const result = await generate({
           secret,
           epoch: 1234567890,
@@ -387,7 +387,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
         expect(typeof result).toBe("string");
       });
 
-      it("should return detailed result from generateSync when format is 'detailed'", () => {
+      it("should return full result from generateSync when format is 'full'", () => {
         const result = generateSync({
           secret,
           epoch: 1234567890,
@@ -413,6 +413,122 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           format: "full",
         });
         expect(detailed.token).toBe(plain);
+      });
+
+      it("should return string when format is 'plain'", async () => {
+        const result = await generate({
+          secret,
+          crypto,
+          epoch: 59,
+          format: "plain",
+        });
+        expect(typeof result).toBe("string");
+        expect(result).toBe("287082");
+      });
+
+      it("should return string when format is 'plain' (sync)", () => {
+        const result = generateSync({
+          secret,
+          crypto,
+          epoch: 59,
+          format: "plain",
+        });
+        expect(typeof result).toBe("string");
+        expect(result).toBe("287082");
+      });
+    });
+
+    describe("verify format options", () => {
+      it("should return boolean when format is 'plain'", async () => {
+        const token = await generate({ secret, crypto, epoch: 59 });
+        const result = await verify({
+          secret,
+          crypto,
+          token,
+          epoch: 59,
+          format: "plain",
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should return false when format is 'plain' and token is invalid", async () => {
+        const result = await verify({
+          secret,
+          crypto,
+          token: "000000",
+          epoch: 59,
+          format: "plain",
+        });
+        expect(result).toBe(false);
+      });
+
+      it("should return VerifyResult when format is 'full'", async () => {
+        const token = await generate({ secret, crypto, epoch: 59 });
+        const result = await verify({
+          secret,
+          crypto,
+          token,
+          epoch: 59,
+          format: "full",
+        });
+        expect(result).toEqual({
+          valid: true,
+          delta: 0,
+          epoch: expect.any(Number),
+          timeStep: expect.any(Number),
+        });
+      });
+
+      it("should return VerifyResult when format is omitted (default)", async () => {
+        const token = await generate({ secret, crypto, epoch: 59 });
+        const result = await verify({
+          secret,
+          crypto,
+          token,
+          epoch: 59,
+        });
+        expect(result).toHaveProperty("valid", true);
+        expect(result).toHaveProperty("delta");
+      });
+
+      it("should return boolean when format is 'plain' (sync)", () => {
+        const token = generateSync({ secret, crypto, epoch: 59 });
+        const result = verifySync({
+          secret,
+          crypto,
+          token,
+          epoch: 59,
+          format: "plain",
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should return false when format is 'plain' and token is invalid (sync)", () => {
+        const result = verifySync({
+          secret,
+          crypto,
+          token: "000000",
+          epoch: 59,
+          format: "plain",
+        });
+        expect(result).toBe(false);
+      });
+
+      it("should return VerifyResult when format is 'full' (sync)", () => {
+        const token = generateSync({ secret, crypto, epoch: 59 });
+        const result = verifySync({
+          secret,
+          crypto,
+          token,
+          epoch: 59,
+          format: "full",
+        });
+        expect(result).toEqual({
+          valid: true,
+          delta: 0,
+          epoch: expect.any(Number),
+          timeStep: expect.any(Number),
+        });
       });
     });
 

--- a/packages/totp/src/index-test.ts
+++ b/packages/totp/src/index-test.ts
@@ -328,15 +328,20 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
       });
 
       it("should compute epoch as timeStep * period + t0", async () => {
+        const epoch = 1234567890;
+        const period = 30;
+        const t0 = 0;
         const result = await generate({
           secret,
-          epoch: 1234567890,
-          period: 30,
-          t0: 0,
+          epoch,
+          period,
+          t0,
           crypto,
           format: "detailed",
         });
-        expect(result.epoch).toBe(result.timeStep * 30 + 0);
+        expect(result.epoch).toBe(result.timeStep * period + t0);
+        expect(result.epoch).toBeLessThanOrEqual(epoch);
+        expect(result.epoch % period).toBe(0);
       });
 
       it("should reflect custom t0 in epoch computation", async () => {

--- a/packages/totp/src/index-test.ts
+++ b/packages/totp/src/index-test.ts
@@ -471,12 +471,16 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           epoch: 59,
           format: "full",
         });
-        expect(result).toEqual({
-          valid: true,
-          delta: 0,
-          epoch: expect.any(Number),
-          timeStep: expect.any(Number),
-        });
+        const verifyResult = result as {
+          valid: boolean;
+          delta: number;
+          epoch: number;
+          timeStep: number;
+        };
+        expect(verifyResult.valid).toBe(true);
+        expect(verifyResult.delta).toBe(0);
+        expect(typeof verifyResult.epoch).toBe("number");
+        expect(typeof verifyResult.timeStep).toBe("number");
       });
 
       it("should return VerifyResult when format is omitted (default)", async () => {
@@ -487,8 +491,9 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           token,
           epoch: 59,
         });
-        expect(result).toHaveProperty("valid", true);
-        expect(result).toHaveProperty("delta");
+        const verifyResult = result as { valid: boolean; delta: number };
+        expect(verifyResult.valid).toBe(true);
+        expect(typeof verifyResult.delta).toBe("number");
       });
 
       it("should return boolean when format is 'plain' (sync)", () => {
@@ -523,12 +528,16 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           epoch: 59,
           format: "full",
         });
-        expect(result).toEqual({
-          valid: true,
-          delta: 0,
-          epoch: expect.any(Number),
-          timeStep: expect.any(Number),
-        });
+        const verifyResult = result as {
+          valid: boolean;
+          delta: number;
+          epoch: number;
+          timeStep: number;
+        };
+        expect(verifyResult.valid).toBe(true);
+        expect(verifyResult.delta).toBe(0);
+        expect(typeof verifyResult.epoch).toBe("number");
+        expect(typeof verifyResult.timeStep).toBe("number");
       });
     });
 

--- a/packages/totp/src/index-test.ts
+++ b/packages/totp/src/index-test.ts
@@ -301,7 +301,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           secret,
           epoch: 1234567890,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         expect(typeof result).toBe("object");
         expect(result).toHaveProperty("token");
@@ -322,7 +322,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           secret,
           epoch: 1234567890,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         expect(detailed.token).toBe(plain);
       });
@@ -337,7 +337,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           period,
           t0,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         expect(result.epoch).toBe(result.timeStep * period + t0);
         expect(result.epoch).toBeLessThanOrEqual(epoch);
@@ -352,7 +352,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           period: 30,
           t0,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         expect(result.epoch).toBe(result.timeStep * 30 + t0);
       });
@@ -363,7 +363,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           secret,
           epoch,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         const verifyResult = await verify({
           secret,
@@ -392,7 +392,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           secret,
           epoch: 1234567890,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         expect(typeof result).toBe("object");
         expect(result).toHaveProperty("token");
@@ -410,7 +410,7 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
           secret,
           epoch: 1234567890,
           crypto,
-          format: "detailed",
+          format: "full",
         });
         expect(detailed.token).toBe(plain);
       });

--- a/packages/totp/src/index.ts
+++ b/packages/totp/src/index.ts
@@ -28,7 +28,14 @@ import {
 import { generate as generateHOTP, generateSync as generateHOTPSync } from "@otplib/hotp";
 
 import type { TOTPGenerateOptions, TOTPVerifyOptions, VerifyResult } from "./types.js";
-import type { CryptoPlugin, Digits, HashAlgorithm, OTPGuardrails, OTPHooks } from "@otplib/core";
+import type {
+  CryptoPlugin,
+  Digits,
+  HashAlgorithm,
+  OTPGuardrails,
+  OTPHooks,
+  TOTPGenerateResult,
+} from "@otplib/core";
 
 /**
  * Normalized options for TOTP generation
@@ -42,6 +49,8 @@ type TOTPGenerateOptionsInternal = {
   crypto: CryptoPlugin;
   guardrails: OTPGuardrails;
   hooks?: OTPHooks;
+  epoch: number;
+  timeStep: number;
 };
 
 /**
@@ -86,6 +95,8 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
     crypto,
     guardrails,
     hooks,
+    epoch: counter * period + t0,
+    timeStep: counter,
   };
 }
 
@@ -125,9 +136,20 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
  * // Returns: '123456'
  * ```
  */
-export async function generate(options: TOTPGenerateOptions): Promise<string> {
+export async function generate(
+  options: TOTPGenerateOptions & { readonly format: "detailed" },
+): Promise<TOTPGenerateResult>;
+export async function generate(
+  options: TOTPGenerateOptions & { readonly format?: "default" },
+): Promise<string>;
+export async function generate(options: TOTPGenerateOptions): Promise<string | TOTPGenerateResult>;
+export async function generate(options: TOTPGenerateOptions): Promise<string | TOTPGenerateResult> {
   const opt = getTOTPGenerateOptions(options);
-  return generateHOTP(opt);
+  const token = await generateHOTP(opt);
+  if (options.format === "detailed") {
+    return { token, timeStep: opt.timeStep, epoch: opt.epoch };
+  }
+  return token;
 }
 
 /**
@@ -159,9 +181,20 @@ export async function generate(options: TOTPGenerateOptions): Promise<string> {
  * // Returns: '123456'
  * ```
  */
-export function generateSync(options: TOTPGenerateOptions): string {
+export function generateSync(
+  options: TOTPGenerateOptions & { readonly format: "detailed" },
+): TOTPGenerateResult;
+export function generateSync(
+  options: TOTPGenerateOptions & { readonly format?: "default" },
+): string;
+export function generateSync(options: TOTPGenerateOptions): string | TOTPGenerateResult;
+export function generateSync(options: TOTPGenerateOptions): string | TOTPGenerateResult {
   const opt = getTOTPGenerateOptions(options);
-  return generateHOTPSync(opt);
+  const token = generateHOTPSync(opt);
+  if (options.format === "detailed") {
+    return { token, timeStep: opt.timeStep, epoch: opt.epoch };
+  }
+  return token;
 }
 
 /**
@@ -218,7 +251,7 @@ type TOTPVerifyOptionsInternal = {
   period: number;
   afterTimeStep?: number;
 
-  getGenerateOptions: (counter: number) => TOTPGenerateOptions;
+  getGenerateOptions: (counter: number) => Omit<TOTPGenerateOptions, "format">;
 };
 
 /**
@@ -488,7 +521,14 @@ export function getTimeStepUsed(
   return Math.floor((time - t0) / period);
 }
 
-export type { CryptoPlugin, Digits, HashAlgorithm, OTPResult } from "@otplib/core";
+export type {
+  CryptoPlugin,
+  Digits,
+  HashAlgorithm,
+  OTPResult,
+  OTPFormat,
+  TOTPGenerateResult,
+} from "@otplib/core";
 export type {
   TOTPOptions,
   TOTPGenerateOptions,

--- a/packages/totp/src/index.ts
+++ b/packages/totp/src/index.ts
@@ -34,7 +34,7 @@ import type {
   HashAlgorithm,
   OTPGuardrails,
   OTPHooks,
-  TOTPGenerateResult,
+  GenerateResult,
 } from "@otplib/core";
 
 /**
@@ -137,16 +137,16 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
  * ```
  */
 export async function generate(
-  options: TOTPGenerateOptions & { readonly format: "detailed" },
-): Promise<TOTPGenerateResult>;
+  options: TOTPGenerateOptions & { readonly format: "full" },
+): Promise<GenerateResult>;
 export async function generate(
-  options: TOTPGenerateOptions & { readonly format?: "default" },
+  options: TOTPGenerateOptions & { readonly format?: "default" | "plain" },
 ): Promise<string>;
-export async function generate(options: TOTPGenerateOptions): Promise<string | TOTPGenerateResult>;
-export async function generate(options: TOTPGenerateOptions): Promise<string | TOTPGenerateResult> {
+export async function generate(options: TOTPGenerateOptions): Promise<string | GenerateResult>;
+export async function generate(options: TOTPGenerateOptions): Promise<string | GenerateResult> {
   const opt = getTOTPGenerateOptions(options);
   const token = await generateHOTP(opt);
-  if (options.format === "detailed") {
+  if (options.format === "full") {
     return { token, timeStep: opt.timeStep, epoch: opt.epoch };
   }
   return token;
@@ -182,16 +182,16 @@ export async function generate(options: TOTPGenerateOptions): Promise<string | T
  * ```
  */
 export function generateSync(
-  options: TOTPGenerateOptions & { readonly format: "detailed" },
-): TOTPGenerateResult;
+  options: TOTPGenerateOptions & { readonly format: "full" },
+): GenerateResult;
 export function generateSync(
-  options: TOTPGenerateOptions & { readonly format?: "default" },
+  options: TOTPGenerateOptions & { readonly format?: "default" | "plain" },
 ): string;
-export function generateSync(options: TOTPGenerateOptions): string | TOTPGenerateResult;
-export function generateSync(options: TOTPGenerateOptions): string | TOTPGenerateResult {
+export function generateSync(options: TOTPGenerateOptions): string | GenerateResult;
+export function generateSync(options: TOTPGenerateOptions): string | GenerateResult {
   const opt = getTOTPGenerateOptions(options);
   const token = generateHOTPSync(opt);
-  if (options.format === "detailed") {
+  if (options.format === "full") {
     return { token, timeStep: opt.timeStep, epoch: opt.epoch };
   }
   return token;
@@ -365,7 +365,14 @@ function getTOTPVerifyOptions(options: TOTPVerifyOptions): TOTPVerifyOptionsInte
  * }
  * ```
  */
-export async function verify(options: TOTPVerifyOptions): Promise<VerifyResult> {
+export async function verify(
+  options: TOTPVerifyOptions & { readonly format: "plain" },
+): Promise<boolean>;
+export async function verify(
+  options: TOTPVerifyOptions & { readonly format?: "default" | "full" },
+): Promise<VerifyResult>;
+export async function verify(options: TOTPVerifyOptions): Promise<boolean | VerifyResult>;
+export async function verify(options: TOTPVerifyOptions): Promise<boolean | VerifyResult> {
   const {
     token,
     crypto,
@@ -379,13 +386,15 @@ export async function verify(options: TOTPVerifyOptions): Promise<VerifyResult> 
   } = getTOTPVerifyOptions(options);
 
   for (let counter = minCounter; counter <= maxCounter; counter++) {
-    // Early rejection: skip counters that don't meet afterTimeStep constraint
     if (shouldSkipAfterTimeStep(counter, afterTimeStep)) {
       continue;
     }
 
     const expected = await generate(getGenerateOptions(counter));
     if (crypto.constantTimeEqual(expected, token)) {
+      if (options.format === "plain") {
+        return true;
+      }
       return {
         valid: true,
         delta: counter - currentCounter,
@@ -395,6 +404,9 @@ export async function verify(options: TOTPVerifyOptions): Promise<VerifyResult> 
     }
   }
 
+  if (options.format === "plain") {
+    return false;
+  }
   return { valid: false };
 }
 
@@ -428,7 +440,14 @@ export async function verify(options: TOTPVerifyOptions): Promise<VerifyResult> 
  * }
  * ```
  */
-export function verifySync(options: TOTPVerifyOptions): VerifyResult {
+export function verifySync(
+  options: TOTPVerifyOptions & { readonly format: "plain" },
+): boolean;
+export function verifySync(
+  options: TOTPVerifyOptions & { readonly format?: "default" | "full" },
+): VerifyResult;
+export function verifySync(options: TOTPVerifyOptions): boolean | VerifyResult;
+export function verifySync(options: TOTPVerifyOptions): boolean | VerifyResult {
   const {
     token,
     crypto,
@@ -442,13 +461,15 @@ export function verifySync(options: TOTPVerifyOptions): VerifyResult {
   } = getTOTPVerifyOptions(options);
 
   for (let counter = minCounter; counter <= maxCounter; counter++) {
-    // Early rejection: skip counters that don't meet afterTimeStep constraint
     if (shouldSkipAfterTimeStep(counter, afterTimeStep)) {
       continue;
     }
 
     const expected = generateSync(getGenerateOptions(counter));
     if (crypto.constantTimeEqual(expected, token)) {
+      if (options.format === "plain") {
+        return true;
+      }
       return {
         valid: true,
         delta: counter - currentCounter,
@@ -458,6 +479,9 @@ export function verifySync(options: TOTPVerifyOptions): VerifyResult {
     }
   }
 
+  if (options.format === "plain") {
+    return false;
+  }
   return { valid: false };
 }
 
@@ -527,7 +551,7 @@ export type {
   HashAlgorithm,
   OTPResult,
   OTPFormat,
-  TOTPGenerateResult,
+  GenerateResult,
 } from "@otplib/core";
 export type {
   TOTPOptions,

--- a/packages/totp/src/index.ts
+++ b/packages/totp/src/index.ts
@@ -440,9 +440,7 @@ export async function verify(options: TOTPVerifyOptions): Promise<boolean | Veri
  * }
  * ```
  */
-export function verifySync(
-  options: TOTPVerifyOptions & { readonly format: "plain" },
-): boolean;
+export function verifySync(options: TOTPVerifyOptions & { readonly format: "plain" }): boolean;
 export function verifySync(
   options: TOTPVerifyOptions & { readonly format?: "default" | "full" },
 ): VerifyResult;

--- a/packages/totp/src/types.ts
+++ b/packages/totp/src/types.ts
@@ -61,13 +61,6 @@ export type TOTPOptions = {
    * the default numeric encoding with custom schemes.
    */
   readonly hooks?: OTPHooks;
-  /**
-   * Output format for generation
-   *
-   * - `"default"` (or omitted): returns a plain `string` token
-   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
-   */
-  readonly format?: OTPFormat;
 };
 
 /**
@@ -79,6 +72,16 @@ export type TOTPOptions = {
 export type TOTPGenerateOptions = TOTPOptions & {
   readonly secret: string | Uint8Array;
   readonly crypto: CryptoPlugin;
+  /**
+   * Output format for generation
+   *
+   * - `"default"` (or omitted): returns a plain `string` token
+   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
+   *
+   * This is a per-call option (not available at the class constructor level)
+   * to ensure TypeScript overload resolution accurately reflects the return type.
+   */
+  readonly format?: OTPFormat;
 };
 
 /**

--- a/packages/totp/src/types.ts
+++ b/packages/totp/src/types.ts
@@ -11,6 +11,7 @@ import type {
   Base32Plugin,
   OTPGuardrails,
   OTPHooks,
+  OTPFormat,
 } from "@otplib/core";
 
 /**
@@ -60,6 +61,13 @@ export type TOTPOptions = {
    * the default numeric encoding with custom schemes.
    */
   readonly hooks?: OTPHooks;
+  /**
+   * Output format for generation
+   *
+   * - `"default"` (or omitted): returns a plain `string` token
+   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
+   */
+  readonly format?: OTPFormat;
 };
 
 /**

--- a/packages/totp/src/types.ts
+++ b/packages/totp/src/types.ts
@@ -75,8 +75,9 @@ export type TOTPGenerateOptions = TOTPOptions & {
   /**
    * Output format for generation
    *
-   * - `"default"` (or omitted): returns a plain `string` token
-   * - `"detailed"`: returns `{ token, timeStep, epoch }` with computed metadata
+   * - `"default"` (or omitted): returns a plain `string` token (same as `"plain"`)
+   * - `"plain"`: returns a plain `string` token
+   * - `"full"`: returns `{ token, timeStep, epoch }` with computed metadata
    *
    * This is a per-call option (not available at the class constructor level)
    * to ensure TypeScript overload resolution accurately reflects the return type.
@@ -184,6 +185,17 @@ export type TOTPVerifyOptions = TOTPGenerateOptions & {
    * ```
    */
   readonly afterTimeStep?: number;
+  /**
+   * Output format for verification
+   *
+   * - `"default"` (or omitted): returns `VerifyResult` object (same as `"full"`)
+   * - `"plain"`: returns `boolean` (true if valid, false if invalid)
+   * - `"full"`: returns `VerifyResult` object with delta, epoch, and timeStep
+   *
+   * This is a per-call option (not available at the class constructor level)
+   * to ensure TypeScript overload resolution accurately reflects the return type.
+   */
+  readonly format?: OTPFormat;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add `format: "detailed"` option to TOTP `generate`/`generateSync` that returns `{ token, timeStep, epoch }` instead of a plain string
- Enables replay protection (store `timeStep`, pass as `afterTimeStep` to verify) and time-window deduplication without separate utility calls
- Fully backward compatible — omitting `format` or using `"default"` returns a plain string as before
- TypeScript overloads provide exact return type narrowing across TOTP functions, TOTP class, and otplib wrappers
