### PR TITLE
docs(getting-started): clarify when each function runs

### DIFF
--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -290,6 +290,17 @@ const remainingCustom = getRemainingTime(
 
 ## Important Notes
 
+### Common usage location for each function
+
+The Quick Start snippets above show all functions inline so they're runnable end-to-end. In typical 2FA usage, they're commonly called from different places:
+
+| Function         | When                       | Common Location |
+| ---------------- | -------------------------- | --------------- |
+| `generateSecret` | Enrollment (once per user) | Server          |
+| `generateURI`    | Enrollment (once per user) | Server          |
+| `generate`       | Verification (every login) | 2FA device      |
+| `verify`         | Verification (every login) | Server          |
+
 ### Time Synchronization
 
 TOTP depends on accurate time synchronization between client and server:


### PR DESCRIPTION
## Summary

Closes #838.

A first-time reader reported that the Quick Start snippets in `getting-started.md` imply the server generates tokens, when in real 2FA flows the server only verifies. Add a small subsection inside `## Important Notes` with a function-phase table that maps each function to its lifecycle phase and common location:

| Function         | When                       | Common Location |
| ---------------- | -------------------------- | --------------- |
| `generateSecret` | Enrollment (once per user) | Server          |
| `generateURI`    | Enrollment (once per user) | Server          |
| `generate`       | Verification (every login) | 2FA device      |
| `verify`         | Verification (every login) | Server          |

Reading top-to-bottom traces the actual auth flow: server enrolls, device generates the code, server verifies it. The device-vs-server split is self-evident from the table without needing prose narrative.

## Why a table instead of diagrams

An earlier iteration of this PR took a sequence-diagram approach (four mermaid diagrams covering TOTP/HOTP × enrollment/verification, rendered to SVG via Docker mermaid-cli). On reflection that approach was:

- Architecturally prescriptive: it baked a Frontend / Server / Database / Carrier shape into the docs that doesn't match every reader's setup.
- Misframed in places: the original "HOTP issuance" diagram conflated server-generated SMS codes with HOTP enrollment, which is a footgun rather than a clarification.
- Higher maintenance: Docker-gated regeneration, four `.mmd` sources + four committed `.svg` outputs, drift risk every time the API or recommended pattern shifts.

A four-row table is more accurate for a library with this small a surface area, opinion-free about architecture, and trivially maintainable.

## Test plan

- [x] `pnpm --filter @repo/docs docs:dev` and visit `/guide/getting-started.html` — confirm the table renders inside `## Important Notes` and the Quick Start section is clean.
- [x] `pnpm --filter @repo/docs docs:build` succeeds.
- [x] Pre-commit hooks (typecheck, lint, format) pass.