### PR TITLE
fix(docker): bump pnpm to 10.30.1 to match packageManager

### DIFF
--- a/docker/Dockerfile.bun
+++ b/docker/Dockerfile.bun
@@ -3,7 +3,7 @@ FROM oven/bun:${IMAGE_TAG}
 
 # Install Node.js and pnpm for building packages
 RUN apk add --no-cache nodejs npm
-RUN npm install -g pnpm@9.15.9
+RUN npm install -g pnpm@10.30.1
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.deno
+++ b/docker/Dockerfile.deno
@@ -6,7 +6,7 @@ FROM denoland/deno:${IMAGE_TAG}
 RUN apt-get update && apt-get install -y curl && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g pnpm@9.15.9 && \
+    npm install -g pnpm@10.30.1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/docker/Dockerfile.node
+++ b/docker/Dockerfile.node
@@ -2,7 +2,7 @@ ARG IMAGE_TAG=24.14.1-alpine3.22
 FROM node:${IMAGE_TAG}
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
+RUN corepack enable && corepack prepare pnpm@10.30.1 --activate
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary

All three Docker images pinned `pnpm@9.15.9`, but `package.json` declares `packageManager: pnpm@10.30.1`. With pnpm 10's strict `packageManager` enforcement, container builds were failing on `pnpm install --frozen-lockfile`. Aligning the Dockerfiles with the host pin resolves the install failure.

Files touched:

- `docker/Dockerfile.node`
- `docker/Dockerfile.bun`
- `docker/Dockerfile.deno`

## Test plan

- [x] `docker compose -f docker/docker-compose.yml build --no-cache node-24` succeeds.
- [x] Same for `bun-1` and `deno-2` services.
- [x] `docker compose -f docker/docker-compose.yml run --rm node-24` runs the test suite end-to-end.