### PR TITLE
docs: note short-secret guardrail override for legacy/test secrets

### DIFF
--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -173,6 +173,10 @@ If you are permanently using passphrases or other non-Base32 strings, you can ei
 
 ### TOTP Options
 
+::: info Minimum secret length
+Secrets must be at least 16 bytes (128 bits) after decoding. If you need to work with shorter secrets (e.g. RFC test vectors or legacy authenticator secrets), see [Troubleshooting - SecretTooShortError](/guide/troubleshooting#secrettooshorterror).
+:::
+
 ```typescript
 const token = await generate({
   secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY", // Base32-encoded secret (required)

--- a/apps/docs/guide/troubleshooting.md
+++ b/apps/docs/guide/troubleshooting.md
@@ -138,6 +138,21 @@ import { generateSecret } from "otplib";
 const secret = generateSecret(); // 20 bytes by default
 ```
 
+::: tip Working with shorter secrets
+RFC 4226 recommends a minimum of 128 bits (16 bytes), but many tutorials, RFC test vectors, and authenticator-app-issued secrets are shorter than this. If you need to interoperate with such secrets, you can override the `MIN_SECRET_BYTES` guardrail:
+
+```typescript
+import { generate, createGuardrails } from "otplib";
+
+const token = await generate({
+  secret: "12345678901234567890", // shorter than 16 bytes after decoding
+  guardrails: createGuardrails({ MIN_SECRET_BYTES: 10 }),
+});
+```
+
+See [Danger Zone - Guardrails](/guide/danger-zone#guardrails) for the full list of overridable limits and the security implications.
+:::
+
 ### "SecretTooLongError"
 
 Secrets must not exceed 64 bytes (512 bits):

--- a/apps/docs/guide/troubleshooting.md
+++ b/apps/docs/guide/troubleshooting.md
@@ -145,7 +145,7 @@ RFC 4226 recommends a minimum of 128 bits (16 bytes), but many tutorials, RFC te
 import { generate, createGuardrails } from "otplib";
 
 const token = await generate({
-  secret: "12345678901234567890", // shorter than 16 bytes after decoding
+  secret: "JBSWY3DPEHPK3PXP", // 10 bytes after Base32 decoding (below default 16-byte minimum)
   guardrails: createGuardrails({ MIN_SECRET_BYTES: 10 }),
 });
 ```

--- a/apps/docs/guide/v11-adapter.md
+++ b/apps/docs/guide/v11-adapter.md
@@ -48,7 +48,7 @@ The `check` and `verify` methods swallow errors and return `false`, matching v11
 Strict secret length checks (> 16 bytes) are enforced due to security requirements in the v13 core.
 
 ::: warning Legacy Secrets
-If your existing secrets are shorter than 16 bytes, you may need to override guardrails for backward compatibility. This is not done by default to preserve security. See [Danger Zone - Guardrails](/guide/danger-zone#guardrails) for details.
+Generate or verify calls with secrets shorter than 16 bytes (measured after Base32 decoding, where applicable) will now throw `SecretTooShortError`. The minimum is not relaxed by default, to preserve security. If you need to keep accepting shorter legacy secrets, override the `MIN_SECRET_BYTES` guardrail. See [Danger Zone - Guardrails](/guide/danger-zone#guardrails) for the override and [Troubleshooting - SecretTooShortError](/guide/troubleshooting#secrettooshorterror) for examples.
 :::
 
 ::: tip See Also

--- a/apps/docs/guide/v12-adapter.md
+++ b/apps/docs/guide/v12-adapter.md
@@ -186,7 +186,7 @@ await generate({
 v13 enforces a minimum secret length of 16 bytes. Older deployments may have shorter secrets.
 
 ::: warning Legacy Secrets
-If your existing secrets are shorter than 16 bytes, you may need to override guardrails for backward compatibility. This is not done by default to preserve security. See [Danger Zone - Guardrails](/guide/danger-zone#guardrails) for details.
+Generate or verify calls with secrets shorter than 16 bytes (measured after Base32 decoding, where applicable) will now throw `SecretTooShortError`. The minimum is not relaxed by default, to preserve security. If you need to keep accepting shorter legacy secrets, override the `MIN_SECRET_BYTES` guardrail. See [Danger Zone - Guardrails](/guide/danger-zone#guardrails) for the override and [Troubleshooting - SecretTooShortError](/guide/troubleshooting#secrettooshorterror) for examples.
 :::
 
 ### 6. Class-Based API Changes


### PR DESCRIPTION
## Summary
- Add a tip under **SecretTooShortError** in `troubleshooting.md` explaining that many tutorials, RFC test vectors, and authenticator-issued secrets fall below the 16-byte minimum, with a snippet showing the `MIN_SECRET_BYTES` guardrail override and a link to the Danger Zone page for the full set of overridable limits.
- Add a one-line `:::info` note above the **TOTP Options** block in `getting-started.md` clarifying that the 16-byte minimum is enforced after decoding, and cross-linking to the new troubleshooting tip so users hitting this case land on the right escape hatch instead of getting stuck on the happy path.

## Test plan
- [x] Render the docs site locally and confirm the new tip and info blocks render correctly under VitePress
- [x] Verify the `#secrettooshorterror` and `#guardrails` anchor links resolve
- [x] Sanity-check the `createGuardrails({ MIN_SECRET_BYTES: 10 })` snippet still matches the public API exported from `otplib`