### PR TITLE
ci: split security audit into blocking prod and informational full scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,8 +278,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run security audit
+      - name: Audit production dependencies (blocking)
+        run: pnpm audit --prod --audit-level=moderate
+
+      - name: Audit all dependencies (informational)
         run: pnpm audit --audit-level=moderate
+        continue-on-error: true
 
   reporting:
     name: Reporting (Coverage and Bundle Analysis)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,8 +282,19 @@ jobs:
         run: pnpm audit --prod --audit-level=moderate
 
       - name: Audit all dependencies (informational)
-        run: pnpm audit --audit-level=moderate
         continue-on-error: true
+        run: |
+          if ! pnpm audit --audit-level=moderate > audit.txt 2>&1; then
+            {
+              echo "## Security Audit — full dependency tree (informational)"
+              echo ""
+              echo "⚠️ Advisories found in dev/transitive dependencies (non-blocking):"
+              echo '```'
+              cat audit.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Informational audit found advisories in the full dependency tree — see the job summary."
+          fi
 
   reporting:
     name: Reporting (Coverage and Bundle Analysis)


### PR DESCRIPTION
Audit production dependencies as a blocking gate (what downstream
consumers are actually exposed to) and run the full dev+prod tree as an
informational, non-blocking scan. Keeps severity at moderate.

https://claude.ai/code/session_01GC4ms5J1NPts8oPxx7ceBL