### PR TITLE
fix: reject unknown hash algorithms instead of silently substituting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,9 @@ cache/
 coverage/
 .turbo/
 
+# Local tooling config (not part of the repo's source)
+.claude/
+
 # Package lock files
 pnpm-lock.yaml
 package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,9 +11,6 @@ cache/
 coverage/
 .turbo/
 
-# Local tooling config (not part of the repo's source)
-.claude/
-
 # Package lock files
 pnpm-lock.yaml
 package-lock.json

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -437,7 +437,7 @@ Only `sha1`, `sha256` and `sha512` are supported. The name is matched ignoring c
 `-` or `_` before the digest size, so `SHA256`, `SHA-256` and `sha_256` are all accepted as `sha256` —
 useful when the value comes from an `otpauth://` URI, since issuers spell it either way. Anything else
 throws `AlgorithmUnsupportedError` rather than falling back to a default, because a substituted
-algorithm produces tokens that no authenticator app can verify.
+algorithm produces tokens that do not match clients using the requested algorithm.
 
 ### Custom Secret Lengths
 

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -416,13 +416,21 @@ For strict RFC Compliance, enable padding.
 Google Authenticator and most standard apps use **SHA-1**.
 
 ```typescript
-import { generate } from "otplib";
+import { AlgorithmUnsupportedError, generate } from "otplib";
 
-// Using SHA-256
-const token = await generate({
-  secret,
-  algorithm: "sha256",
-});
+try {
+  // Using SHA-256
+  const token = await generate({
+    secret,
+    algorithm: "sha256",
+  });
+} catch (error) {
+  if (error instanceof AlgorithmUnsupportedError) {
+    console.error("The selected algorithm is not supported");
+  } else {
+    throw error;
+  }
+}
 ```
 
 Only `sha1`, `sha256` and `sha512` are supported. The name is matched ignoring case, with an optional
@@ -477,7 +485,8 @@ These utilities return an `OTPResult` object which discriminates on the `ok` pro
 Wrap synchronous functions like `otp.generateSync` or `otp.verifySync` (when used with synchronous plugins):
 
 ```typescript
-import { wrapResult, generateSync, OTPError } from "otplib";
+import { generateSync, wrapResult } from "otplib";
+import { OTPError } from "@otplib/core";
 
 // 1. Create your wrapped function
 // Note: Types are automatically inferred
@@ -549,6 +558,8 @@ OTPError (base class)
 ├── TokenError
 │   ├── TokenLengthError
 │   └── TokenFormatError
+├── AlgorithmError
+│   └── AlgorithmUnsupportedError
 ├── CryptoError
 │   ├── HMACError
 │   └── RandomBytesError
@@ -579,19 +590,20 @@ OTPError (base class)
 You can catch specific error types to handle different failure modes:
 
 ```typescript
-import {
-  generate,
-  SecretTooShortError,
-  TokenFormatError,
-  CryptoPluginMissingError,
-  OTPError,
-} from "otplib";
+import { AlgorithmError, AlgorithmUnsupportedError, HMACError, generate } from "otplib";
+import { SecretTooShortError, CryptoPluginMissingError, OTPError } from "@otplib/core";
 
 try {
   const token = await generate({ secret, crypto });
 } catch (error) {
   if (error instanceof SecretTooShortError) {
     console.error("Secret must be at least 16 bytes");
+  } else if (error instanceof AlgorithmUnsupportedError) {
+    console.error("The selected algorithm is not supported");
+  } else if (error instanceof AlgorithmError) {
+    console.error("The algorithm configuration is invalid");
+  } else if (error instanceof HMACError) {
+    console.error("The crypto plugin could not compute the HMAC");
   } else if (error instanceof CryptoPluginMissingError) {
     console.error("Please provide a crypto plugin");
   } else if (error instanceof OTPError) {
@@ -608,7 +620,7 @@ try {
 When errors originate from underlying plugins (crypto or Base32), otplib wraps them while preserving the original error via the `cause` property. This enables powerful debugging capabilities:
 
 ```typescript
-import { Base32DecodeError, HMACError } from "@otplib/core";
+import { Base32DecodeError } from "@otplib/core";
 
 try {
   const decoded = base32Context.decode("invalid!@#");
@@ -627,10 +639,13 @@ try {
 
 ### Error Types Reference
 
+`otplib` re-exports `AlgorithmError`, `AlgorithmUnsupportedError`, and `HMACError`. Import the
+remaining core-only error classes from `@otplib/core`.
+
 | Error Class                       | When Thrown                                      |
 | --------------------------------- | ------------------------------------------------ |
 | `AlgorithmError`                  | Base class for algorithm validation errors       |
-| `AlgorithmUnsupportedError`       | Algorithm is not sha1, sha256 or sha512          |
+| `AlgorithmUnsupportedError`       | Algorithm is invalid or unsupported by plugin    |
 | `AfterTimeStepRangeExceededError` | `afterTimeStep` exceeds max possible time step   |
 | `AfterTimeStepNegativeError`      | `afterTimeStep` is negative                      |
 | `AfterTimeStepNotIntegerError`    | `afterTimeStep` is not an integer (e.g., 1.5)    |

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -623,7 +623,8 @@ try {
 
 | Error Class                       | When Thrown                                      |
 | --------------------------------- | ------------------------------------------------ |
-| `AlgorithmError`                  | Invalid algorithm (not sha1/sha256/etc)          |
+| `AlgorithmError`                  | Base class for algorithm validation errors       |
+| `AlgorithmUnsupportedError`       | Algorithm is not sha1, sha256 or sha512          |
 | `AfterTimeStepRangeExceededError` | `afterTimeStep` exceeds max possible time step   |
 | `AfterTimeStepNegativeError`      | `afterTimeStep` is negative                      |
 | `AfterTimeStepNotIntegerError`    | `afterTimeStep` is not an integer (e.g., 1.5)    |

--- a/apps/docs/guide/advanced-usage.md
+++ b/apps/docs/guide/advanced-usage.md
@@ -425,6 +425,12 @@ const token = await generate({
 });
 ```
 
+Only `sha1`, `sha256` and `sha512` are supported. The name is matched ignoring case, with an optional
+`-` or `_` before the digest size, so `SHA256`, `SHA-256` and `sha_256` are all accepted as `sha256` —
+useful when the value comes from an `otpauth://` URI, since issuers spell it either way. Anything else
+throws `AlgorithmUnsupportedError` rather than falling back to a default, because a substituted
+algorithm produces tokens that no authenticator app can verify.
+
 ### Custom Secret Lengths
 
 You can generate secrets of specific lengths:

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -161,12 +161,15 @@ If you are permanently using passphrases or other non-Base32 strings, you can ei
 
 ::: info Note on Google Authenticator vs RFC4648 (TOTP)
 
-**Google Authenticator** requires specific settings for compatibility:
+For the widest **Google Authenticator** compatibility, use:
 
 - Algorithm: `sha1` (default)
 - Digits: `6` (default)
 - Period: `30` seconds (default)
 - Secret: Base32 encoded, **unpadded**
+
+Some authenticator versions ignore algorithm, digits, or period overrides, so
+non-default values may not be honored.
 
 **RFC 4648** specifies that Base32 should be padded. However, Google Authenticator and many other apps expect unpadded secrets. `otplib` defaults to `padding: false` in `generateSecret` and `generateURI` to ensure compatibility out of the box.
 :::

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -288,12 +288,14 @@ If you need a custom crypto or Base32 implementation, use the `createCryptoPlugi
 ### Custom Crypto
 
 ```typescript
-import { createCryptoPlugin } from "@otplib/core";
+import { createCryptoPlugin, normalizeHashAlgorithm } from "@otplib/core";
 
 const customCrypto = createCryptoPlugin({
   name: "custom",
   hmac: async (algorithm, key, data) => {
-    // your HMAC implementation here
+    const alg = normalizeHashAlgorithm(algorithm, undefined, "custom");
+
+    // your HMAC implementation here, dispatching on `alg`
     return new Uint8Array();
   },
   randomBytes: (length) => {
@@ -306,6 +308,28 @@ const customCrypto = createCryptoPlugin({
   },
 });
 ```
+
+#### Handling the algorithm
+
+Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Two rules apply:
+
+1. **Never fall back to a default.** Pass the value through `normalizeHashAlgorithm`, which matches
+   case-insensitively (`SHA1` → `sha1`) and throws `AlgorithmUnsupportedError` for anything else. Silently
+   substituting a different algorithm produces tokens that are self-consistent but never match other
+   implementations - the failure only shows up against a real authenticator app.
+2. **Map spellings inside the plugin.** If the implementation you wrap names algorithms differently, translate
+   the canonical name locally rather than expecting callers to adapt. The Web Crypto plugin does exactly this:
+
+   ```typescript
+   const ALGORITHM_MAP = {
+     sha1: "SHA-1",
+     sha256: "SHA-256",
+     sha512: "SHA-512",
+   } as const;
+   ```
+
+`CryptoContext` also normalizes before delegating, so plugins used through the library are protected either
+way - but a plugin called directly should still validate its own input.
 
 ### Custom Base32
 

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -344,6 +344,32 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
    narrow - the value is intersected with `HASH_ALGORITHMS`, so listing a digest outside that set does not
    enable it.
 
+::: warning A declaration is a contract, not a hint
+`algorithms` must hold whether the plugin is reached through `CryptoContext` or called directly as
+`plugin.hmac(...)`. `createCryptoPlugin` enforces it for you — it validates before invoking your `hmac`,
+so the implementation only ever sees a canonical name it declared.
+
+A **class-based plugin enforces its own declaration**. Pass the declared set through when you normalize:
+
+```typescript
+class RestrictedCryptoPlugin implements CryptoPlugin {
+  readonly name = "restricted";
+  readonly algorithms = ["sha1"] as const;
+
+  hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
+    const alg = normalizeHashAlgorithm(algorithm, {
+      supported: this.algorithms,
+      plugin: this.name,
+    });
+    // ...
+  }
+}
+```
+
+Omitting `supported` here would leave the plugin accepting an algorithm it advertises it cannot compute
+whenever it is called directly.
+:::
+
 `CryptoContext` also normalizes before delegating, so plugins used through the library are protected either
 way - but a plugin called directly should still validate its own input.
 

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -288,14 +288,13 @@ If you need a custom crypto or Base32 implementation, use the `createCryptoPlugi
 ### Custom Crypto
 
 ```typescript
-import { createCryptoPlugin, normalizeHashAlgorithm } from "@otplib/core";
+import { createCryptoPlugin } from "@otplib/core";
 
 const customCrypto = createCryptoPlugin({
   name: "custom",
   hmac: async (algorithm, key, data) => {
-    const alg = normalizeHashAlgorithm(algorithm, { plugin: "custom" });
-
-    // your HMAC implementation here, dispatching on `alg`
+    // `algorithm` is already canonical and validated - the factory checks it
+    // before calling this. Dispatch on it directly; do not re-validate.
     return new Uint8Array();
   },
   randomBytes: (length) => {
@@ -313,11 +312,20 @@ const customCrypto = createCryptoPlugin({
 
 Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
 
-1. **Never fall back to a default.** Pass the value through `normalizeHashAlgorithm`, which ignores case and
-   accepts an optional `-` or `_` before the digest size (`SHA1`, `SHA-1`, `sha_1` → `sha1`), throwing
-   `AlgorithmUnsupportedError` for anything else.
-   Silently substituting a _different_ algorithm produces tokens that are self-consistent but never match
-   other implementations - the failure only shows up against a real authenticator app.
+1. **Never fall back to a default.** An unrecognised name must throw `AlgorithmUnsupportedError`, never
+   resolve to some other digest — silently substituting a _different_ algorithm produces tokens that are
+   self-consistent but never match other implementations, and the failure only shows up against a real
+   authenticator app.
+
+   Who performs that check depends on how you build the plugin:
+
+   - **`createCryptoPlugin`** does it for you. Your `hmac` receives a canonical, validated name; calling
+     `normalizeHashAlgorithm` again inside it is redundant.
+   - **A class implementing `CryptoPlugin`** must call `normalizeHashAlgorithm` itself, as shown below.
+
+   Matching ignores case and accepts an optional `-` or `_` before the digest size (`SHA1`, `SHA-1`,
+   `sha_1` → `sha1`).
+
 2. **Map inside the plugin.** If the implementation you wrap names algorithms differently, translate
    the canonical name locally rather than expecting callers to adapt. The Web Crypto plugin does exactly this:
 
@@ -336,8 +344,12 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
    writing a second list, so the declaration cannot disagree with what the plugin actually dispatches:
 
    ```typescript
-   const SUPPORTED_ALGORITHMS = Object.keys(ALGORITHM_MAP) as readonly HashAlgorithm[];
+   const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(ALGORITHM_MAP) as HashAlgorithm[]);
    ```
+
+   Freeze it. `readonly` is erased at compile time, so an unfrozen array exposed as `plugin.algorithms`
+   could be mutated in-process to broaden what your plugin claims to support. (`createCryptoPlugin` copies
+   and freezes whatever you pass, so this only applies to class-based plugins.)
 
    `CryptoContext` reads this and rejects an unsupported algorithm _before_ delegating, so callers get a
    clear error rather than one raised from inside your plugin. Omit it to mean the full set. It can only
@@ -370,8 +382,9 @@ Omitting `supported` here would leave the plugin accepting an algorithm it adver
 whenever it is called directly.
 :::
 
-`CryptoContext` also normalizes before delegating, so plugins used through the library are protected either
-way - but a plugin called directly should still validate its own input.
+`CryptoContext` normalizes before delegating too, so a plugin reached through the library is covered
+regardless. That is a backstop, not a substitute: a class-based plugin is a public entry point in its own
+right and must hold its contract when called directly.
 
 ### Custom Base32
 

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -402,6 +402,25 @@ whenever it is called directly.
 regardless. That is a backstop, not a substitute: a class-based plugin is a public entry point in its own
 right and must hold its contract when called directly.
 
+#### Error boundaries
+
+Validation belongs at each public entry point, but not inside an already-protected implementation
+callback:
+
+- `createCryptoPlugin` is the public boundary for a factory plugin. It normalizes and checks the declared
+  `algorithms` before invoking your `hmac` callback, so the callback should dispatch directly without
+  repeating that validation.
+- A class-based plugin is its own public boundary. Its `hmac` method must normalize and enforce its
+  declaration because callers can invoke it without a `CryptoContext`.
+- `CryptoContext` is another public boundary. It checks a plugin's declared `algorithms` before delegation;
+  that pre-delegation failure is an `AlgorithmUnsupportedError` and the plugin is not called. After
+  delegation, any plugin failure is wrapped as `HMACError`, with the original value preserved as `cause`.
+  This includes an `AlgorithmUnsupportedError` raised by a class-based plugin whose narrower restriction
+  was not declared. Calling that plugin directly still exposes its original `AlgorithmUnsupportedError`.
+
+This layering avoids duplicate checks in factory callbacks while keeping every independently callable API
+safe and giving `CryptoContext` one consistent boundary for plugin failures.
+
 ### Custom Base32
 
 ```typescript

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -314,7 +314,8 @@ const customCrypto = createCryptoPlugin({
 Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
 
 1. **Never fall back to a default.** Pass the value through `normalizeHashAlgorithm`, which ignores case and
-   `-`/`_` separators (`SHA1`, `SHA-1` → `sha1`) and throws `AlgorithmUnsupportedError` for anything else.
+   accepts an optional `-` or `_` before the digest size (`SHA1`, `SHA-1`, `sha_1` → `sha1`), throwing
+   `AlgorithmUnsupportedError` for anything else.
    Silently substituting a _different_ algorithm produces tokens that are self-consistent but never match
    other implementations - the failure only shows up against a real authenticator app.
 2. **Map inside the plugin.** If the implementation you wrap names algorithms differently, translate

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -315,8 +315,8 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
 
 1. **Never fall back to a default.** An unrecognised name must throw `AlgorithmUnsupportedError`, never
    resolve to some other digest — silently substituting a _different_ algorithm produces tokens that are
-   self-consistent but never match other implementations, and the failure only shows up against a real
-   authenticator app.
+   self-consistent but do not match implementations using the requested algorithm, and the failure only
+   shows up against a real authenticator app.
 
    Who performs that check depends on how you build the plugin:
 
@@ -380,17 +380,20 @@ so the implementation only ever sees a canonical name it declared.
 A **class-based plugin enforces its own declaration**. Pass the declared set through when you normalize:
 
 ```typescript
-class RestrictedCryptoPlugin implements CryptoPlugin {
+class RestrictedCryptoPlugin {
   readonly name = "restricted";
-  readonly algorithms = ["sha1"] as const;
+  readonly algorithms = Object.freeze(["sha1"] as const);
 
   hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
     const alg = normalizeHashAlgorithm(algorithm, {
       supported: this.algorithms,
       plugin: this.name,
     });
-    // ...
+    // Compute HMAC-SHA-1 using `key` and `data`.
+    return new Uint8Array();
   }
+
+  // `randomBytes` and `constantTimeEqual` omitted here for brevity.
 }
 ```
 
@@ -447,7 +450,7 @@ Unlike `createCryptoPlugin`, a class is responsible for enforcing its own algori
 wraps `hmac` on your behalf when it is called directly.
 
 ```typescript
-import { normalizeHashAlgorithm } from "@otplib/core";
+import { constantTimeEqual as coreConstantTimeEqual, normalizeHashAlgorithm } from "@otplib/core";
 import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
 
 const DIGESTS = {
@@ -456,10 +459,10 @@ const DIGESTS = {
 } as const satisfies Partial<Record<HashAlgorithm, string>>;
 
 class CustomCryptoPlugin implements CryptoPlugin {
-  name = "custom";
+  readonly name = "custom";
 
-  // Derived from the map, and frozen so it cannot be broadened at runtime
-  algorithms = Object.freeze(Object.keys(DIGESTS) as HashAlgorithm[]);
+  // Derived from the map and frozen so its contents cannot be mutated
+  readonly algorithms = Object.freeze(Object.keys(DIGESTS) as HashAlgorithm[]);
 
   hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array) {
     const alg = normalizeHashAlgorithm(algorithm, {
@@ -474,14 +477,12 @@ class CustomCryptoPlugin implements CryptoPlugin {
     return new Uint8Array();
   }
 
-  randomBytes(length) {
-    // your random bytes implementation here
-    return new Uint8Array(length);
+  randomBytes(length: number): Uint8Array {
+    return globalThis.crypto.getRandomValues(new Uint8Array(length));
   }
 
-  constantTimeEqual(a, b) {
-    // your constant time implementation here
-    return true;
+  constantTimeEqual(a: string | Uint8Array, b: string | Uint8Array): boolean {
+    return coreConstantTimeEqual(a, b);
   }
 }
 ```

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -317,7 +317,7 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
    `-`/`_` separators (`SHA1`, `SHA-1` → `sha1`) and throws `AlgorithmUnsupportedError` for anything else.
    Silently substituting a _different_ algorithm produces tokens that are self-consistent but never match
    other implementations - the failure only shows up against a real authenticator app.
-2. **Map spellings inside the plugin.** If the implementation you wrap names algorithms differently, translate
+2. **Map inside the plugin.** If the implementation you wrap names algorithms differently, translate
    the canonical name locally rather than expecting callers to adapt. The Web Crypto plugin does exactly this:
 
    ```typescript

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -313,10 +313,10 @@ const customCrypto = createCryptoPlugin({
 
 Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Two rules apply:
 
-1. **Never fall back to a default.** Pass the value through `normalizeHashAlgorithm`, which matches
-   case-insensitively (`SHA1` → `sha1`) and throws `AlgorithmUnsupportedError` for anything else. Silently
-   substituting a different algorithm produces tokens that are self-consistent but never match other
-   implementations - the failure only shows up against a real authenticator app.
+1. **Never fall back to a default.** Pass the value through `normalizeHashAlgorithm`, which ignores case and
+   `-`/`_` separators (`SHA1`, `SHA-1` → `sha1`) and throws `AlgorithmUnsupportedError` for anything else.
+   Silently substituting a _different_ algorithm produces tokens that are self-consistent but never match
+   other implementations - the failure only shows up against a real authenticator app.
 2. **Map spellings inside the plugin.** If the implementation you wrap names algorithms differently, translate
    the canonical name locally rather than expecting callers to adapt. The Web Crypto plugin does exactly this:
 

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -35,7 +35,7 @@ const validCrypto = new NodeCryptoPlugin();
 ## Choosing a Crypto Plugin
 
 ::: info Other Runtimes
-This section focuses on package selection. for specific setup instructions for **Deno** (using `npm:` specifiers) or **Bun**, please refer to the [Runtime Compatibility](./runtime-compatibility) guide.
+This section focuses on package selection. For specific setup instructions for **Deno** (using `npm:` specifiers) or **Bun**, please refer to the [Runtime Compatibility](./runtime-compatibility) guide.
 :::
 
 ### Node.js Applications
@@ -293,8 +293,9 @@ import { createCryptoPlugin } from "@otplib/core";
 const customCrypto = createCryptoPlugin({
   name: "custom",
   hmac: async (algorithm, key, data) => {
-    // `algorithm` is already canonical and validated - the factory checks it
-    // before calling this. Dispatch on it directly; do not re-validate.
+    // `algorithm` is already canonical - `sha1`, `sha256` or `sha512` - and,
+    // if you declared `algorithms`, already one of those. The factory checks
+    // before calling this, so dispatch directly and do not re-validate.
     return new Uint8Array();
   },
   randomBytes: (length) => {
@@ -319,9 +320,12 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
 
    Who performs that check depends on how you build the plugin:
 
-   - **`createCryptoPlugin`** does it for you. Your `hmac` receives a canonical, validated name; calling
-     `normalizeHashAlgorithm` again inside it is redundant.
-   - **A class implementing `CryptoPlugin`** must call `normalizeHashAlgorithm` itself, as shown below.
+   - **`createCryptoPlugin`** does it for you. Your `hmac` receives a canonical name that is already
+     within `algorithms` when you declare one; calling `normalizeHashAlgorithm` again inside it is
+     redundant.
+   - **A class implementing `CryptoPlugin`** must call `normalizeHashAlgorithm` itself, passing
+     `supported: this.algorithms` whenever it declares a restricted set. Nothing else enforces the
+     declaration when the class is called directly.
 
    Matching ignores case and accepts an optional `-` or `_` before the digest size (`SHA1`, `SHA-1`,
    `sha_1` → `sha1`).
@@ -337,19 +341,31 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
    } as const satisfies Record<HashAlgorithm, string>;
    ```
 
-   The `satisfies` clause is worth copying: it rejects a key outside `HashAlgorithm`, and requires every
-   member of it, so the map cannot drift from what the library supports.
+   The `satisfies` clause is worth copying: it rejects a key outside `HashAlgorithm`, and — because
+   `Record` requires every member — fails to compile if an algorithm is ever added without a mapping. Use
+   it whenever your plugin covers all three.
 
-3. **Declare `algorithms` if you support fewer than all three.** Derive it from the map above rather than
-   writing a second list, so the declaration cannot disagree with what the plugin actually dispatches:
+   A plugin that covers only some of them wants `Partial` instead, which still forbids unknown keys while
+   allowing a subset:
+
+   ```typescript
+   const ALGORITHM_MAP = {
+     sha1: "SHA-1",
+   } as const satisfies Partial<Record<HashAlgorithm, string>>;
+   ```
+
+3. **Declare `algorithms` if you support fewer than all three.** Derive it from the `Partial` map above
+   rather than writing a second list, so the declaration cannot disagree with what the plugin actually
+   dispatches:
 
    ```typescript
    const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(ALGORITHM_MAP) as HashAlgorithm[]);
    ```
 
-   Freeze it. `readonly` is erased at compile time, so an unfrozen array exposed as `plugin.algorithms`
-   could be mutated in-process to broaden what your plugin claims to support. (`createCryptoPlugin` copies
-   and freezes whatever you pass, so this only applies to class-based plugins.)
+   Freeze it, and note that `Object.keys(...) as readonly HashAlgorithm[]` does **not** do this — the
+   annotation is erased at compile time, leaving a mutable array that could be pushed to in-process to
+   broaden what your plugin claims to support. `Object.freeze` is what makes it hold at runtime.
+   (`createCryptoPlugin` copies and freezes whatever you pass, so this applies to class-based plugins.)
 
    `CryptoContext` reads this and rejects an unsupported algorithm _before_ delegating, so callers get a
    clear error rather than one raised from inside your plugin. Omit it to mean the full set. It can only
@@ -408,14 +424,34 @@ const customBase32 = createBase32Plugin({
 
 For more advanced behavior (stateful configuration, shared helpers, or multiple methods), you can extend a class that implements the plugin interface instead of using the factories. This is useful when you need lifecycle setup or richer internal structure.
 
+Unlike `createCryptoPlugin`, a class is responsible for enforcing its own algorithm contract — nothing
+wraps `hmac` on your behalf when it is called directly.
+
 ```typescript
-import type { CryptoPlugin } from "@otplib/core";
+import { normalizeHashAlgorithm } from "@otplib/core";
+import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
+
+const DIGESTS = {
+  sha1: "SHA-1",
+  sha256: "SHA-256",
+} as const satisfies Partial<Record<HashAlgorithm, string>>;
 
 class CustomCryptoPlugin implements CryptoPlugin {
   name = "custom";
 
-  hmac(algorithm, key, data) {
-    // your HMAC implementation here
+  // Derived from the map, and frozen so it cannot be broadened at runtime
+  algorithms = Object.freeze(Object.keys(DIGESTS) as HashAlgorithm[]);
+
+  hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array) {
+    const alg = normalizeHashAlgorithm(algorithm, {
+      supported: this.algorithms,
+      plugin: this.name,
+    });
+
+    // `alg` is canonical and within `algorithms` - safe to dispatch on
+    const digest = DIGESTS[alg as keyof typeof DIGESTS];
+
+    // your HMAC implementation here, using `digest`
     return new Uint8Array();
   }
 

--- a/apps/docs/guide/plugins.md
+++ b/apps/docs/guide/plugins.md
@@ -293,7 +293,7 @@ import { createCryptoPlugin, normalizeHashAlgorithm } from "@otplib/core";
 const customCrypto = createCryptoPlugin({
   name: "custom",
   hmac: async (algorithm, key, data) => {
-    const alg = normalizeHashAlgorithm(algorithm, undefined, "custom");
+    const alg = normalizeHashAlgorithm(algorithm, { plugin: "custom" });
 
     // your HMAC implementation here, dispatching on `alg`
     return new Uint8Array();
@@ -311,7 +311,7 @@ const customCrypto = createCryptoPlugin({
 
 #### Handling the algorithm
 
-Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Two rules apply:
+Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Three rules apply:
 
 1. **Never fall back to a default.** Pass the value through `normalizeHashAlgorithm`, which ignores case and
    `-`/`_` separators (`SHA1`, `SHA-1` → `sha1`) and throws `AlgorithmUnsupportedError` for anything else.
@@ -325,8 +325,23 @@ Crypto plugins receive one of `sha1`, `sha256` or `sha512`. Two rules apply:
      sha1: "SHA-1",
      sha256: "SHA-256",
      sha512: "SHA-512",
-   } as const;
+   } as const satisfies Record<HashAlgorithm, string>;
    ```
+
+   The `satisfies` clause is worth copying: it rejects a key outside `HashAlgorithm`, and requires every
+   member of it, so the map cannot drift from what the library supports.
+
+3. **Declare `algorithms` if you support fewer than all three.** Derive it from the map above rather than
+   writing a second list, so the declaration cannot disagree with what the plugin actually dispatches:
+
+   ```typescript
+   const SUPPORTED_ALGORITHMS = Object.keys(ALGORITHM_MAP) as readonly HashAlgorithm[];
+   ```
+
+   `CryptoContext` reads this and rejects an unsupported algorithm _before_ delegating, so callers get a
+   clear error rather than one raised from inside your plugin. Omit it to mean the full set. It can only
+   narrow - the value is intersected with `HASH_ALGORITHMS`, so listing a digest outside that set does not
+   enable it.
 
 `CryptoContext` also normalizes before delegating, so plugins used through the library are protected either
 way - but a plugin called directly should still validate its own input.

--- a/apps/docs/guide/rfc-implementations.md
+++ b/apps/docs/guide/rfc-implementations.md
@@ -151,6 +151,12 @@ otpauth://TYPE/LABEL?PARAMETERS
 | counter   | No (HOTP only) | number | Initial counter       | 0       |
 | period    | No (TOTP only) | number | Time step in seconds  | 30      |
 
+The OTPAuth URI format does not define how duplicate query parameters are
+resolved. Otplib consistently uses the first occurrence of every decoded key,
+matching `URLSearchParams.get()`: the first value is parsed and validated, while
+later values are ignored without being decoded. A bare parameter counts as an
+empty first value. Avoid duplicate parameters when interoperability matters.
+
 ### URI Generation
 
 ```typescript

--- a/apps/docs/guide/rfc-implementations.md
+++ b/apps/docs/guide/rfc-implementations.md
@@ -134,7 +134,8 @@ const secret = base32.encode(randomBytes(20), { padding: false });
 
 ### otpauth:// URI Format
 
-otplib fully implements the otpauth:// URI format used by Google Authenticator:
+otplib generates interoperable otpauth:// URIs and permissively parses the
+format used by Google Authenticator:
 
 ```
 otpauth://TYPE/LABEL?PARAMETERS
@@ -142,14 +143,18 @@ otpauth://TYPE/LABEL?PARAMETERS
 
 **Supported Parameters:**
 
-| Parameter | Required       | Type   | Description           | Default |
-| --------- | -------------- | ------ | --------------------- | ------- |
-| secret    | Yes            | string | Base32-encoded secret | -       |
-| issuer    | Recommended    | string | Provider name         | -       |
-| algorithm | No             | string | Hash algorithm        | SHA1    |
-| digits    | No             | number | OTP length            | 6       |
-| counter   | No (HOTP only) | number | Initial counter       | 0       |
-| period    | No (TOTP only) | number | Time step in seconds  | 30      |
+| Parameter | Required        | Type   | Description           | Default |
+| --------- | --------------- | ------ | --------------------- | ------- |
+| secret    | Yes             | string | Base32-encoded secret | -       |
+| issuer    | Recommended     | string | Provider name         | -       |
+| algorithm | No              | string | Hash algorithm        | SHA1    |
+| digits    | No              | number | OTP length            | 6       |
+| counter   | Yes (HOTP only) | number | Initial counter       | -       |
+| period    | No (TOTP only)  | number | Time step in seconds  | 30      |
+
+The Key URI format requires `counter` for HOTP. Otplib's HOTP generation helpers
+default it to `0` and always emit it; parsing also accepts an absent counter for
+backward compatibility.
 
 The OTPAuth URI format does not define how duplicate query parameters are
 resolved. Otplib consistently uses the first occurrence of every decoded key,
@@ -157,12 +162,14 @@ matching `URLSearchParams.get()`: the first value is parsed and validated, while
 later values are ignored without being decoded. A bare parameter counts as an
 empty first value. Avoid duplicate parameters when interoperability matters.
 
+Parsing preserves optionality: an absent, bare, or empty `algorithm` parameter
+leaves the parsed algorithm undefined. OTP generation and verification apply
+the SHA-1 default when consuming that result.
+
 ### URI Generation
 
 ```typescript
 import { generateURI } from "otplib";
-import { crypto } from "@otplib/plugin-crypto-node";
-import { base32 } from "@otplib/plugin-base32-scure";
 
 const uri = generateURI({
   issuer: "MyService",
@@ -171,10 +178,8 @@ const uri = generateURI({
   algorithm: "sha1",
   digits: 6,
   period: 30,
-  crypto,
-  base32,
 });
-// otpauth://totp/MyService:user@example.com?secret=...&issuer=MyService&algorithm=SHA1&digits=6&period=30
+// otpauth://totp/MyService:user%40example.com?secret=...&issuer=MyService
 ```
 
 ### Test Integration

--- a/apps/docs/guide/troubleshooting.md
+++ b/apps/docs/guide/troubleshooting.md
@@ -95,7 +95,7 @@ const result = await verify({
 
 **Affects `@otplib/plugin-crypto-noble` 13.0.0 – 13.4.1**, the default crypto plugin. In that range it fell
 back to SHA-512 for any algorithm name it did not recognise. A caller passing `'SHA1'` or `'SHA256'` —
-spellings TypeScript rejects, but plain JavaScript does not — silently got HMAC-SHA-512 with no error. Those
+aliases TypeScript rejects, but plain JavaScript does not — silently got HMAC-SHA-512 with no error. Those
 tokens were self-consistent, so they verified against otplib and nothing else.
 
 Later versions remove the fallback: an unrecognised name throws `AlgorithmUnsupportedError`, and a recognised

--- a/apps/docs/guide/troubleshooting.md
+++ b/apps/docs/guide/troubleshooting.md
@@ -96,7 +96,8 @@ const result = await verify({
 **Affects `@otplib/plugin-crypto-noble` 13.0.0 – 13.4.1**, the default crypto plugin. In that range it fell
 back to SHA-512 for any algorithm name it did not recognise. A caller passing `'SHA1'` or `'SHA256'` —
 aliases TypeScript rejects, but plain JavaScript does not — silently got HMAC-SHA-512 with no error. Those
-tokens were self-consistent, so they verified against otplib and nothing else.
+tokens were self-consistent, so they verified against the same fallback but not clients computing the
+algorithm the caller requested.
 
 Later versions remove the fallback: an unrecognised name throws `AlgorithmUnsupportedError`, and a recognised
 one computes the algorithm it actually names. If secrets enrolled on 13.4.1 or earlier stop verifying after

--- a/apps/docs/guide/troubleshooting.md
+++ b/apps/docs/guide/troubleshooting.md
@@ -93,14 +93,14 @@ const result = await verify({
 
 ### "Existing enrollments stopped verifying after an upgrade"
 
-Older versions of the default crypto plugin (`@otplib/plugin-crypto-noble`) fell back to SHA-512 for any
-algorithm name they did not recognise. A caller passing `'SHA1'` or `'SHA256'` — spellings TypeScript rejects,
-but plain JavaScript does not — silently got HMAC-SHA-512 with no error. Those tokens were self-consistent, so
-they verified against otplib and nothing else.
+**Affects `@otplib/plugin-crypto-noble` 13.0.0 – 13.4.1**, the default crypto plugin. In that range it fell
+back to SHA-512 for any algorithm name it did not recognise. A caller passing `'SHA1'` or `'SHA256'` —
+spellings TypeScript rejects, but plain JavaScript does not — silently got HMAC-SHA-512 with no error. Those
+tokens were self-consistent, so they verified against otplib and nothing else.
 
-Current versions remove the fallback: an unrecognised name throws `AlgorithmUnsupportedError`, and a
-recognised one computes the algorithm it actually names. If secrets enrolled before the upgrade stop
-verifying, they were almost certainly created through that path.
+Later versions remove the fallback: an unrecognised name throws `AlgorithmUnsupportedError`, and a recognised
+one computes the algorithm it actually names. If secrets enrolled on 13.4.1 or earlier stop verifying after
+you upgrade, they were almost certainly created through that path.
 
 Two ways out:
 

--- a/apps/docs/guide/troubleshooting.md
+++ b/apps/docs/guide/troubleshooting.md
@@ -91,6 +91,29 @@ const result = await verify({
 });
 ```
 
+### "Existing enrollments stopped verifying after an upgrade"
+
+Older versions of the default crypto plugin (`@otplib/plugin-crypto-noble`) fell back to SHA-512 for any
+algorithm name they did not recognise. A caller passing `'SHA1'` or `'SHA256'` — spellings TypeScript rejects,
+but plain JavaScript does not — silently got HMAC-SHA-512 with no error. Those tokens were self-consistent, so
+they verified against otplib and nothing else.
+
+Current versions remove the fallback: an unrecognised name throws `AlgorithmUnsupportedError`, and a
+recognised one computes the algorithm it actually names. If secrets enrolled before the upgrade stop
+verifying, they were almost certainly created through that path.
+
+Two ways out:
+
+```typescript
+// 1. Keep the old tokens working - they really were SHA-512
+const result = await verify({ secret, token, algorithm: "sha512" });
+
+// 2. Or re-enroll the user against the algorithm you intended
+```
+
+Newly generated tokens are unaffected. Only stored secrets whose recorded algorithm disagrees with the digest
+they were actually enrolled with are at risk.
+
 ### "Tolerance validation failed"
 
 The tolerance parameters have maximum values to prevent DoS attacks:

--- a/deno.lock
+++ b/deno.lock
@@ -1,52 +1,52 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@codecov/bundle-analyzer@^2.0.1": "2.0.1",
-    "npm:@eslint/js@^9.39.3": "9.39.5",
+    "npm:@codecov/bundle-analyzer@^1.9.1": "1.9.1",
+    "npm:@eslint/js@^9.39.2": "9.39.2",
     "npm:@noble/hashes@^2.0.1": "2.0.1",
     "npm:@scure/base@2": "2.0.0",
-    "npm:@stryker-mutator/core@^9.6.1": "9.6.1_@types+node@25.9.5",
-    "npm:@stryker-mutator/vitest-runner@^9.6.1": "9.6.1_@stryker-mutator+core@9.6.1__@types+node@25.9.5_vitest@4.1.10__@types+node@25.9.5__@vitest+coverage-v8@4.1.10__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0__tsx@4.21.0_@types+node@25.9.5_@vitest+coverage-v8@4.1.10__vitest@4.1.10__@types+node@25.9.5__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0_tsx@4.21.0_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0",
-    "npm:@types/node@^25.6.0": "25.9.5",
-    "npm:@typescript-eslint/eslint-plugin@^8.59.2": "8.64.0_@typescript-eslint+parser@8.64.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3",
-    "npm:@typescript-eslint/parser@^8.59.2": "8.64.0_eslint@9.39.2_typescript@5.9.3",
-    "npm:@vitest/coverage-v8@^4.1.5": "4.1.10_vitest@4.1.10_@types+node@25.9.5_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0",
+    "npm:@size-limit/preset-small-lib@12": "12.0.0_size-limit@12.0.0",
+    "npm:@types/node@^25.0.10": "25.1.0",
+    "npm:@typescript-eslint/eslint-plugin@^8.54.0": "8.54.0_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3",
+    "npm:@typescript-eslint/parser@^8.54.0": "8.54.0_eslint@9.39.2_typescript@5.9.3",
+    "npm:@vitest/coverage-v8@^4.0.18": "4.0.18_vitest@4.0.18__@types+node@25.1.0__vite@7.3.1___@types+node@25.1.0___tsx@4.21.0___picomatch@4.0.3__tsx@4.21.0_@types+node@25.1.0_tsx@4.21.0",
     "npm:eslint-config-prettier@^10.1.8": "10.1.8_eslint@9.39.2",
     "npm:eslint-plugin-import@^2.32.0": "2.32.0_eslint@9.39.2",
     "npm:eslint@^9.39.2": "9.39.2",
-    "npm:fast-check@^4.7.0": "4.9.0",
-    "npm:lefthook@^2.1.6": "2.1.10",
-    "npm:prettier@^3.8.3": "3.9.5",
+    "npm:fast-check@^4.5.3": "4.5.3",
+    "npm:lefthook@^2.0.16": "2.0.16",
+    "npm:prettier@^3.8.1": "3.8.1",
+    "npm:size-limit@12": "12.0.0",
     "npm:tsup@^8.5.1": "8.5.1_typescript@5.9.3_esbuild@0.27.2_tsx@4.21.0",
     "npm:tsx@^4.21.0": "4.21.0",
-    "npm:turbo@^2.9.14": "2.10.5",
-    "npm:typedoc-plugin-markdown@^4.11.0": "4.12.0_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3",
-    "npm:typedoc-vitepress-theme@^1.1.2": "1.1.2_typedoc-plugin-markdown@4.12.0__typedoc@0.28.20___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3",
-    "npm:typedoc@~0.28.19": "0.28.20_typescript@5.9.3",
-    "npm:typescript-eslint@^8.59.2": "8.64.0_eslint@9.39.2_typescript@5.9.3",
+    "npm:turbo@^2.8.1": "2.8.1",
+    "npm:typedoc-plugin-markdown@^4.9.0": "4.9.0_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3",
+    "npm:typedoc-vitepress-theme@^1.1.2": "1.1.2_typedoc-plugin-markdown@4.9.0__typedoc@0.28.16___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3",
+    "npm:typedoc@~0.28.16": "0.28.16_typescript@5.9.3",
+    "npm:typescript-eslint@^8.54.0": "8.54.0_eslint@9.39.2_typescript@5.9.3_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3",
     "npm:typescript@^5.9.3": "5.9.3",
-    "npm:vite@^8.0.11": "8.1.5_@types+node@25.9.5_tsx@4.21.0",
+    "npm:vite@^7.3.1": "7.3.1_@types+node@25.1.0_tsx@4.21.0_picomatch@4.0.3",
     "npm:vitest-tsconfig-paths@^3.4.1": "3.4.1",
-    "npm:vitest@^4.1.5": "4.1.10_@types+node@25.9.5_@vitest+coverage-v8@4.1.10_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0_tsx@4.21.0"
+    "npm:vitest@^4.0.18": "4.0.18_@types+node@25.1.0_vite@7.3.1__@types+node@25.1.0__tsx@4.21.0__picomatch@4.0.3_tsx@4.21.0"
   },
   "npm": {
-    "@actions/core@3.0.1": {
-      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+    "@actions/core@1.11.1": {
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "dependencies": [
         "@actions/exec",
-        "@actions/http-client@4.0.1"
+        "@actions/http-client"
       ]
     },
-    "@actions/exec@3.0.0": {
-      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+    "@actions/exec@1.1.1": {
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "dependencies": [
         "@actions/io"
       ]
     },
-    "@actions/github@9.1.1": {
-      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
+    "@actions/github@6.0.1_@octokit+core@5.2.2": {
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
       "dependencies": [
-        "@actions/http-client@3.0.2",
+        "@actions/http-client",
         "@octokit/core",
         "@octokit/plugin-paginate-rest",
         "@octokit/plugin-rest-endpoint-methods",
@@ -55,265 +55,31 @@
         "undici"
       ]
     },
-    "@actions/http-client@3.0.2": {
-      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+    "@actions/http-client@2.2.3": {
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "dependencies": [
         "tunnel",
         "undici"
       ]
     },
-    "@actions/http-client@4.0.1": {
-      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
-      "dependencies": [
-        "tunnel",
-        "undici"
-      ]
+    "@actions/io@1.1.3": {
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
-    "@actions/io@3.0.2": {
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="
+    "@babel/helper-string-parser@7.27.1": {
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
     },
-    "@babel/code-frame@7.29.7": {
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dependencies": [
-        "@babel/helper-validator-identifier",
-        "js-tokens@4.0.0",
-        "picocolors"
-      ]
+    "@babel/helper-validator-identifier@7.28.5": {
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
     },
-    "@babel/compat-data@7.29.7": {
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="
-    },
-    "@babel/core@7.29.7": {
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dependencies": [
-        "@babel/code-frame",
-        "@babel/generator",
-        "@babel/helper-compilation-targets",
-        "@babel/helper-module-transforms",
-        "@babel/helpers",
-        "@babel/parser",
-        "@babel/template",
-        "@babel/traverse",
-        "@babel/types",
-        "@jridgewell/remapping",
-        "convert-source-map",
-        "debug@4.4.3",
-        "gensync",
-        "json5@2.2.3",
-        "semver@6.3.1"
-      ]
-    },
-    "@babel/generator@7.29.7": {
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "dependencies": [
-        "@babel/parser",
-        "@babel/types",
-        "@jridgewell/gen-mapping",
-        "@jridgewell/trace-mapping",
-        "jsesc"
-      ]
-    },
-    "@babel/helper-annotate-as-pure@7.29.7": {
-      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
-      "dependencies": [
-        "@babel/types"
-      ]
-    },
-    "@babel/helper-compilation-targets@7.29.7": {
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dependencies": [
-        "@babel/compat-data",
-        "@babel/helper-validator-option",
-        "browserslist",
-        "lru-cache",
-        "semver@6.3.1"
-      ]
-    },
-    "@babel/helper-create-class-features-plugin@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-annotate-as-pure",
-        "@babel/helper-member-expression-to-functions",
-        "@babel/helper-optimise-call-expression",
-        "@babel/helper-replace-supers",
-        "@babel/helper-skip-transparent-expression-wrappers",
-        "@babel/traverse",
-        "semver@6.3.1"
-      ]
-    },
-    "@babel/helper-globals@7.29.7": {
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="
-    },
-    "@babel/helper-member-expression-to-functions@7.29.7": {
-      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
-      "dependencies": [
-        "@babel/traverse",
-        "@babel/types"
-      ]
-    },
-    "@babel/helper-module-imports@7.29.7": {
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dependencies": [
-        "@babel/traverse",
-        "@babel/types"
-      ]
-    },
-    "@babel/helper-module-transforms@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-module-imports",
-        "@babel/helper-validator-identifier",
-        "@babel/traverse"
-      ]
-    },
-    "@babel/helper-optimise-call-expression@7.29.7": {
-      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
-      "dependencies": [
-        "@babel/types"
-      ]
-    },
-    "@babel/helper-plugin-utils@7.29.7": {
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="
-    },
-    "@babel/helper-replace-supers@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-member-expression-to-functions",
-        "@babel/helper-optimise-call-expression",
-        "@babel/traverse"
-      ]
-    },
-    "@babel/helper-skip-transparent-expression-wrappers@7.29.7": {
-      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
-      "dependencies": [
-        "@babel/traverse",
-        "@babel/types"
-      ]
-    },
-    "@babel/helper-string-parser@7.29.7": {
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="
-    },
-    "@babel/helper-validator-identifier@7.29.7": {
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="
-    },
-    "@babel/helper-validator-option@7.29.7": {
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="
-    },
-    "@babel/helpers@7.29.7": {
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dependencies": [
-        "@babel/template",
-        "@babel/types"
-      ]
-    },
-    "@babel/parser@7.29.7": {
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+    "@babel/parser@7.28.6": {
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
       "dependencies": [
         "@babel/types"
       ],
       "bin": true
     },
-    "@babel/plugin-proposal-decorators@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-create-class-features-plugin",
-        "@babel/helper-plugin-utils",
-        "@babel/plugin-syntax-decorators"
-      ]
-    },
-    "@babel/plugin-syntax-decorators@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-plugin-utils"
-      ]
-    },
-    "@babel/plugin-syntax-jsx@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-plugin-utils"
-      ]
-    },
-    "@babel/plugin-syntax-typescript@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-plugin-utils"
-      ]
-    },
-    "@babel/plugin-transform-destructuring@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-plugin-utils",
-        "@babel/traverse"
-      ]
-    },
-    "@babel/plugin-transform-explicit-resource-management@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-plugin-utils",
-        "@babel/plugin-transform-destructuring"
-      ]
-    },
-    "@babel/plugin-transform-modules-commonjs@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-module-transforms",
-        "@babel/helper-plugin-utils"
-      ]
-    },
-    "@babel/plugin-transform-typescript@7.29.7_@babel+core@7.29.7": {
-      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-annotate-as-pure",
-        "@babel/helper-create-class-features-plugin",
-        "@babel/helper-plugin-utils",
-        "@babel/helper-skip-transparent-expression-wrappers",
-        "@babel/plugin-syntax-typescript"
-      ]
-    },
-    "@babel/preset-typescript@7.28.5_@babel+core@7.29.7": {
-      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/helper-plugin-utils",
-        "@babel/helper-validator-option",
-        "@babel/plugin-syntax-jsx",
-        "@babel/plugin-transform-modules-commonjs",
-        "@babel/plugin-transform-typescript"
-      ]
-    },
-    "@babel/template@7.29.7": {
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dependencies": [
-        "@babel/code-frame",
-        "@babel/parser",
-        "@babel/types"
-      ]
-    },
-    "@babel/traverse@7.29.7": {
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "dependencies": [
-        "@babel/code-frame",
-        "@babel/generator",
-        "@babel/helper-globals",
-        "@babel/parser",
-        "@babel/template",
-        "@babel/types",
-        "debug@4.4.3"
-      ]
-    },
-    "@babel/types@7.29.7": {
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+    "@babel/types@7.28.6": {
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
@@ -322,8 +88,8 @@
     "@bcoe/v8-coverage@1.0.2": {
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="
     },
-    "@codecov/bundle-analyzer@2.0.1": {
-      "integrity": "sha512-SkL0+Ccs6VuHIA9Bxb8/J110CffRXpqtKt7m18FTWC0P6gDKEsoieUerDdcd6K9BFKujj6gaUdTt5i4I/v8GTA==",
+    "@codecov/bundle-analyzer@1.9.1": {
+      "integrity": "sha512-WVWZIV0v09RueL0L2x8pgaWzGsJsKMsMFjsFgzfjeApq9cE6bZ+0fQC3f/pTQ8h40Y3D5Gk9o4W6jd/if3ohSA==",
       "dependencies": [
         "@codecov/bundler-plugin-core",
         "micromatch",
@@ -332,38 +98,19 @@
       "os": ["darwin", "linux"],
       "bin": true
     },
-    "@codecov/bundler-plugin-core@2.0.1": {
-      "integrity": "sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==",
+    "@codecov/bundler-plugin-core@1.9.1": {
+      "integrity": "sha512-dt3ic7gMswz4p/qdkYPVJwXlLiLsz55rBBn2I7mr0HTG8pCoLRqnANJIwo5WrqGBZgPyVSMPBqBra6VxLWfDyA==",
       "dependencies": [
         "@actions/core",
         "@actions/github",
-        "chalk@4.1.2",
-        "semver@7.8.5",
+        "chalk",
+        "semver@7.7.3",
         "unplugin",
-        "zod@3.25.76"
+        "zod"
       ]
     },
     "@cush/relative@1.0.0": {
       "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA=="
-    },
-    "@emnapi/core@1.11.1": {
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dependencies": [
-        "@emnapi/wasi-threads",
-        "tslib@2.8.1"
-      ]
-    },
-    "@emnapi/runtime@1.11.1": {
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dependencies": [
-        "tslib@2.8.1"
-      ]
-    },
-    "@emnapi/wasi-threads@1.2.2": {
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dependencies": [
-        "tslib@2.8.1"
-      ]
     },
     "@esbuild/aix-ppc64@0.27.2": {
       "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
@@ -528,7 +275,7 @@
     "@eslint/eslintrc@3.3.3": {
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dependencies": [
-        "ajv@6.12.6",
+        "ajv",
         "debug@4.4.3",
         "espree",
         "globals",
@@ -542,9 +289,6 @@
     "@eslint/js@9.39.2": {
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="
     },
-    "@eslint/js@9.39.5": {
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="
-    },
     "@eslint/object-schema@2.1.7": {
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="
     },
@@ -555,8 +299,11 @@
         "levn"
       ]
     },
-    "@gerrit0/mini-shiki@3.23.0": {
-      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+    "@fastify/busboy@2.1.1": {
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+    },
+    "@gerrit0/mini-shiki@3.21.0": {
+      "integrity": "sha512-9PrsT5DjZA+w3lur/aOIx3FlDeHdyCEFlv9U+fmsVyjPZh61G5SYURQ/1ebe2U63KbDmI2V8IhIUegWb8hjOyg==",
       "dependencies": [
         "@shikijs/engine-oniguruma",
         "@shikijs/langs",
@@ -581,195 +328,10 @@
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
     },
-    "@inquirer/ansi@2.0.7": {
-      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="
-    },
-    "@inquirer/checkbox@5.2.1_@types+node@25.9.5": {
-      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
-      "dependencies": [
-        "@inquirer/ansi",
-        "@inquirer/core",
-        "@inquirer/figures",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/confirm@6.1.1_@types+node@25.9.5": {
-      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/core@11.2.1_@types+node@25.9.5": {
-      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
-      "dependencies": [
-        "@inquirer/ansi",
-        "@inquirer/figures",
-        "@inquirer/type",
-        "@types/node",
-        "cli-width",
-        "fast-wrap-ansi",
-        "mute-stream",
-        "signal-exit"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/editor@5.2.2_@types+node@25.9.5": {
-      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/external-editor",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/expand@5.1.1_@types+node@25.9.5": {
-      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/external-editor@3.0.3_@types+node@25.9.5": {
-      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
-      "dependencies": [
-        "@types/node",
-        "chardet",
-        "iconv-lite"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/figures@2.0.7": {
-      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw=="
-    },
-    "@inquirer/input@5.1.2_@types+node@25.9.5": {
-      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/number@4.1.1_@types+node@25.9.5": {
-      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/password@5.1.1_@types+node@25.9.5": {
-      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
-      "dependencies": [
-        "@inquirer/ansi",
-        "@inquirer/core",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/prompts@8.5.2_@types+node@25.9.5": {
-      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
-      "dependencies": [
-        "@inquirer/checkbox",
-        "@inquirer/confirm",
-        "@inquirer/editor",
-        "@inquirer/expand",
-        "@inquirer/input",
-        "@inquirer/number",
-        "@inquirer/password",
-        "@inquirer/rawlist",
-        "@inquirer/search",
-        "@inquirer/select",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/rawlist@5.3.1_@types+node@25.9.5": {
-      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/search@4.2.1_@types+node@25.9.5": {
-      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
-      "dependencies": [
-        "@inquirer/core",
-        "@inquirer/figures",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/select@5.2.1_@types+node@25.9.5": {
-      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
-      "dependencies": [
-        "@inquirer/ansi",
-        "@inquirer/core",
-        "@inquirer/figures",
-        "@inquirer/type",
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
-    "@inquirer/type@4.0.7_@types+node@25.9.5": {
-      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-      "dependencies": [
-        "@types/node"
-      ],
-      "optionalPeers": [
-        "@types/node"
-      ]
-    },
     "@jridgewell/gen-mapping@0.3.13": {
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dependencies": [
         "@jridgewell/sourcemap-codec",
-        "@jridgewell/trace-mapping"
-      ]
-    },
-    "@jridgewell/remapping@2.3.5": {
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dependencies": [
-        "@jridgewell/gen-mapping",
         "@jridgewell/trace-mapping"
       ]
     },
@@ -786,171 +348,87 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@napi-rs/wasm-runtime@1.1.6_@emnapi+core@1.11.1_@emnapi+runtime@1.11.1": {
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dependencies": [
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util"
-      ]
-    },
     "@noble/hashes@2.0.1": {
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="
     },
-    "@octokit/auth-token@6.0.0": {
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="
+    "@octokit/auth-token@4.0.0": {
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
     },
-    "@octokit/core@7.0.6": {
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+    "@octokit/core@5.2.2": {
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dependencies": [
         "@octokit/auth-token",
         "@octokit/graphql",
         "@octokit/request",
         "@octokit/request-error",
-        "@octokit/types",
+        "@octokit/types@13.10.0",
         "before-after-hook",
         "universal-user-agent"
       ]
     },
-    "@octokit/endpoint@11.0.3": {
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+    "@octokit/endpoint@9.0.6": {
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "dependencies": [
-        "@octokit/types",
+        "@octokit/types@13.10.0",
         "universal-user-agent"
       ]
     },
-    "@octokit/graphql@9.0.3": {
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+    "@octokit/graphql@7.1.1": {
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "dependencies": [
         "@octokit/request",
-        "@octokit/types",
+        "@octokit/types@13.10.0",
         "universal-user-agent"
       ]
     },
-    "@octokit/openapi-types@27.0.0": {
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
+    "@octokit/openapi-types@20.0.0": {
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
     },
-    "@octokit/plugin-paginate-rest@14.0.0_@octokit+core@7.0.6": {
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+    "@octokit/openapi-types@24.2.0": {
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "@octokit/plugin-paginate-rest@9.2.2_@octokit+core@5.2.2": {
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types"
+        "@octokit/types@12.6.0"
       ]
     },
-    "@octokit/plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6": {
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+    "@octokit/plugin-rest-endpoint-methods@10.4.1_@octokit+core@5.2.2": {
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types"
+        "@octokit/types@12.6.0"
       ]
     },
-    "@octokit/request-error@7.1.0": {
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+    "@octokit/request-error@5.1.1": {
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "dependencies": [
-        "@octokit/types"
+        "@octokit/types@13.10.0",
+        "deprecation",
+        "once"
       ]
     },
-    "@octokit/request@10.0.11": {
-      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+    "@octokit/request@8.4.1": {
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "dependencies": [
         "@octokit/endpoint",
         "@octokit/request-error",
-        "@octokit/types",
-        "content-type",
-        "json-with-bigint",
+        "@octokit/types@13.10.0",
         "universal-user-agent"
       ]
     },
-    "@octokit/types@16.0.0": {
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+    "@octokit/types@12.6.0": {
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "dependencies": [
-        "@octokit/openapi-types"
+        "@octokit/openapi-types@20.0.0"
       ]
     },
-    "@oxc-project/types@0.139.0": {
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="
-    },
-    "@rolldown/binding-android-arm64@1.1.5": {
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-darwin-arm64@1.1.5": {
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-darwin-x64@1.1.5": {
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-freebsd-x64@1.1.5": {
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-linux-arm-gnueabihf@1.1.5": {
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@rolldown/binding-linux-arm64-gnu@1.1.5": {
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-linux-arm64-musl@1.1.5": {
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-linux-ppc64-gnu@1.1.5": {
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
-      "os": ["linux"],
-      "cpu": ["ppc64"]
-    },
-    "@rolldown/binding-linux-s390x-gnu@1.1.5": {
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
-      "os": ["linux"],
-      "cpu": ["s390x"]
-    },
-    "@rolldown/binding-linux-x64-gnu@1.1.5": {
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-linux-x64-musl@1.1.5": {
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/binding-openharmony-arm64@1.1.5": {
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
-      "os": ["openharmony"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-wasm32-wasi@1.1.5": {
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+    "@octokit/types@13.10.0": {
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "dependencies": [
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@napi-rs/wasm-runtime"
-      ],
-      "cpu": ["wasm32"]
-    },
-    "@rolldown/binding-win32-arm64-msvc@1.1.5": {
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@rolldown/binding-win32-x64-msvc@1.1.5": {
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@rolldown/pluginutils@1.0.1": {
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="
+        "@octokit/openapi-types@24.2.0"
+      ]
     },
     "@rollup/rollup-android-arm-eabi@4.55.1": {
       "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
@@ -1083,30 +561,27 @@
     "@scure/base@2.0.0": {
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="
     },
-    "@sec-ant/readable-stream@0.4.1": {
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
-    },
-    "@shikijs/engine-oniguruma@3.23.0": {
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+    "@shikijs/engine-oniguruma@3.21.0": {
+      "integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
       "dependencies": [
         "@shikijs/types",
         "@shikijs/vscode-textmate"
       ]
     },
-    "@shikijs/langs@3.23.0": {
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+    "@shikijs/langs@3.21.0": {
+      "integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
       "dependencies": [
         "@shikijs/types"
       ]
     },
-    "@shikijs/themes@3.23.0": {
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+    "@shikijs/themes@3.21.0": {
+      "integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
       "dependencies": [
         "@shikijs/types"
       ]
     },
-    "@shikijs/types@3.23.0": {
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+    "@shikijs/types@3.21.0": {
+      "integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
       "dependencies": [
         "@shikijs/vscode-textmate",
         "@types/hast"
@@ -1115,119 +590,30 @@
     "@shikijs/vscode-textmate@10.0.2": {
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
-    "@sindresorhus/merge-streams@4.0.0": {
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
+    "@size-limit/esbuild@12.0.0_size-limit@12.0.0": {
+      "integrity": "sha512-r9i+HrtunIu7wAPtqD3t4DqfYin3kxPoMAv8cidkzlCS69IYCe3EG2UbQa10AdvQyaHTEK+MPkr9ifUd3W29og==",
+      "dependencies": [
+        "esbuild",
+        "nanoid@5.1.6",
+        "size-limit"
+      ]
+    },
+    "@size-limit/file@12.0.0_size-limit@12.0.0": {
+      "integrity": "sha512-OzKYpDzWJ2jo6cAIzVsaPuvzZTmMLDoVCViEvsctmImxpXzwJZcuBEpPohFKKdgVdZuNTU8WstmvywPq55Njdw==",
+      "dependencies": [
+        "size-limit"
+      ]
+    },
+    "@size-limit/preset-small-lib@12.0.0_size-limit@12.0.0": {
+      "integrity": "sha512-HHHVQjZmj+8vg7qsHs1dd3Hmn8ygUsE5O2CfxnbCbHOGyUw7VodZGERh/+5ogVrF2DYza/DIo2PnCJZZETdTRA==",
+      "dependencies": [
+        "@size-limit/esbuild",
+        "@size-limit/file",
+        "size-limit"
+      ]
     },
     "@standard-schema/spec@1.1.0": {
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
-    },
-    "@stryker-mutator/api@9.6.1": {
-      "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
-      "dependencies": [
-        "mutation-testing-metrics",
-        "mutation-testing-report-schema",
-        "tslib@2.8.1",
-        "typed-inject"
-      ]
-    },
-    "@stryker-mutator/core@9.6.1_@types+node@25.9.5": {
-      "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
-      "dependencies": [
-        "@inquirer/prompts",
-        "@stryker-mutator/api",
-        "@stryker-mutator/instrumenter",
-        "@stryker-mutator/util",
-        "ajv@8.18.0",
-        "chalk@5.6.2",
-        "commander@14.0.3",
-        "diff-match-patch",
-        "emoji-regex@10.6.0",
-        "execa",
-        "json-rpc-2.0",
-        "lodash.groupby",
-        "minimatch@10.2.5",
-        "mutation-server-protocol",
-        "mutation-testing-elements",
-        "mutation-testing-metrics",
-        "mutation-testing-report-schema",
-        "npm-run-path",
-        "progress",
-        "rxjs",
-        "semver@7.8.5",
-        "source-map",
-        "tree-kill",
-        "tslib@2.8.1",
-        "typed-inject",
-        "typed-rest-client"
-      ],
-      "bin": true
-    },
-    "@stryker-mutator/instrumenter@9.6.1": {
-      "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/generator",
-        "@babel/parser",
-        "@babel/plugin-proposal-decorators",
-        "@babel/plugin-transform-explicit-resource-management",
-        "@babel/preset-typescript",
-        "@stryker-mutator/api",
-        "@stryker-mutator/util",
-        "angular-html-parser",
-        "semver@7.7.4",
-        "tslib@2.8.1",
-        "weapon-regex"
-      ]
-    },
-    "@stryker-mutator/util@9.6.1": {
-      "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ=="
-    },
-    "@stryker-mutator/vitest-runner@9.6.1_@stryker-mutator+core@9.6.1__@types+node@25.9.5_vitest@4.1.10__@types+node@25.9.5__@vitest+coverage-v8@4.1.10__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0__tsx@4.21.0_@types+node@25.9.5_@vitest+coverage-v8@4.1.10__vitest@4.1.10__@types+node@25.9.5__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0_tsx@4.21.0_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0": {
-      "integrity": "sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==",
-      "dependencies": [
-        "@stryker-mutator/api",
-        "@stryker-mutator/core",
-        "@stryker-mutator/util",
-        "semver@7.8.5",
-        "tslib@2.8.1",
-        "vitest"
-      ]
-    },
-    "@turbo/darwin-64@2.10.5": {
-      "integrity": "sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@turbo/darwin-arm64@2.10.5": {
-      "integrity": "sha512-rqROo9zsF/P9RqsdtbLD1nFJicjSrYyvQ9kNJC38AbxA3pAs6VAlATvtvOFx7bqOv6vicf20SP9kF33avJjy2w==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@turbo/linux-64@2.10.5": {
-      "integrity": "sha512-RoSSiNFUxi27zLJuM9F6GyWWjHgLch9t6nwD6K0FkXRirZkTLlzIj6IhFnK8H9++nefLtdFqylE4vGjZAv6AAA==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@turbo/linux-arm64@2.10.5": {
-      "integrity": "sha512-4ZComcpzmHGmVynQqvvi+iZOSq/tBvY1SltXB8g4NZRsrA01W8E+yRL8RNM+PLoyWsrCnJa8xa+DkWkv+xg4iQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@turbo/windows-64@2.10.5": {
-      "integrity": "sha512-eL2Iyj4DbMINq1Sr1w0iAi6nAiZOF16KSlRGwCJpVh+IWZeY33MAsLHVOBMj1xoFtncVJXclCVpTPL2nBoYkFg==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@turbo/windows-arm64@2.10.5": {
-      "integrity": "sha512-sog+wP+8YSJrdWZ/rUJg8xghVTrwoG+BrSlDQpnK5fzSgJHn1INRWXbVWRH0d3vX8dBI01E3yxXRre9Dn+OXQA==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@tybys/wasm-util@0.10.3": {
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dependencies": [
-        "tslib@2.8.1"
-      ]
     },
     "@types/chai@5.2.3": {
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
@@ -1254,8 +640,8 @@
     "@types/json5@0.0.29": {
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
-    "@types/node@25.9.5": {
-      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+    "@types/node@25.1.0": {
+      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dependencies": [
         "undici-types"
       ]
@@ -1263,8 +649,8 @@
     "@types/unist@3.0.3": {
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
-    "@typescript-eslint/eslint-plugin@8.64.0_@typescript-eslint+parser@8.64.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+    "@typescript-eslint/eslint-plugin@8.54.0_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dependencies": [
         "@eslint-community/regexpp",
         "@typescript-eslint/parser",
@@ -1273,14 +659,14 @@
         "@typescript-eslint/utils",
         "@typescript-eslint/visitor-keys",
         "eslint",
-        "ignore@7.0.6",
+        "ignore@7.0.5",
         "natural-compare",
         "ts-api-utils",
         "typescript"
       ]
     },
-    "@typescript-eslint/parser@8.64.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+    "@typescript-eslint/parser@8.54.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/types",
@@ -1291,8 +677,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/project-service@8.64.0_typescript@5.9.3": {
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+    "@typescript-eslint/project-service@8.54.0_typescript@5.9.3": {
+      "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
       "dependencies": [
         "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
@@ -1300,21 +686,21 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/scope-manager@8.64.0": {
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+    "@typescript-eslint/scope-manager@8.54.0": {
+      "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/visitor-keys"
       ]
     },
-    "@typescript-eslint/tsconfig-utils@8.64.0_typescript@5.9.3": {
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+    "@typescript-eslint/tsconfig-utils@8.54.0_typescript@5.9.3": {
+      "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@typescript-eslint/type-utils@8.64.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+    "@typescript-eslint/type-utils@8.54.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
@@ -1325,26 +711,26 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/types@8.64.0": {
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA=="
+    "@typescript-eslint/types@8.54.0": {
+      "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="
     },
-    "@typescript-eslint/typescript-estree@8.64.0_typescript@5.9.3": {
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+    "@typescript-eslint/typescript-estree@8.54.0_typescript@5.9.3": {
+      "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
       "dependencies": [
         "@typescript-eslint/project-service",
         "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
         "@typescript-eslint/visitor-keys",
         "debug@4.4.3",
-        "minimatch@10.2.5",
-        "semver@7.8.5",
+        "minimatch@9.0.5",
+        "semver@7.7.3",
         "tinyglobby",
         "ts-api-utils",
         "typescript"
       ]
     },
-    "@typescript-eslint/utils@8.64.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+    "@typescript-eslint/utils@8.54.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
       "dependencies": [
         "@eslint-community/eslint-utils",
         "@typescript-eslint/scope-manager",
@@ -1354,15 +740,15 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/visitor-keys@8.64.0": {
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+    "@typescript-eslint/visitor-keys@8.54.0": {
+      "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
       "dependencies": [
         "@typescript-eslint/types",
-        "eslint-visitor-keys@5.0.1"
+        "eslint-visitor-keys@4.2.1"
       ]
     },
-    "@vitest/coverage-v8@4.1.10_vitest@4.1.10_@types+node@25.9.5_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0": {
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+    "@vitest/coverage-v8@4.0.18_vitest@4.0.18__@types+node@25.1.0__vite@7.3.1___@types+node@25.1.0___tsx@4.21.0___picomatch@4.0.3__tsx@4.21.0_@types+node@25.1.0_tsx@4.21.0": {
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
       "dependencies": [
         "@bcoe/v8-coverage",
         "@vitest/utils",
@@ -1377,8 +763,8 @@
         "vitest"
       ]
     },
-    "@vitest/expect@4.1.10": {
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+    "@vitest/expect@4.0.18": {
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
       "dependencies": [
         "@standard-schema/spec",
         "@types/chai",
@@ -1388,8 +774,8 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.1.10_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0_@types+node@25.9.5_tsx@4.21.0": {
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+    "@vitest/mocker@4.0.18_vite@7.3.1__@types+node@25.1.0__tsx@4.21.0__picomatch@4.0.3_@types+node@25.1.0_tsx@4.21.0": {
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
       "dependencies": [
         "@vitest/spy",
         "estree-walker",
@@ -1400,36 +786,34 @@
         "vite"
       ]
     },
-    "@vitest/pretty-format@4.1.10": {
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+    "@vitest/pretty-format@4.0.18": {
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dependencies": [
         "tinyrainbow"
       ]
     },
-    "@vitest/runner@4.1.10": {
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+    "@vitest/runner@4.0.18": {
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
       "dependencies": [
         "@vitest/utils",
         "pathe"
       ]
     },
-    "@vitest/snapshot@4.1.10": {
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+    "@vitest/snapshot@4.0.18": {
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
       "dependencies": [
         "@vitest/pretty-format",
-        "@vitest/utils",
         "magic-string",
         "pathe"
       ]
     },
-    "@vitest/spy@4.1.10": {
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="
+    "@vitest/spy@4.0.18": {
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="
     },
-    "@vitest/utils@4.1.10": {
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+    "@vitest/utils@4.0.18": {
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dependencies": [
         "@vitest/pretty-format",
-        "convert-source-map",
         "tinyrainbow"
       ]
     },
@@ -1448,21 +832,9 @@
       "dependencies": [
         "fast-deep-equal",
         "fast-json-stable-stringify",
-        "json-schema-traverse@0.4.1",
+        "json-schema-traverse",
         "uri-js"
       ]
-    },
-    "ajv@8.18.0": {
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dependencies": [
-        "fast-deep-equal",
-        "fast-uri",
-        "json-schema-traverse@1.0.0",
-        "require-from-string"
-      ]
-    },
-    "angular-html-parser@10.4.0": {
-      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww=="
     },
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
@@ -1544,12 +916,12 @@
     "assertion-error@2.0.1": {
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
     },
-    "ast-v8-to-istanbul@1.0.5": {
-      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+    "ast-v8-to-istanbul@0.3.11": {
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
       "dependencies": [
         "@jridgewell/trace-mapping",
         "estree-walker",
-        "js-tokens@10.0.0"
+        "js-tokens"
       ]
     },
     "async-function@1.0.0": {
@@ -1564,27 +936,20 @@
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "balanced-match@4.0.4": {
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-    },
-    "baseline-browser-mapping@2.10.43": {
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
-      "bin": true
-    },
-    "before-after-hook@4.0.0": {
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="
+    "before-after-hook@2.2.3": {
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
     "brace-expansion@1.1.12": {
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": [
-        "balanced-match@1.0.2",
+        "balanced-match",
         "concat-map"
       ]
     },
-    "brace-expansion@5.0.7": {
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+    "brace-expansion@2.0.2": {
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": [
-        "balanced-match@4.0.4"
+        "balanced-match"
       ]
     },
     "braces@3.0.3": {
@@ -1593,23 +958,15 @@
         "fill-range"
       ]
     },
-    "browserslist@4.28.6": {
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
-      "dependencies": [
-        "baseline-browser-mapping",
-        "caniuse-lite",
-        "electron-to-chromium",
-        "node-releases",
-        "update-browserslist-db"
-      ],
-      "bin": true
-    },
     "bundle-require@5.1.0_esbuild@0.27.2": {
       "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
       "dependencies": [
         "esbuild",
         "load-tsconfig"
       ]
+    },
+    "bytes-iec@3.1.1": {
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA=="
     },
     "cac@6.7.14": {
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
@@ -1640,9 +997,6 @@
     "callsites@3.1.0": {
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
-    "caniuse-lite@1.0.30001806": {
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="
-    },
     "chai@6.2.2": {
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="
     },
@@ -1653,20 +1007,11 @@
         "supports-color"
       ]
     },
-    "chalk@5.6.2": {
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
-    },
-    "chardet@2.2.0": {
-      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="
-    },
     "chokidar@4.0.3": {
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": [
         "readdirp"
       ]
-    },
-    "cli-width@4.1.0": {
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
     },
     "cliui@8.0.1": {
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
@@ -1685,9 +1030,6 @@
     "color-name@1.1.4": {
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "commander@14.0.3": {
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
-    },
     "commander@4.1.1": {
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
     },
@@ -1700,16 +1042,10 @@
     "consola@3.4.2": {
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
     },
-    "content-type@2.0.0": {
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
-    },
-    "convert-source-map@2.0.0": {
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
-    },
     "cross-spawn@7.0.6": {
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": [
-        "path-key@3.1.1",
+        "path-key",
         "shebang-command",
         "which"
       ]
@@ -1769,18 +1105,8 @@
         "object-keys"
       ]
     },
-    "des.js@1.1.0": {
-      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-      "dependencies": [
-        "inherits",
-        "minimalistic-assert"
-      ]
-    },
-    "detect-libc@2.1.2": {
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
-    },
-    "diff-match-patch@1.0.5": {
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    "deprecation@2.3.1": {
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "doctrine@2.1.0": {
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
@@ -1795,12 +1121,6 @@
         "es-errors",
         "gopd"
       ]
-    },
-    "electron-to-chromium@1.5.393": {
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg=="
-    },
-    "emoji-regex@10.6.0": {
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
@@ -1873,8 +1193,8 @@
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
-    "es-module-lexer@2.3.1": {
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="
+    "es-module-lexer@1.7.0": {
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
     },
     "es-object-atoms@1.1.1": {
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
@@ -2003,9 +1323,6 @@
     "eslint-visitor-keys@4.2.1": {
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="
     },
-    "eslint-visitor-keys@5.0.1": {
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="
-    },
     "eslint@9.39.2": {
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dependencies": [
@@ -2015,14 +1332,14 @@
         "@eslint/config-helpers",
         "@eslint/core",
         "@eslint/eslintrc",
-        "@eslint/js@9.39.2",
+        "@eslint/js",
         "@eslint/plugin-kit",
         "@humanfs/node",
         "@humanwhocodes/module-importer",
         "@humanwhocodes/retry",
         "@types/estree",
-        "ajv@6.12.6",
-        "chalk@4.1.2",
+        "ajv",
+        "chalk",
         "cross-spawn",
         "debug@4.4.3",
         "escape-string-regexp",
@@ -2078,28 +1395,11 @@
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
-    "execa@9.6.1": {
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dependencies": [
-        "@sindresorhus/merge-streams",
-        "cross-spawn",
-        "figures",
-        "get-stream",
-        "human-signals",
-        "is-plain-obj",
-        "is-stream",
-        "npm-run-path",
-        "pretty-ms",
-        "signal-exit",
-        "strip-final-newline",
-        "yoctocolors"
-      ]
+    "expect-type@1.3.0": {
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="
     },
-    "expect-type@1.4.0": {
-      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="
-    },
-    "fast-check@4.9.0": {
-      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+    "fast-check@4.5.3": {
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
       "dependencies": [
         "pure-rand"
       ]
@@ -2113,37 +1413,13 @@
     "fast-levenshtein@2.0.6": {
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "fast-string-truncated-width@3.0.3": {
-      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="
-    },
-    "fast-string-width@3.0.2": {
-      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-      "dependencies": [
-        "fast-string-truncated-width"
-      ]
-    },
-    "fast-uri@3.1.3": {
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="
-    },
-    "fast-wrap-ansi@0.2.2": {
-      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
-      "dependencies": [
-        "fast-string-width"
-      ]
-    },
-    "fdir@6.5.0_picomatch@4.0.5": {
+    "fdir@6.5.0_picomatch@4.0.3": {
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dependencies": [
-        "picomatch@4.0.5"
+        "picomatch@4.0.3"
       ],
       "optionalPeers": [
-        "picomatch@4.0.5"
-      ]
-    },
-    "figures@6.1.0": {
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dependencies": [
-        "is-unicode-supported"
+        "picomatch@4.0.3"
       ]
     },
     "file-entry-cache@8.0.0": {
@@ -2214,9 +1490,6 @@
     "generator-function@2.0.1": {
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
     },
-    "gensync@1.0.0-beta.2": {
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
-    },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
@@ -2240,13 +1513,6 @@
       "dependencies": [
         "dunder-proto",
         "es-object-atoms"
-      ]
-    },
-    "get-stream@9.0.1": {
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dependencies": [
-        "@sec-ant/readable-stream",
-        "is-stream"
       ]
     },
     "get-symbol-description@1.1.0": {
@@ -2324,20 +1590,11 @@
     "html-escaper@2.0.2": {
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
-    "human-signals@8.0.1": {
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="
-    },
-    "iconv-lite@0.7.3": {
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "dependencies": [
-        "safer-buffer"
-      ]
-    },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
-    "ignore@7.0.6": {
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="
+    "ignore@7.0.5": {
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
     },
     "import-fresh@3.3.1": {
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
@@ -2348,9 +1605,6 @@
     },
     "imurmurhash@0.1.4": {
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
-    },
-    "inherits@2.0.4": {
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot@1.1.0": {
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
@@ -2459,9 +1713,6 @@
     "is-number@7.0.0": {
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "is-plain-obj@4.1.0": {
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
-    },
     "is-regex@1.2.1": {
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dependencies": [
@@ -2479,9 +1730,6 @@
       "dependencies": [
         "call-bound"
       ]
-    },
-    "is-stream@4.0.1": {
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
     },
     "is-string@1.1.1": {
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
@@ -2503,9 +1751,6 @@
       "dependencies": [
         "which-typed-array"
       ]
-    },
-    "is-unicode-supported@2.1.0": {
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
     },
     "is-weakmap@2.0.2": {
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
@@ -2550,14 +1795,8 @@
     "joycon@3.1.1": {
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
     },
-    "js-md4@0.3.2": {
-      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
-    },
     "js-tokens@10.0.0": {
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
-    },
-    "js-tokens@4.0.0": {
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml@4.1.1": {
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
@@ -2566,27 +1805,14 @@
       ],
       "bin": true
     },
-    "jsesc@3.1.0": {
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "bin": true
-    },
     "json-buffer@3.0.1": {
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
-    },
-    "json-rpc-2.0@1.7.1": {
-      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg=="
     },
     "json-schema-traverse@0.4.1": {
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-schema-traverse@1.0.0": {
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
     "json-stable-stringify-without-jsonify@1.0.1": {
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
-    },
-    "json-with-bigint@3.5.10": {
-      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w=="
     },
     "json5@1.0.2": {
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
@@ -2595,68 +1821,64 @@
       ],
       "bin": true
     },
-    "json5@2.2.3": {
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "bin": true
-    },
     "keyv@4.5.4": {
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": [
         "json-buffer"
       ]
     },
-    "lefthook-darwin-arm64@2.1.10": {
-      "integrity": "sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==",
+    "lefthook-darwin-arm64@2.0.16": {
+      "integrity": "sha512-kjVHkD7rfPa7M0aKJSx/yatdV9uC6o3cJyzM9zk7cg5HD7alSwchFalgF/P0w6nt7C02rAUx8C05qiWCDWaKeA==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "lefthook-darwin-x64@2.1.10": {
-      "integrity": "sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ==",
+    "lefthook-darwin-x64@2.0.16": {
+      "integrity": "sha512-tbJ0mdT49DNRLqknro0BvWrYNC23TTcqBJFQnQ32pq1/H9B87bTNKvKKAtogp/saxfHUzkIq1i3twZlBZ3G3Xw==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "lefthook-freebsd-arm64@2.1.10": {
-      "integrity": "sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w==",
+    "lefthook-freebsd-arm64@2.0.16": {
+      "integrity": "sha512-wa1KFD5tSUhw3tuetVef/BCSxbbmS7auTDNdoLx3WFeuN5RS15woSN9+E8GPGOOY1g2HCsgdLrhrexEomulfjQ==",
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
-    "lefthook-freebsd-x64@2.1.10": {
-      "integrity": "sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ==",
+    "lefthook-freebsd-x64@2.0.16": {
+      "integrity": "sha512-UXowfn2e94AwNk9UuoePRK+qiF15jZsssiyA15VK5GTtxpn6Sn+Z2QFciofxJczXXxM4abaf7qgx2OoJBt32VA==",
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
-    "lefthook-linux-arm64@2.1.10": {
-      "integrity": "sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ==",
+    "lefthook-linux-arm64@2.0.16": {
+      "integrity": "sha512-U355elz4Z0AHSVqxfcglN09TGR86ov/GtYlliDknci2mmz6EWLiD3dTYnqJiwa4dYxqmuCDc/DvAL9rgb3YJiQ==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "lefthook-linux-x64@2.1.10": {
-      "integrity": "sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ==",
+    "lefthook-linux-x64@2.0.16": {
+      "integrity": "sha512-7eAvBeWGAgjOKZ23OQbjJINLPImDIuDeX8dXOfk+aI6IFt2X6KCzRkp+ASUvGQtrPuNZQZT43EhW0/1jZU14ZQ==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "lefthook-openbsd-arm64@2.1.10": {
-      "integrity": "sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ==",
+    "lefthook-openbsd-arm64@2.0.16": {
+      "integrity": "sha512-Fcd+E17ZkWGnRSQINb5gf+rNy2So5PYn5mBljiC31dl+TgWM8Wy46mSEGveHo7lKCO3q+DkmHIa50Qm58G03AQ==",
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
-    "lefthook-openbsd-x64@2.1.10": {
-      "integrity": "sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg==",
+    "lefthook-openbsd-x64@2.0.16": {
+      "integrity": "sha512-uL5nOkz8eBtQHped0/tB5X8clZ5kfnyjQrv1fpKbGAjeFHI2J+GmRqcn6Awq2IeuBbQvkyV6jDjpATyHBp5mCA==",
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
-    "lefthook-windows-arm64@2.1.10": {
-      "integrity": "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog==",
+    "lefthook-windows-arm64@2.0.16": {
+      "integrity": "sha512-U61bNWzD6Vd2kjuJ7b4voPfTQ4mlBFOyTpCU3k/h0YjpKDQEFT1T5fDKkDothdnw/JVDSgrclIcfAY7Jyr/UIg==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "lefthook-windows-x64@2.1.10": {
-      "integrity": "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA==",
+    "lefthook-windows-x64@2.0.16": {
+      "integrity": "sha512-dCHi2+hebhPI0LQUGRNjPMsGRyXhrTN3Y/b8M4HO8KVyGamKB3Yemf67ya81tZopDkxNVy5XUBXLYWKGhnAfLQ==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "lefthook@2.1.10": {
-      "integrity": "sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w==",
+    "lefthook@2.0.16": {
+      "integrity": "sha512-ABs3M5V9c4nqxFnZO509HXuQTu8GM8hmqc9ruV0acQ81yKlxEq70MRoYP5Z1dr5le326X8vA5qj3arJA36yE3A==",
       "optionalDependencies": [
         "lefthook-darwin-arm64",
         "lefthook-darwin-x64",
@@ -2679,88 +1901,14 @@
         "type-check"
       ]
     },
-    "lightningcss-android-arm64@1.32.0": {
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-darwin-arm64@1.32.0": {
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-darwin-x64@1.32.0": {
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-freebsd-x64@1.32.0": {
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-linux-arm-gnueabihf@1.32.0": {
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "lightningcss-linux-arm64-gnu@1.32.0": {
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-linux-arm64-musl@1.32.0": {
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-linux-x64-gnu@1.32.0": {
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-linux-x64-musl@1.32.0": {
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "lightningcss-win32-arm64-msvc@1.32.0": {
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "lightningcss-win32-x64-msvc@1.32.0": {
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "lightningcss@1.32.0": {
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dependencies": [
-        "detect-libc"
-      ],
-      "optionalDependencies": [
-        "lightningcss-android-arm64",
-        "lightningcss-darwin-arm64",
-        "lightningcss-darwin-x64",
-        "lightningcss-freebsd-x64",
-        "lightningcss-linux-arm-gnueabihf",
-        "lightningcss-linux-arm64-gnu",
-        "lightningcss-linux-arm64-musl",
-        "lightningcss-linux-x64-gnu",
-        "lightningcss-linux-x64-musl",
-        "lightningcss-win32-arm64-msvc",
-        "lightningcss-win32-x64-msvc"
-      ]
-    },
     "lilconfig@3.1.3": {
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
     },
     "lines-and-columns@1.2.4": {
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
-    "linkify-it@5.0.2": {
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+    "linkify-it@5.0.0": {
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dependencies": [
         "uc.micro"
       ]
@@ -2774,17 +1922,8 @@
         "p-locate"
       ]
     },
-    "lodash.groupby@4.6.0": {
-      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
-    },
     "lodash.merge@4.6.2": {
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lru-cache@5.1.1": {
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dependencies": [
-        "yallist"
-      ]
     },
     "lunr@2.3.9": {
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
@@ -2795,8 +1934,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "magicast@0.5.3": {
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+    "magicast@0.5.1": {
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
@@ -2806,11 +1945,11 @@
     "make-dir@4.0.0": {
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dependencies": [
-        "semver@7.8.5"
+        "semver@7.7.3"
       ]
     },
-    "markdown-it@14.3.0": {
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+    "markdown-it@14.1.0": {
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dependencies": [
         "argparse",
         "entities",
@@ -2831,22 +1970,19 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": [
         "braces",
-        "picomatch@2.3.2"
-      ]
-    },
-    "minimalistic-assert@1.0.1": {
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimatch@10.2.5": {
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dependencies": [
-        "brace-expansion@5.0.7"
+        "picomatch@2.3.1"
       ]
     },
     "minimatch@3.1.2": {
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": [
         "brace-expansion@1.1.12"
+      ]
+    },
+    "minimatch@9.0.5": {
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": [
+        "brace-expansion@2.0.2"
       ]
     },
     "minimist@1.2.8": {
@@ -2864,27 +2000,6 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "mutation-server-protocol@0.4.1": {
-      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
-      "dependencies": [
-        "zod@4.4.3"
-      ]
-    },
-    "mutation-testing-elements@3.7.3": {
-      "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ=="
-    },
-    "mutation-testing-metrics@3.7.3": {
-      "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
-      "dependencies": [
-        "mutation-testing-report-schema"
-      ]
-    },
-    "mutation-testing-report-schema@3.7.3": {
-      "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA=="
-    },
-    "mute-stream@3.0.0": {
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="
-    },
     "mz@2.7.0": {
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dependencies": [
@@ -2893,22 +2008,22 @@
         "thenify-all"
       ]
     },
-    "nanoid@3.3.16": {
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+    "nanoid@3.3.11": {
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "bin": true
+    },
+    "nanoid@5.1.6": {
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "bin": true
+    },
+    "nanospinner@1.2.2": {
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dependencies": [
+        "picocolors"
+      ]
     },
     "natural-compare@1.4.0": {
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
-    },
-    "node-releases@2.0.51": {
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="
-    },
-    "npm-run-path@6.0.0": {
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dependencies": [
-        "path-key@4.0.0",
-        "unicorn-magic"
-      ]
     },
     "object-assign@4.1.1": {
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
@@ -2956,8 +2071,14 @@
         "es-object-atoms"
       ]
     },
-    "obug@2.1.4": {
-      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="
+    "obug@2.1.1": {
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
     },
     "optionator@0.9.4": {
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
@@ -2996,17 +2117,11 @@
         "callsites"
       ]
     },
-    "parse-ms@4.0.0": {
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
-    },
     "path-exists@4.0.0": {
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "path-key@4.0.0": {
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
     },
     "path-parse@1.0.7": {
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
@@ -3017,11 +2132,11 @@
     "picocolors@1.1.1": {
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
-    "picomatch@2.3.2": {
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
+    "picomatch@2.3.1": {
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
-    "picomatch@4.0.5": {
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="
+    "picomatch@4.0.3": {
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
     },
     "pirates@4.0.7": {
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="
@@ -3047,10 +2162,10 @@
         "tsx"
       ]
     },
-    "postcss@8.5.19": {
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+    "postcss@8.5.6": {
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dependencies": [
-        "nanoid",
+        "nanoid@3.3.11",
         "picocolors",
         "source-map-js"
       ]
@@ -3058,18 +2173,9 @@
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
-    "prettier@3.9.5": {
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+    "prettier@3.8.1": {
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "bin": true
-    },
-    "pretty-ms@9.3.0": {
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-      "dependencies": [
-        "parse-ms"
-      ]
-    },
-    "progress@2.0.3": {
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "punycode.js@2.3.1": {
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
@@ -3077,14 +2183,8 @@
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
-    "pure-rand@8.4.2": {
-      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="
-    },
-    "qs@6.15.1": {
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dependencies": [
-        "side-channel"
-      ]
+    "pure-rand@7.0.1": {
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="
     },
     "readdirp@4.1.2": {
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
@@ -3096,7 +2196,7 @@
         "glob-regex",
         "slash",
         "sucrase",
-        "tslib@1.14.1"
+        "tslib"
       ]
     },
     "reflect.getprototypeof@1.0.10": {
@@ -3126,9 +2226,6 @@
     "require-directory@2.1.1": {
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
-    "require-from-string@2.0.2": {
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "resolve-from@4.0.0": {
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
@@ -3144,31 +2241,6 @@
         "is-core-module",
         "path-parse",
         "supports-preserve-symlinks-flag"
-      ],
-      "bin": true
-    },
-    "rolldown@1.1.5": {
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
-      "dependencies": [
-        "@oxc-project/types",
-        "@rolldown/pluginutils"
-      ],
-      "optionalDependencies": [
-        "@rolldown/binding-android-arm64",
-        "@rolldown/binding-darwin-arm64",
-        "@rolldown/binding-darwin-x64",
-        "@rolldown/binding-freebsd-x64",
-        "@rolldown/binding-linux-arm-gnueabihf",
-        "@rolldown/binding-linux-arm64-gnu",
-        "@rolldown/binding-linux-arm64-musl",
-        "@rolldown/binding-linux-ppc64-gnu",
-        "@rolldown/binding-linux-s390x-gnu",
-        "@rolldown/binding-linux-x64-gnu",
-        "@rolldown/binding-linux-x64-musl",
-        "@rolldown/binding-openharmony-arm64",
-        "@rolldown/binding-wasm32-wasi",
-        "@rolldown/binding-win32-arm64-msvc",
-        "@rolldown/binding-win32-x64-msvc"
       ],
       "bin": true
     },
@@ -3207,12 +2279,6 @@
       ],
       "bin": true
     },
-    "rxjs@7.8.2": {
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dependencies": [
-        "tslib@2.8.1"
-      ]
-    },
     "safe-array-concat@1.1.3": {
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dependencies": [
@@ -3238,19 +2304,12 @@
         "is-regex"
       ]
     },
-    "safer-buffer@2.1.2": {
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "semver@6.3.1": {
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": true
     },
-    "semver@7.7.4": {
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "bin": true
-    },
-    "semver@7.8.5": {
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+    "semver@7.7.3": {
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "bin": true
     },
     "set-function-length@1.2.2": {
@@ -3329,8 +2388,16 @@
     "siginfo@2.0.0": {
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
     },
-    "signal-exit@4.1.0": {
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+    "size-limit@12.0.0": {
+      "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
+      "dependencies": [
+        "bytes-iec",
+        "lilconfig",
+        "nanospinner",
+        "picocolors",
+        "tinyglobby"
+      ],
+      "bin": true
     },
     "slash@3.0.0": {
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
@@ -3344,8 +2411,8 @@
     "stackback@0.0.2": {
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
     },
-    "std-env@4.2.0": {
-      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="
+    "std-env@3.10.0": {
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="
     },
     "stop-iteration-iterator@1.1.0": {
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
@@ -3357,7 +2424,7 @@
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": [
-        "emoji-regex@8.0.0",
+        "emoji-regex",
         "is-fullwidth-code-point",
         "strip-ansi"
       ]
@@ -3400,9 +2467,6 @@
     "strip-bom@3.0.0": {
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
-    "strip-final-newline@4.0.0": {
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
-    },
     "strip-json-comments@3.1.1": {
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
@@ -3410,7 +2474,7 @@
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "dependencies": [
         "@jridgewell/gen-mapping",
-        "commander@4.1.1",
+        "commander",
         "lines-and-columns",
         "mz",
         "pirates",
@@ -3446,18 +2510,18 @@
     "tinyexec@0.3.2": {
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
-    "tinyexec@1.2.4": {
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="
+    "tinyexec@1.0.2": {
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="
     },
-    "tinyglobby@0.2.17": {
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+    "tinyglobby@0.2.15_picomatch@4.0.3": {
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dependencies": [
         "fdir",
-        "picomatch@4.0.5"
+        "picomatch@4.0.3"
       ]
     },
-    "tinyrainbow@3.1.0": {
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="
+    "tinyrainbow@3.0.3": {
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -3469,8 +2533,8 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "bin": true
     },
-    "ts-api-utils@2.5.0_typescript@5.9.3": {
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+    "ts-api-utils@2.4.0_typescript@5.9.3": {
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dependencies": [
         "typescript"
       ]
@@ -3482,16 +2546,13 @@
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dependencies": [
         "@types/json5",
-        "json5@1.0.2",
+        "json5",
         "minimist",
         "strip-bom"
       ]
     },
     "tslib@1.14.1": {
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "tslib@2.8.1": {
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsup@8.5.1_typescript@5.9.3_esbuild@0.27.2_tsx@4.21.0": {
       "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
@@ -3534,15 +2595,45 @@
     "tunnel@0.0.6": {
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
-    "turbo@2.10.5": {
-      "integrity": "sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ==",
+    "turbo-darwin-64@2.8.1": {
+      "integrity": "sha512-FQ6Uqxty/H1Nvn1dpBe8KUlMRclTuiyNSc1PCeDL/ad7M9ykpWutB51YpMpf9ibTA32M6wLdIRf+D96W6hDAtQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "turbo-darwin-arm64@2.8.1": {
+      "integrity": "sha512-4bCcEpGP2/aSXmeN2gl5SuAmS1q5ykjubnFvSoXjQoCKtDOV+vc4CTl/DduZzUUutCVUWXjl8OyfIQ+DGCaV4A==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "turbo-linux-64@2.8.1": {
+      "integrity": "sha512-m99JRlWlEgXPR7mkThAbKh6jbTmWSOXM/c6rt8yd4Uxh0+wjq7+DYcQbead6aoOqmCP9akswZ8EXIv1ogKBblg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "turbo-linux-arm64@2.8.1": {
+      "integrity": "sha512-AsPlza3AsavJdl2o7FE67qyv0aLfmT1XwFQGzvwpoAO6Bj7S4a03tpUchZKNuGjNAkKVProQRFnB7PgUAScFXA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "turbo-windows-64@2.8.1": {
+      "integrity": "sha512-GdqNO6bYShRsr79B+2G/2ssjLEp9uBTvLBJSWRtRCiac/SEmv8T6RYv9hu+h5oGbFALtnKNp6BQBw78RJURsPw==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "turbo-windows-arm64@2.8.1": {
+      "integrity": "sha512-n40E6IpkzrShRo3yMdRpgnn1/sAbGC6tZXwyNu8fe9RsufeD7KBiaoRSvw8xLyqV3pd2yoTL2rdCXq24MnTCWA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "turbo@2.8.1": {
+      "integrity": "sha512-pbSMlRflA0RAuk/0jnAt8pzOYh1+sKaT8nVtcs75OFGVWD0evleQRmKtHJJV42QOhaC3Hx9mUUSOom/irasbjA==",
       "optionalDependencies": [
-        "@turbo/darwin-64",
-        "@turbo/darwin-arm64",
-        "@turbo/linux-64",
-        "@turbo/linux-arm64",
-        "@turbo/windows-64",
-        "@turbo/windows-arm64"
+        "turbo-darwin-64",
+        "turbo-darwin-arm64",
+        "turbo-linux-64",
+        "turbo-linux-arm64",
+        "turbo-windows-64",
+        "turbo-windows-arm64"
       ],
       "bin": true
     },
@@ -3593,45 +2684,32 @@
         "reflect.getprototypeof"
       ]
     },
-    "typed-inject@5.0.0": {
-      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA=="
-    },
-    "typed-rest-client@2.3.1": {
-      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
-      "dependencies": [
-        "des.js",
-        "js-md4",
-        "qs",
-        "tunnel",
-        "underscore"
-      ]
-    },
-    "typedoc-plugin-markdown@4.12.0_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3": {
-      "integrity": "sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==",
+    "typedoc-plugin-markdown@4.9.0_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3": {
+      "integrity": "sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==",
       "dependencies": [
         "typedoc"
       ]
     },
-    "typedoc-vitepress-theme@1.1.2_typedoc-plugin-markdown@4.12.0__typedoc@0.28.20___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3": {
+    "typedoc-vitepress-theme@1.1.2_typedoc-plugin-markdown@4.9.0__typedoc@0.28.16___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-hQvCZRr5uKDqY1bRuY1+eNTNn6d4TE4OP5pnw65Y7WGgajkJW9X1/lVJK2UJpcwCmwkdjw1QIO49H9JQlxWhhw==",
       "dependencies": [
         "typedoc-plugin-markdown"
       ]
     },
-    "typedoc@0.28.20_typescript@5.9.3": {
-      "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
+    "typedoc@0.28.16_typescript@5.9.3": {
+      "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dependencies": [
         "@gerrit0/mini-shiki",
         "lunr",
         "markdown-it",
-        "minimatch@10.2.5",
+        "minimatch@9.0.5",
         "typescript",
         "yaml"
       ],
       "bin": true
     },
-    "typescript-eslint@8.64.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+    "typescript-eslint@8.54.0_eslint@9.39.2_typescript@5.9.3_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3": {
+      "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
       "dependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
@@ -3660,20 +2738,17 @@
         "which-boxed-primitive"
       ]
     },
-    "underscore@1.13.8": {
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
+    "undici-types@7.16.0": {
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
-    "undici-types@7.24.6": {
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+    "undici@5.29.0": {
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dependencies": [
+        "@fastify/busboy"
+      ]
     },
-    "undici@6.27.0": {
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="
-    },
-    "unicorn-magic@0.3.0": {
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
-    },
-    "universal-user-agent@7.0.3": {
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
+    "universal-user-agent@6.0.1": {
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
     },
     "unplugin@1.16.1": {
       "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
@@ -3682,29 +2757,21 @@
         "webpack-virtual-modules"
       ]
     },
-    "update-browserslist-db@1.2.3_browserslist@4.28.6": {
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dependencies": [
-        "browserslist",
-        "escalade",
-        "picocolors"
-      ],
-      "bin": true
-    },
     "uri-js@4.4.1": {
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": [
         "punycode"
       ]
     },
-    "vite@8.1.5_@types+node@25.9.5_tsx@4.21.0": {
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+    "vite@7.3.1_@types+node@25.1.0_tsx@4.21.0_picomatch@4.0.3": {
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dependencies": [
         "@types/node",
-        "lightningcss",
-        "picomatch@4.0.5",
+        "esbuild",
+        "fdir",
+        "picomatch@4.0.3",
         "postcss",
-        "rolldown",
+        "rollup",
         "tinyglobby",
         "tsx"
       ],
@@ -3726,11 +2793,10 @@
         "tsconfig-paths"
       ]
     },
-    "vitest@4.1.10_@types+node@25.9.5_@vitest+coverage-v8@4.1.10_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0_tsx@4.21.0": {
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+    "vitest@4.0.18_@types+node@25.1.0_vite@7.3.1__@types+node@25.1.0__tsx@4.21.0__picomatch@4.0.3_tsx@4.21.0": {
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dependencies": [
         "@types/node",
-        "@vitest/coverage-v8",
         "@vitest/expect",
         "@vitest/mocker",
         "@vitest/pretty-format",
@@ -3743,23 +2809,19 @@
         "magic-string",
         "obug",
         "pathe",
-        "picomatch@4.0.5",
+        "picomatch@4.0.3",
         "std-env",
         "tinybench",
-        "tinyexec@1.2.4",
+        "tinyexec@1.0.2",
         "tinyglobby",
         "tinyrainbow",
         "vite",
         "why-is-node-running"
       ],
       "optionalPeers": [
-        "@types/node",
-        "@vitest/coverage-v8"
+        "@types/node"
       ],
       "bin": true
-    },
-    "weapon-regex@1.3.6": {
-      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA=="
     },
     "webpack-virtual-modules@0.6.2": {
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="
@@ -3839,21 +2901,21 @@
         "strip-ansi"
       ]
     },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "y18n@5.0.8": {
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
-    "yallist@3.1.1": {
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "yaml@2.9.0": {
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+    "yaml@2.8.2": {
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "bin": true
     },
     "yargs-parser@21.1.1": {
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
-    "yargs@17.7.3": {
-      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+    "yargs@17.7.2": {
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": [
         "cliui",
         "escalade",
@@ -3867,14 +2929,8 @@
     "yocto-queue@0.1.0": {
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
-    "yoctocolors@2.1.2": {
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="
-    },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
-    },
-    "zod@4.4.3": {
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     }
   },
   "remote": {
@@ -3907,28 +2963,10 @@
     "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
     "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
     "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
-    "https://deno.land/std@0.224.0/expect/_assert_equals.ts": "08a5ba74c1c7ca51c4c2c33158509746c560777ad3cb8996a55d85a8d57c351c",
-    "https://deno.land/std@0.224.0/expect/_assert_not_equals.ts": "f8c56aafbc12b2d49bb5e1478f02a3ae8a6fd884eff18ccbc899a94829eb1510",
-    "https://deno.land/std@0.224.0/expect/_asymmetric_matchers.ts": "bf2385fc9a943f0600f7870c8dfcbfd0ab5d633fe3c45b84339016e0d8069ac4",
-    "https://deno.land/std@0.224.0/expect/_build_message.ts": "5381029035b3ff64839167f1be3e36ee2c5c5f062878f50b8d060407945206c6",
-    "https://deno.land/std@0.224.0/expect/_constants.ts": "751a014c4b803ad21287529d55d213d8b5eb34d203cca9509e4c9b84ced440a8",
-    "https://deno.land/std@0.224.0/expect/_custom_equality_tester.ts": "9426916863d2b740ae3ec74e2de5f2ec79d36bb1a62bdd5965a9b9543c8ee46d",
-    "https://deno.land/std@0.224.0/expect/_equal.ts": "f2d4f3a10f91cd6c21deefc8facdbc9e6f07a828e68b8e50049a33f8a4c3c6d4",
-    "https://deno.land/std@0.224.0/expect/_extend.ts": "df775060bffb0756519aa20663ecea5503167a8f13f5aef9cf18c24f16161ca3",
-    "https://deno.land/std@0.224.0/expect/_inspect_args.ts": "6cc9b3809e6f9671b35d0305d1ed7cc340b00b0455731b0b47b6c2ae707f8f27",
-    "https://deno.land/std@0.224.0/expect/_matchers.ts": "5e1056b4243fc3094381c9db0783ce0d47559fa11745c63227cf01c0352cb4ed",
-    "https://deno.land/std@0.224.0/expect/_mock_util.ts": "7e79e07eb869ff71b96601ac76807c745465bd3c5a3df622abf44c28a0c4ca8c",
-    "https://deno.land/std@0.224.0/expect/_snapshot_serializer.ts": "de8cf3b1d7005789ea35ce0052146a4a42ce8d36fe947c712db7147b83ffa778",
-    "https://deno.land/std@0.224.0/expect/_utils.ts": "fc45069227d1c5a04f642b9224f060017eb02923159a4848d79a7a3fcef53c55",
-    "https://deno.land/std@0.224.0/expect/expect.ts": "474fa2c581c861be43bf4fcf58875d7d28b879bea1d2c671b833b2147ced24ab",
-    "https://deno.land/std@0.224.0/expect/fn.ts": "2508684de0a3147698b3b162f6fc99f7f9fe424ba3136fc4016f654aaff243cd",
-    "https://deno.land/std@0.224.0/expect/mod.ts": "dc79508c6f554d70ef087fdb726d09add7a48f5e612aabc2d951e5cc69c4529a",
     "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
     "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
     "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
-    "https://deno.land/std@0.224.0/testing/_test_suite.ts": "f10a8a6338b60c403f07a76f3f46bdc9f1e1a820c0a1decddeb2949f7a8a0546",
-    "https://deno.land/std@0.224.0/testing/bdd.ts": "3e4de4ff6d8f348b5574661cef9501b442046a59079e201b849d0e74120d476b"
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   },
   "workspace": {
     "dependencies": [
@@ -3937,31 +2975,31 @@
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@codecov/bundle-analyzer@^2.0.1",
-        "npm:@eslint/js@^9.39.3",
-        "npm:@stryker-mutator/core@^9.6.1",
-        "npm:@stryker-mutator/vitest-runner@^9.6.1",
-        "npm:@types/node@^25.6.0",
-        "npm:@typescript-eslint/eslint-plugin@^8.59.2",
-        "npm:@typescript-eslint/parser@^8.59.2",
-        "npm:@vitest/coverage-v8@^4.1.5",
+        "npm:@codecov/bundle-analyzer@^1.9.1",
+        "npm:@eslint/js@^9.39.2",
+        "npm:@size-limit/preset-small-lib@12",
+        "npm:@types/node@^25.0.10",
+        "npm:@typescript-eslint/eslint-plugin@^8.54.0",
+        "npm:@typescript-eslint/parser@^8.54.0",
+        "npm:@vitest/coverage-v8@^4.0.18",
         "npm:eslint-config-prettier@^10.1.8",
         "npm:eslint-plugin-import@^2.32.0",
         "npm:eslint@^9.39.2",
-        "npm:fast-check@^4.7.0",
-        "npm:lefthook@^2.1.6",
-        "npm:prettier@^3.8.3",
+        "npm:fast-check@^4.5.3",
+        "npm:lefthook@^2.0.16",
+        "npm:prettier@^3.8.1",
+        "npm:size-limit@12",
         "npm:tsup@^8.5.1",
         "npm:tsx@^4.21.0",
-        "npm:turbo@^2.9.14",
-        "npm:typedoc-plugin-markdown@^4.11.0",
+        "npm:turbo@^2.8.1",
+        "npm:typedoc-plugin-markdown@^4.9.0",
         "npm:typedoc-vitepress-theme@^1.1.2",
-        "npm:typedoc@~0.28.19",
-        "npm:typescript-eslint@^8.59.2",
+        "npm:typedoc@~0.28.16",
+        "npm:typescript-eslint@^8.54.0",
         "npm:typescript@^5.9.3",
-        "npm:vite@^8.0.11",
+        "npm:vite@^7.3.1",
         "npm:vitest-tsconfig-paths@^3.4.1",
-        "npm:vitest@^4.1.5"
+        "npm:vitest@^4.0.18"
       ]
     }
   }

--- a/deno.lock
+++ b/deno.lock
@@ -1,52 +1,52 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@codecov/bundle-analyzer@^1.9.1": "1.9.1",
-    "npm:@eslint/js@^9.39.2": "9.39.2",
+    "npm:@codecov/bundle-analyzer@^2.0.1": "2.0.1",
+    "npm:@eslint/js@^9.39.3": "9.39.5",
     "npm:@noble/hashes@^2.0.1": "2.0.1",
     "npm:@scure/base@2": "2.0.0",
-    "npm:@size-limit/preset-small-lib@12": "12.0.0_size-limit@12.0.0",
-    "npm:@types/node@^25.0.10": "25.1.0",
-    "npm:@typescript-eslint/eslint-plugin@^8.54.0": "8.54.0_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3",
-    "npm:@typescript-eslint/parser@^8.54.0": "8.54.0_eslint@9.39.2_typescript@5.9.3",
-    "npm:@vitest/coverage-v8@^4.0.18": "4.0.18_vitest@4.0.18__@types+node@25.1.0__vite@7.3.1___@types+node@25.1.0___tsx@4.21.0___picomatch@4.0.3__tsx@4.21.0_@types+node@25.1.0_tsx@4.21.0",
+    "npm:@stryker-mutator/core@^9.6.1": "9.6.1_@types+node@25.9.5",
+    "npm:@stryker-mutator/vitest-runner@^9.6.1": "9.6.1_@stryker-mutator+core@9.6.1__@types+node@25.9.5_vitest@4.1.10__@types+node@25.9.5__@vitest+coverage-v8@4.1.10__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0__tsx@4.21.0_@types+node@25.9.5_@vitest+coverage-v8@4.1.10__vitest@4.1.10__@types+node@25.9.5__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0_tsx@4.21.0_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0",
+    "npm:@types/node@^25.6.0": "25.9.5",
+    "npm:@typescript-eslint/eslint-plugin@^8.59.2": "8.64.0_@typescript-eslint+parser@8.64.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3",
+    "npm:@typescript-eslint/parser@^8.59.2": "8.64.0_eslint@9.39.2_typescript@5.9.3",
+    "npm:@vitest/coverage-v8@^4.1.5": "4.1.10_vitest@4.1.10_@types+node@25.9.5_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0",
     "npm:eslint-config-prettier@^10.1.8": "10.1.8_eslint@9.39.2",
     "npm:eslint-plugin-import@^2.32.0": "2.32.0_eslint@9.39.2",
     "npm:eslint@^9.39.2": "9.39.2",
-    "npm:fast-check@^4.5.3": "4.5.3",
-    "npm:lefthook@^2.0.16": "2.0.16",
-    "npm:prettier@^3.8.1": "3.8.1",
-    "npm:size-limit@12": "12.0.0",
+    "npm:fast-check@^4.7.0": "4.9.0",
+    "npm:lefthook@^2.1.6": "2.1.10",
+    "npm:prettier@^3.8.3": "3.9.5",
     "npm:tsup@^8.5.1": "8.5.1_typescript@5.9.3_esbuild@0.27.2_tsx@4.21.0",
     "npm:tsx@^4.21.0": "4.21.0",
-    "npm:turbo@^2.8.1": "2.8.1",
-    "npm:typedoc-plugin-markdown@^4.9.0": "4.9.0_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3",
-    "npm:typedoc-vitepress-theme@^1.1.2": "1.1.2_typedoc-plugin-markdown@4.9.0__typedoc@0.28.16___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3",
-    "npm:typedoc@~0.28.16": "0.28.16_typescript@5.9.3",
-    "npm:typescript-eslint@^8.54.0": "8.54.0_eslint@9.39.2_typescript@5.9.3_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3",
+    "npm:turbo@^2.9.14": "2.10.5",
+    "npm:typedoc-plugin-markdown@^4.11.0": "4.12.0_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3",
+    "npm:typedoc-vitepress-theme@^1.1.2": "1.1.2_typedoc-plugin-markdown@4.12.0__typedoc@0.28.20___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3",
+    "npm:typedoc@~0.28.19": "0.28.20_typescript@5.9.3",
+    "npm:typescript-eslint@^8.59.2": "8.64.0_eslint@9.39.2_typescript@5.9.3",
     "npm:typescript@^5.9.3": "5.9.3",
-    "npm:vite@^7.3.1": "7.3.1_@types+node@25.1.0_tsx@4.21.0_picomatch@4.0.3",
+    "npm:vite@^8.0.11": "8.1.5_@types+node@25.9.5_tsx@4.21.0",
     "npm:vitest-tsconfig-paths@^3.4.1": "3.4.1",
-    "npm:vitest@^4.0.18": "4.0.18_@types+node@25.1.0_vite@7.3.1__@types+node@25.1.0__tsx@4.21.0__picomatch@4.0.3_tsx@4.21.0"
+    "npm:vitest@^4.1.5": "4.1.10_@types+node@25.9.5_@vitest+coverage-v8@4.1.10_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0_tsx@4.21.0"
   },
   "npm": {
-    "@actions/core@1.11.1": {
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+    "@actions/core@3.0.1": {
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
       "dependencies": [
         "@actions/exec",
-        "@actions/http-client"
+        "@actions/http-client@4.0.1"
       ]
     },
-    "@actions/exec@1.1.1": {
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+    "@actions/exec@3.0.0": {
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "dependencies": [
         "@actions/io"
       ]
     },
-    "@actions/github@6.0.1_@octokit+core@5.2.2": {
-      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+    "@actions/github@9.1.1": {
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
       "dependencies": [
-        "@actions/http-client",
+        "@actions/http-client@3.0.2",
         "@octokit/core",
         "@octokit/plugin-paginate-rest",
         "@octokit/plugin-rest-endpoint-methods",
@@ -55,31 +55,265 @@
         "undici"
       ]
     },
-    "@actions/http-client@2.2.3": {
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+    "@actions/http-client@3.0.2": {
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
       "dependencies": [
         "tunnel",
         "undici"
       ]
     },
-    "@actions/io@1.1.3": {
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+    "@actions/http-client@4.0.1": {
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dependencies": [
+        "tunnel",
+        "undici"
+      ]
     },
-    "@babel/helper-string-parser@7.27.1": {
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
+    "@actions/io@3.0.2": {
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="
     },
-    "@babel/helper-validator-identifier@7.28.5": {
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+    "@babel/code-frame@7.29.7": {
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dependencies": [
+        "@babel/helper-validator-identifier",
+        "js-tokens@4.0.0",
+        "picocolors"
+      ]
     },
-    "@babel/parser@7.28.6": {
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+    "@babel/compat-data@7.29.7": {
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="
+    },
+    "@babel/core@7.29.7": {
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@babel/generator",
+        "@babel/helper-compilation-targets",
+        "@babel/helper-module-transforms",
+        "@babel/helpers",
+        "@babel/parser",
+        "@babel/template",
+        "@babel/traverse",
+        "@babel/types",
+        "@jridgewell/remapping",
+        "convert-source-map",
+        "debug@4.4.3",
+        "gensync",
+        "json5@2.2.3",
+        "semver@6.3.1"
+      ]
+    },
+    "@babel/generator@7.29.7": {
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dependencies": [
+        "@babel/parser",
+        "@babel/types",
+        "@jridgewell/gen-mapping",
+        "@jridgewell/trace-mapping",
+        "jsesc"
+      ]
+    },
+    "@babel/helper-annotate-as-pure@7.29.7": {
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "dependencies": [
+        "@babel/types"
+      ]
+    },
+    "@babel/helper-compilation-targets@7.29.7": {
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dependencies": [
+        "@babel/compat-data",
+        "@babel/helper-validator-option",
+        "browserslist",
+        "lru-cache",
+        "semver@6.3.1"
+      ]
+    },
+    "@babel/helper-create-class-features-plugin@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-annotate-as-pure",
+        "@babel/helper-member-expression-to-functions",
+        "@babel/helper-optimise-call-expression",
+        "@babel/helper-replace-supers",
+        "@babel/helper-skip-transparent-expression-wrappers",
+        "@babel/traverse",
+        "semver@6.3.1"
+      ]
+    },
+    "@babel/helper-globals@7.29.7": {
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="
+    },
+    "@babel/helper-member-expression-to-functions@7.29.7": {
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "dependencies": [
+        "@babel/traverse",
+        "@babel/types"
+      ]
+    },
+    "@babel/helper-module-imports@7.29.7": {
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dependencies": [
+        "@babel/traverse",
+        "@babel/types"
+      ]
+    },
+    "@babel/helper-module-transforms@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-module-imports",
+        "@babel/helper-validator-identifier",
+        "@babel/traverse"
+      ]
+    },
+    "@babel/helper-optimise-call-expression@7.29.7": {
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dependencies": [
+        "@babel/types"
+      ]
+    },
+    "@babel/helper-plugin-utils@7.29.7": {
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="
+    },
+    "@babel/helper-replace-supers@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-member-expression-to-functions",
+        "@babel/helper-optimise-call-expression",
+        "@babel/traverse"
+      ]
+    },
+    "@babel/helper-skip-transparent-expression-wrappers@7.29.7": {
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dependencies": [
+        "@babel/traverse",
+        "@babel/types"
+      ]
+    },
+    "@babel/helper-string-parser@7.29.7": {
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="
+    },
+    "@babel/helper-validator-identifier@7.29.7": {
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="
+    },
+    "@babel/helper-validator-option@7.29.7": {
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="
+    },
+    "@babel/helpers@7.29.7": {
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dependencies": [
+        "@babel/template",
+        "@babel/types"
+      ]
+    },
+    "@babel/parser@7.29.7": {
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dependencies": [
         "@babel/types"
       ],
       "bin": true
     },
-    "@babel/types@7.28.6": {
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+    "@babel/plugin-proposal-decorators@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-create-class-features-plugin",
+        "@babel/helper-plugin-utils",
+        "@babel/plugin-syntax-decorators"
+      ]
+    },
+    "@babel/plugin-syntax-decorators@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils"
+      ]
+    },
+    "@babel/plugin-syntax-jsx@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils"
+      ]
+    },
+    "@babel/plugin-syntax-typescript@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils"
+      ]
+    },
+    "@babel/plugin-transform-destructuring@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils",
+        "@babel/traverse"
+      ]
+    },
+    "@babel/plugin-transform-explicit-resource-management@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils",
+        "@babel/plugin-transform-destructuring"
+      ]
+    },
+    "@babel/plugin-transform-modules-commonjs@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-module-transforms",
+        "@babel/helper-plugin-utils"
+      ]
+    },
+    "@babel/plugin-transform-typescript@7.29.7_@babel+core@7.29.7": {
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-annotate-as-pure",
+        "@babel/helper-create-class-features-plugin",
+        "@babel/helper-plugin-utils",
+        "@babel/helper-skip-transparent-expression-wrappers",
+        "@babel/plugin-syntax-typescript"
+      ]
+    },
+    "@babel/preset-typescript@7.28.5_@babel+core@7.29.7": {
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils",
+        "@babel/helper-validator-option",
+        "@babel/plugin-syntax-jsx",
+        "@babel/plugin-transform-modules-commonjs",
+        "@babel/plugin-transform-typescript"
+      ]
+    },
+    "@babel/template@7.29.7": {
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@babel/parser",
+        "@babel/types"
+      ]
+    },
+    "@babel/traverse@7.29.7": {
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@babel/generator",
+        "@babel/helper-globals",
+        "@babel/parser",
+        "@babel/template",
+        "@babel/types",
+        "debug@4.4.3"
+      ]
+    },
+    "@babel/types@7.29.7": {
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
@@ -88,8 +322,8 @@
     "@bcoe/v8-coverage@1.0.2": {
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="
     },
-    "@codecov/bundle-analyzer@1.9.1": {
-      "integrity": "sha512-WVWZIV0v09RueL0L2x8pgaWzGsJsKMsMFjsFgzfjeApq9cE6bZ+0fQC3f/pTQ8h40Y3D5Gk9o4W6jd/if3ohSA==",
+    "@codecov/bundle-analyzer@2.0.1": {
+      "integrity": "sha512-SkL0+Ccs6VuHIA9Bxb8/J110CffRXpqtKt7m18FTWC0P6gDKEsoieUerDdcd6K9BFKujj6gaUdTt5i4I/v8GTA==",
       "dependencies": [
         "@codecov/bundler-plugin-core",
         "micromatch",
@@ -98,19 +332,38 @@
       "os": ["darwin", "linux"],
       "bin": true
     },
-    "@codecov/bundler-plugin-core@1.9.1": {
-      "integrity": "sha512-dt3ic7gMswz4p/qdkYPVJwXlLiLsz55rBBn2I7mr0HTG8pCoLRqnANJIwo5WrqGBZgPyVSMPBqBra6VxLWfDyA==",
+    "@codecov/bundler-plugin-core@2.0.1": {
+      "integrity": "sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==",
       "dependencies": [
         "@actions/core",
         "@actions/github",
-        "chalk",
-        "semver@7.7.3",
+        "chalk@4.1.2",
+        "semver@7.8.5",
         "unplugin",
-        "zod"
+        "zod@3.25.76"
       ]
     },
     "@cush/relative@1.0.0": {
       "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA=="
+    },
+    "@emnapi/core@1.11.1": {
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dependencies": [
+        "@emnapi/wasi-threads",
+        "tslib@2.8.1"
+      ]
+    },
+    "@emnapi/runtime@1.11.1": {
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
+    },
+    "@emnapi/wasi-threads@1.2.2": {
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
     },
     "@esbuild/aix-ppc64@0.27.2": {
       "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
@@ -275,7 +528,7 @@
     "@eslint/eslintrc@3.3.3": {
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dependencies": [
-        "ajv",
+        "ajv@6.12.6",
         "debug@4.4.3",
         "espree",
         "globals",
@@ -289,6 +542,9 @@
     "@eslint/js@9.39.2": {
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="
     },
+    "@eslint/js@9.39.5": {
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A=="
+    },
     "@eslint/object-schema@2.1.7": {
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="
     },
@@ -299,11 +555,8 @@
         "levn"
       ]
     },
-    "@fastify/busboy@2.1.1": {
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
-    },
-    "@gerrit0/mini-shiki@3.21.0": {
-      "integrity": "sha512-9PrsT5DjZA+w3lur/aOIx3FlDeHdyCEFlv9U+fmsVyjPZh61G5SYURQ/1ebe2U63KbDmI2V8IhIUegWb8hjOyg==",
+    "@gerrit0/mini-shiki@3.23.0": {
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
       "dependencies": [
         "@shikijs/engine-oniguruma",
         "@shikijs/langs",
@@ -328,10 +581,195 @@
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
     },
+    "@inquirer/ansi@2.0.7": {
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="
+    },
+    "@inquirer/checkbox@5.2.1_@types+node@25.9.5": {
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dependencies": [
+        "@inquirer/ansi",
+        "@inquirer/core",
+        "@inquirer/figures",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/confirm@6.1.1_@types+node@25.9.5": {
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/core@11.2.1_@types+node@25.9.5": {
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dependencies": [
+        "@inquirer/ansi",
+        "@inquirer/figures",
+        "@inquirer/type",
+        "@types/node",
+        "cli-width",
+        "fast-wrap-ansi",
+        "mute-stream",
+        "signal-exit"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/editor@5.2.2_@types+node@25.9.5": {
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/external-editor",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/expand@5.1.1_@types+node@25.9.5": {
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/external-editor@3.0.3_@types+node@25.9.5": {
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dependencies": [
+        "@types/node",
+        "chardet",
+        "iconv-lite"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/figures@2.0.7": {
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw=="
+    },
+    "@inquirer/input@5.1.2_@types+node@25.9.5": {
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/number@4.1.1_@types+node@25.9.5": {
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/password@5.1.1_@types+node@25.9.5": {
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dependencies": [
+        "@inquirer/ansi",
+        "@inquirer/core",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/prompts@8.5.2_@types+node@25.9.5": {
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dependencies": [
+        "@inquirer/checkbox",
+        "@inquirer/confirm",
+        "@inquirer/editor",
+        "@inquirer/expand",
+        "@inquirer/input",
+        "@inquirer/number",
+        "@inquirer/password",
+        "@inquirer/rawlist",
+        "@inquirer/search",
+        "@inquirer/select",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/rawlist@5.3.1_@types+node@25.9.5": {
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/search@4.2.1_@types+node@25.9.5": {
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dependencies": [
+        "@inquirer/core",
+        "@inquirer/figures",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/select@5.2.1_@types+node@25.9.5": {
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dependencies": [
+        "@inquirer/ansi",
+        "@inquirer/core",
+        "@inquirer/figures",
+        "@inquirer/type",
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
+    "@inquirer/type@4.0.7_@types+node@25.9.5": {
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dependencies": [
+        "@types/node"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ]
+    },
     "@jridgewell/gen-mapping@0.3.13": {
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dependencies": [
         "@jridgewell/sourcemap-codec",
+        "@jridgewell/trace-mapping"
+      ]
+    },
+    "@jridgewell/remapping@2.3.5": {
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dependencies": [
+        "@jridgewell/gen-mapping",
         "@jridgewell/trace-mapping"
       ]
     },
@@ -348,87 +786,171 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
+    "@napi-rs/wasm-runtime@1.1.6_@emnapi+core@1.11.1_@emnapi+runtime@1.11.1": {
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dependencies": [
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util"
+      ]
+    },
     "@noble/hashes@2.0.1": {
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="
     },
-    "@octokit/auth-token@4.0.0": {
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+    "@octokit/auth-token@6.0.0": {
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="
     },
-    "@octokit/core@5.2.2": {
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+    "@octokit/core@7.0.6": {
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dependencies": [
         "@octokit/auth-token",
         "@octokit/graphql",
         "@octokit/request",
         "@octokit/request-error",
-        "@octokit/types@13.10.0",
+        "@octokit/types",
         "before-after-hook",
         "universal-user-agent"
       ]
     },
-    "@octokit/endpoint@9.0.6": {
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+    "@octokit/endpoint@11.0.3": {
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "dependencies": [
-        "@octokit/types@13.10.0",
+        "@octokit/types",
         "universal-user-agent"
       ]
     },
-    "@octokit/graphql@7.1.1": {
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+    "@octokit/graphql@9.0.3": {
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "dependencies": [
         "@octokit/request",
-        "@octokit/types@13.10.0",
+        "@octokit/types",
         "universal-user-agent"
       ]
     },
-    "@octokit/openapi-types@20.0.0": {
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    "@octokit/openapi-types@27.0.0": {
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
     },
-    "@octokit/openapi-types@24.2.0": {
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
-    },
-    "@octokit/plugin-paginate-rest@9.2.2_@octokit+core@5.2.2": {
-      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+    "@octokit/plugin-paginate-rest@14.0.0_@octokit+core@7.0.6": {
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types@12.6.0"
+        "@octokit/types"
       ]
     },
-    "@octokit/plugin-rest-endpoint-methods@10.4.1_@octokit+core@5.2.2": {
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+    "@octokit/plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6": {
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types@12.6.0"
+        "@octokit/types"
       ]
     },
-    "@octokit/request-error@5.1.1": {
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+    "@octokit/request-error@7.1.0": {
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
       "dependencies": [
-        "@octokit/types@13.10.0",
-        "deprecation",
-        "once"
+        "@octokit/types"
       ]
     },
-    "@octokit/request@8.4.1": {
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+    "@octokit/request@10.0.11": {
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
       "dependencies": [
         "@octokit/endpoint",
         "@octokit/request-error",
-        "@octokit/types@13.10.0",
+        "@octokit/types",
+        "content-type",
+        "json-with-bigint",
         "universal-user-agent"
       ]
     },
-    "@octokit/types@12.6.0": {
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+    "@octokit/types@16.0.0": {
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "dependencies": [
-        "@octokit/openapi-types@20.0.0"
+        "@octokit/openapi-types"
       ]
     },
-    "@octokit/types@13.10.0": {
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+    "@oxc-project/types@0.139.0": {
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="
+    },
+    "@rolldown/binding-android-arm64@1.1.5": {
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-darwin-arm64@1.1.5": {
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-darwin-x64@1.1.5": {
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-freebsd-x64@1.1.5": {
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-linux-arm-gnueabihf@1.1.5": {
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@rolldown/binding-linux-arm64-gnu@1.1.5": {
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-linux-arm64-musl@1.1.5": {
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-linux-ppc64-gnu@1.1.5": {
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@rolldown/binding-linux-s390x-gnu@1.1.5": {
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@rolldown/binding-linux-x64-gnu@1.1.5": {
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-linux-x64-musl@1.1.5": {
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-openharmony-arm64@1.1.5": {
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-wasm32-wasi@1.1.5": {
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "dependencies": [
-        "@octokit/openapi-types@24.2.0"
-      ]
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@napi-rs/wasm-runtime"
+      ],
+      "cpu": ["wasm32"]
+    },
+    "@rolldown/binding-win32-arm64-msvc@1.1.5": {
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-win32-x64-msvc@1.1.5": {
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/pluginutils@1.0.1": {
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="
     },
     "@rollup/rollup-android-arm-eabi@4.55.1": {
       "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
@@ -561,27 +1083,30 @@
     "@scure/base@2.0.0": {
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="
     },
-    "@shikijs/engine-oniguruma@3.21.0": {
-      "integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
+    "@sec-ant/readable-stream@0.4.1": {
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
+    },
+    "@shikijs/engine-oniguruma@3.23.0": {
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
       "dependencies": [
         "@shikijs/types",
         "@shikijs/vscode-textmate"
       ]
     },
-    "@shikijs/langs@3.21.0": {
-      "integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
+    "@shikijs/langs@3.23.0": {
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
       "dependencies": [
         "@shikijs/types"
       ]
     },
-    "@shikijs/themes@3.21.0": {
-      "integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
+    "@shikijs/themes@3.23.0": {
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
       "dependencies": [
         "@shikijs/types"
       ]
     },
-    "@shikijs/types@3.21.0": {
-      "integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
+    "@shikijs/types@3.23.0": {
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
       "dependencies": [
         "@shikijs/vscode-textmate",
         "@types/hast"
@@ -590,30 +1115,119 @@
     "@shikijs/vscode-textmate@10.0.2": {
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
-    "@size-limit/esbuild@12.0.0_size-limit@12.0.0": {
-      "integrity": "sha512-r9i+HrtunIu7wAPtqD3t4DqfYin3kxPoMAv8cidkzlCS69IYCe3EG2UbQa10AdvQyaHTEK+MPkr9ifUd3W29og==",
-      "dependencies": [
-        "esbuild",
-        "nanoid@5.1.6",
-        "size-limit"
-      ]
-    },
-    "@size-limit/file@12.0.0_size-limit@12.0.0": {
-      "integrity": "sha512-OzKYpDzWJ2jo6cAIzVsaPuvzZTmMLDoVCViEvsctmImxpXzwJZcuBEpPohFKKdgVdZuNTU8WstmvywPq55Njdw==",
-      "dependencies": [
-        "size-limit"
-      ]
-    },
-    "@size-limit/preset-small-lib@12.0.0_size-limit@12.0.0": {
-      "integrity": "sha512-HHHVQjZmj+8vg7qsHs1dd3Hmn8ygUsE5O2CfxnbCbHOGyUw7VodZGERh/+5ogVrF2DYza/DIo2PnCJZZETdTRA==",
-      "dependencies": [
-        "@size-limit/esbuild",
-        "@size-limit/file",
-        "size-limit"
-      ]
+    "@sindresorhus/merge-streams@4.0.0": {
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
     },
     "@standard-schema/spec@1.1.0": {
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "@stryker-mutator/api@9.6.1": {
+      "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
+      "dependencies": [
+        "mutation-testing-metrics",
+        "mutation-testing-report-schema",
+        "tslib@2.8.1",
+        "typed-inject"
+      ]
+    },
+    "@stryker-mutator/core@9.6.1_@types+node@25.9.5": {
+      "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
+      "dependencies": [
+        "@inquirer/prompts",
+        "@stryker-mutator/api",
+        "@stryker-mutator/instrumenter",
+        "@stryker-mutator/util",
+        "ajv@8.18.0",
+        "chalk@5.6.2",
+        "commander@14.0.3",
+        "diff-match-patch",
+        "emoji-regex@10.6.0",
+        "execa",
+        "json-rpc-2.0",
+        "lodash.groupby",
+        "minimatch@10.2.5",
+        "mutation-server-protocol",
+        "mutation-testing-elements",
+        "mutation-testing-metrics",
+        "mutation-testing-report-schema",
+        "npm-run-path",
+        "progress",
+        "rxjs",
+        "semver@7.8.5",
+        "source-map",
+        "tree-kill",
+        "tslib@2.8.1",
+        "typed-inject",
+        "typed-rest-client"
+      ],
+      "bin": true
+    },
+    "@stryker-mutator/instrumenter@9.6.1": {
+      "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/generator",
+        "@babel/parser",
+        "@babel/plugin-proposal-decorators",
+        "@babel/plugin-transform-explicit-resource-management",
+        "@babel/preset-typescript",
+        "@stryker-mutator/api",
+        "@stryker-mutator/util",
+        "angular-html-parser",
+        "semver@7.7.4",
+        "tslib@2.8.1",
+        "weapon-regex"
+      ]
+    },
+    "@stryker-mutator/util@9.6.1": {
+      "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ=="
+    },
+    "@stryker-mutator/vitest-runner@9.6.1_@stryker-mutator+core@9.6.1__@types+node@25.9.5_vitest@4.1.10__@types+node@25.9.5__@vitest+coverage-v8@4.1.10__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0__tsx@4.21.0_@types+node@25.9.5_@vitest+coverage-v8@4.1.10__vitest@4.1.10__@types+node@25.9.5__vite@8.1.5___@types+node@25.9.5___tsx@4.21.0_tsx@4.21.0_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0": {
+      "integrity": "sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==",
+      "dependencies": [
+        "@stryker-mutator/api",
+        "@stryker-mutator/core",
+        "@stryker-mutator/util",
+        "semver@7.8.5",
+        "tslib@2.8.1",
+        "vitest"
+      ]
+    },
+    "@turbo/darwin-64@2.10.5": {
+      "integrity": "sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@turbo/darwin-arm64@2.10.5": {
+      "integrity": "sha512-rqROo9zsF/P9RqsdtbLD1nFJicjSrYyvQ9kNJC38AbxA3pAs6VAlATvtvOFx7bqOv6vicf20SP9kF33avJjy2w==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@turbo/linux-64@2.10.5": {
+      "integrity": "sha512-RoSSiNFUxi27zLJuM9F6GyWWjHgLch9t6nwD6K0FkXRirZkTLlzIj6IhFnK8H9++nefLtdFqylE4vGjZAv6AAA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@turbo/linux-arm64@2.10.5": {
+      "integrity": "sha512-4ZComcpzmHGmVynQqvvi+iZOSq/tBvY1SltXB8g4NZRsrA01W8E+yRL8RNM+PLoyWsrCnJa8xa+DkWkv+xg4iQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@turbo/windows-64@2.10.5": {
+      "integrity": "sha512-eL2Iyj4DbMINq1Sr1w0iAi6nAiZOF16KSlRGwCJpVh+IWZeY33MAsLHVOBMj1xoFtncVJXclCVpTPL2nBoYkFg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@turbo/windows-arm64@2.10.5": {
+      "integrity": "sha512-sog+wP+8YSJrdWZ/rUJg8xghVTrwoG+BrSlDQpnK5fzSgJHn1INRWXbVWRH0d3vX8dBI01E3yxXRre9Dn+OXQA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@tybys/wasm-util@0.10.3": {
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
     },
     "@types/chai@5.2.3": {
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
@@ -640,8 +1254,8 @@
     "@types/json5@0.0.29": {
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
-    "@types/node@25.1.0": {
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+    "@types/node@25.9.5": {
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dependencies": [
         "undici-types"
       ]
@@ -649,8 +1263,8 @@
     "@types/unist@3.0.3": {
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
-    "@typescript-eslint/eslint-plugin@8.54.0_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
+    "@typescript-eslint/eslint-plugin@8.64.0_@typescript-eslint+parser@8.64.0__eslint@9.39.2__typescript@5.9.3_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
       "dependencies": [
         "@eslint-community/regexpp",
         "@typescript-eslint/parser",
@@ -659,14 +1273,14 @@
         "@typescript-eslint/utils",
         "@typescript-eslint/visitor-keys",
         "eslint",
-        "ignore@7.0.5",
+        "ignore@7.0.6",
         "natural-compare",
         "ts-api-utils",
         "typescript"
       ]
     },
-    "@typescript-eslint/parser@8.54.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
+    "@typescript-eslint/parser@8.64.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/types",
@@ -677,8 +1291,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/project-service@8.54.0_typescript@5.9.3": {
-      "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+    "@typescript-eslint/project-service@8.64.0_typescript@5.9.3": {
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
       "dependencies": [
         "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
@@ -686,21 +1300,21 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/scope-manager@8.54.0": {
-      "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
+    "@typescript-eslint/scope-manager@8.64.0": {
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/visitor-keys"
       ]
     },
-    "@typescript-eslint/tsconfig-utils@8.54.0_typescript@5.9.3": {
-      "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
+    "@typescript-eslint/tsconfig-utils@8.64.0_typescript@5.9.3": {
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@typescript-eslint/type-utils@8.54.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
+    "@typescript-eslint/type-utils@8.64.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
@@ -711,26 +1325,26 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/types@8.54.0": {
-      "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="
+    "@typescript-eslint/types@8.64.0": {
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA=="
     },
-    "@typescript-eslint/typescript-estree@8.54.0_typescript@5.9.3": {
-      "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
+    "@typescript-eslint/typescript-estree@8.64.0_typescript@5.9.3": {
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
       "dependencies": [
         "@typescript-eslint/project-service",
         "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
         "@typescript-eslint/visitor-keys",
         "debug@4.4.3",
-        "minimatch@9.0.5",
-        "semver@7.7.3",
+        "minimatch@10.2.5",
+        "semver@7.8.5",
         "tinyglobby",
         "ts-api-utils",
         "typescript"
       ]
     },
-    "@typescript-eslint/utils@8.54.0_eslint@9.39.2_typescript@5.9.3": {
-      "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
+    "@typescript-eslint/utils@8.64.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
       "dependencies": [
         "@eslint-community/eslint-utils",
         "@typescript-eslint/scope-manager",
@@ -740,15 +1354,15 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/visitor-keys@8.54.0": {
-      "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+    "@typescript-eslint/visitor-keys@8.64.0": {
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dependencies": [
         "@typescript-eslint/types",
-        "eslint-visitor-keys@4.2.1"
+        "eslint-visitor-keys@5.0.1"
       ]
     },
-    "@vitest/coverage-v8@4.0.18_vitest@4.0.18__@types+node@25.1.0__vite@7.3.1___@types+node@25.1.0___tsx@4.21.0___picomatch@4.0.3__tsx@4.21.0_@types+node@25.1.0_tsx@4.21.0": {
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+    "@vitest/coverage-v8@4.1.10_vitest@4.1.10_@types+node@25.9.5_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0": {
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dependencies": [
         "@bcoe/v8-coverage",
         "@vitest/utils",
@@ -763,8 +1377,8 @@
         "vitest"
       ]
     },
-    "@vitest/expect@4.0.18": {
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+    "@vitest/expect@4.1.10": {
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dependencies": [
         "@standard-schema/spec",
         "@types/chai",
@@ -774,8 +1388,8 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.0.18_vite@7.3.1__@types+node@25.1.0__tsx@4.21.0__picomatch@4.0.3_@types+node@25.1.0_tsx@4.21.0": {
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+    "@vitest/mocker@4.1.10_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0_@types+node@25.9.5_tsx@4.21.0": {
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dependencies": [
         "@vitest/spy",
         "estree-walker",
@@ -786,34 +1400,36 @@
         "vite"
       ]
     },
-    "@vitest/pretty-format@4.0.18": {
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+    "@vitest/pretty-format@4.1.10": {
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dependencies": [
         "tinyrainbow"
       ]
     },
-    "@vitest/runner@4.0.18": {
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+    "@vitest/runner@4.1.10": {
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dependencies": [
         "@vitest/utils",
         "pathe"
       ]
     },
-    "@vitest/snapshot@4.0.18": {
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+    "@vitest/snapshot@4.1.10": {
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dependencies": [
         "@vitest/pretty-format",
+        "@vitest/utils",
         "magic-string",
         "pathe"
       ]
     },
-    "@vitest/spy@4.0.18": {
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="
+    "@vitest/spy@4.1.10": {
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="
     },
-    "@vitest/utils@4.0.18": {
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+    "@vitest/utils@4.1.10": {
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dependencies": [
         "@vitest/pretty-format",
+        "convert-source-map",
         "tinyrainbow"
       ]
     },
@@ -832,9 +1448,21 @@
       "dependencies": [
         "fast-deep-equal",
         "fast-json-stable-stringify",
-        "json-schema-traverse",
+        "json-schema-traverse@0.4.1",
         "uri-js"
       ]
+    },
+    "ajv@8.18.0": {
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse@1.0.0",
+        "require-from-string"
+      ]
+    },
+    "angular-html-parser@10.4.0": {
+      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww=="
     },
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
@@ -916,12 +1544,12 @@
     "assertion-error@2.0.1": {
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
     },
-    "ast-v8-to-istanbul@0.3.11": {
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+    "ast-v8-to-istanbul@1.0.5": {
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
       "dependencies": [
         "@jridgewell/trace-mapping",
         "estree-walker",
-        "js-tokens"
+        "js-tokens@10.0.0"
       ]
     },
     "async-function@1.0.0": {
@@ -936,20 +1564,27 @@
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "before-after-hook@2.2.3": {
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    "balanced-match@4.0.4": {
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "baseline-browser-mapping@2.10.43": {
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "bin": true
+    },
+    "before-after-hook@4.0.0": {
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="
     },
     "brace-expansion@1.1.12": {
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": [
-        "balanced-match",
+        "balanced-match@1.0.2",
         "concat-map"
       ]
     },
-    "brace-expansion@2.0.2": {
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+    "brace-expansion@5.0.7": {
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dependencies": [
-        "balanced-match"
+        "balanced-match@4.0.4"
       ]
     },
     "braces@3.0.3": {
@@ -958,15 +1593,23 @@
         "fill-range"
       ]
     },
+    "browserslist@4.28.6": {
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dependencies": [
+        "baseline-browser-mapping",
+        "caniuse-lite",
+        "electron-to-chromium",
+        "node-releases",
+        "update-browserslist-db"
+      ],
+      "bin": true
+    },
     "bundle-require@5.1.0_esbuild@0.27.2": {
       "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
       "dependencies": [
         "esbuild",
         "load-tsconfig"
       ]
-    },
-    "bytes-iec@3.1.1": {
-      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA=="
     },
     "cac@6.7.14": {
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
@@ -997,6 +1640,9 @@
     "callsites@3.1.0": {
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "caniuse-lite@1.0.30001806": {
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="
+    },
     "chai@6.2.2": {
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="
     },
@@ -1007,11 +1653,20 @@
         "supports-color"
       ]
     },
+    "chalk@5.6.2": {
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+    },
+    "chardet@2.2.0": {
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="
+    },
     "chokidar@4.0.3": {
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": [
         "readdirp"
       ]
+    },
+    "cli-width@4.1.0": {
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
     },
     "cliui@8.0.1": {
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
@@ -1030,6 +1685,9 @@
     "color-name@1.1.4": {
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "commander@14.0.3": {
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
+    },
     "commander@4.1.1": {
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
     },
@@ -1042,10 +1700,16 @@
     "consola@3.4.2": {
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
     },
+    "content-type@2.0.0": {
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+    },
+    "convert-source-map@2.0.0": {
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
     "cross-spawn@7.0.6": {
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": [
-        "path-key",
+        "path-key@3.1.1",
         "shebang-command",
         "which"
       ]
@@ -1105,8 +1769,18 @@
         "object-keys"
       ]
     },
-    "deprecation@2.3.1": {
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    "des.js@1.1.0": {
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dependencies": [
+        "inherits",
+        "minimalistic-assert"
+      ]
+    },
+    "detect-libc@2.1.2": {
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
+    },
+    "diff-match-patch@1.0.5": {
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "doctrine@2.1.0": {
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
@@ -1121,6 +1795,12 @@
         "es-errors",
         "gopd"
       ]
+    },
+    "electron-to-chromium@1.5.393": {
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg=="
+    },
+    "emoji-regex@10.6.0": {
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
@@ -1193,8 +1873,8 @@
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
-    "es-module-lexer@1.7.0": {
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+    "es-module-lexer@2.3.1": {
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="
     },
     "es-object-atoms@1.1.1": {
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
@@ -1323,6 +2003,9 @@
     "eslint-visitor-keys@4.2.1": {
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="
     },
+    "eslint-visitor-keys@5.0.1": {
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="
+    },
     "eslint@9.39.2": {
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dependencies": [
@@ -1332,14 +2015,14 @@
         "@eslint/config-helpers",
         "@eslint/core",
         "@eslint/eslintrc",
-        "@eslint/js",
+        "@eslint/js@9.39.2",
         "@eslint/plugin-kit",
         "@humanfs/node",
         "@humanwhocodes/module-importer",
         "@humanwhocodes/retry",
         "@types/estree",
-        "ajv",
-        "chalk",
+        "ajv@6.12.6",
+        "chalk@4.1.2",
         "cross-spawn",
         "debug@4.4.3",
         "escape-string-regexp",
@@ -1395,11 +2078,28 @@
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
-    "expect-type@1.3.0": {
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="
+    "execa@9.6.1": {
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dependencies": [
+        "@sindresorhus/merge-streams",
+        "cross-spawn",
+        "figures",
+        "get-stream",
+        "human-signals",
+        "is-plain-obj",
+        "is-stream",
+        "npm-run-path",
+        "pretty-ms",
+        "signal-exit",
+        "strip-final-newline",
+        "yoctocolors"
+      ]
     },
-    "fast-check@4.5.3": {
-      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+    "expect-type@1.4.0": {
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="
+    },
+    "fast-check@4.9.0": {
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "dependencies": [
         "pure-rand"
       ]
@@ -1413,13 +2113,37 @@
     "fast-levenshtein@2.0.6": {
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "fdir@6.5.0_picomatch@4.0.3": {
+    "fast-string-truncated-width@3.0.3": {
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="
+    },
+    "fast-string-width@3.0.2": {
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dependencies": [
+        "fast-string-truncated-width"
+      ]
+    },
+    "fast-uri@3.1.3": {
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="
+    },
+    "fast-wrap-ansi@0.2.2": {
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dependencies": [
+        "fast-string-width"
+      ]
+    },
+    "fdir@6.5.0_picomatch@4.0.5": {
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dependencies": [
-        "picomatch@4.0.3"
+        "picomatch@4.0.5"
       ],
       "optionalPeers": [
-        "picomatch@4.0.3"
+        "picomatch@4.0.5"
+      ]
+    },
+    "figures@6.1.0": {
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dependencies": [
+        "is-unicode-supported"
       ]
     },
     "file-entry-cache@8.0.0": {
@@ -1490,6 +2214,9 @@
     "generator-function@2.0.1": {
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
     },
+    "gensync@1.0.0-beta.2": {
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
@@ -1513,6 +2240,13 @@
       "dependencies": [
         "dunder-proto",
         "es-object-atoms"
+      ]
+    },
+    "get-stream@9.0.1": {
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dependencies": [
+        "@sec-ant/readable-stream",
+        "is-stream"
       ]
     },
     "get-symbol-description@1.1.0": {
@@ -1590,11 +2324,20 @@
     "html-escaper@2.0.2": {
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
+    "human-signals@8.0.1": {
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="
+    },
+    "iconv-lite@0.7.3": {
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
-    "ignore@7.0.5": {
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
+    "ignore@7.0.6": {
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="
     },
     "import-fresh@3.3.1": {
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
@@ -1605,6 +2348,9 @@
     },
     "imurmurhash@0.1.4": {
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot@1.1.0": {
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
@@ -1713,6 +2459,9 @@
     "is-number@7.0.0": {
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
+    "is-plain-obj@4.1.0": {
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+    },
     "is-regex@1.2.1": {
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dependencies": [
@@ -1730,6 +2479,9 @@
       "dependencies": [
         "call-bound"
       ]
+    },
+    "is-stream@4.0.1": {
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
     },
     "is-string@1.1.1": {
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
@@ -1751,6 +2503,9 @@
       "dependencies": [
         "which-typed-array"
       ]
+    },
+    "is-unicode-supported@2.1.0": {
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
     },
     "is-weakmap@2.0.2": {
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
@@ -1795,8 +2550,14 @@
     "joycon@3.1.1": {
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
     },
+    "js-md4@0.3.2": {
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
+    },
     "js-tokens@10.0.0": {
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
+    },
+    "js-tokens@4.0.0": {
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml@4.1.1": {
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
@@ -1805,14 +2566,27 @@
       ],
       "bin": true
     },
+    "jsesc@3.1.0": {
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "bin": true
+    },
     "json-buffer@3.0.1": {
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "json-rpc-2.0@1.7.1": {
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg=="
     },
     "json-schema-traverse@0.4.1": {
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "json-stable-stringify-without-jsonify@1.0.1": {
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "json-with-bigint@3.5.10": {
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w=="
     },
     "json5@1.0.2": {
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
@@ -1821,64 +2595,68 @@
       ],
       "bin": true
     },
+    "json5@2.2.3": {
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": true
+    },
     "keyv@4.5.4": {
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": [
         "json-buffer"
       ]
     },
-    "lefthook-darwin-arm64@2.0.16": {
-      "integrity": "sha512-kjVHkD7rfPa7M0aKJSx/yatdV9uC6o3cJyzM9zk7cg5HD7alSwchFalgF/P0w6nt7C02rAUx8C05qiWCDWaKeA==",
+    "lefthook-darwin-arm64@2.1.10": {
+      "integrity": "sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "lefthook-darwin-x64@2.0.16": {
-      "integrity": "sha512-tbJ0mdT49DNRLqknro0BvWrYNC23TTcqBJFQnQ32pq1/H9B87bTNKvKKAtogp/saxfHUzkIq1i3twZlBZ3G3Xw==",
+    "lefthook-darwin-x64@2.1.10": {
+      "integrity": "sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "lefthook-freebsd-arm64@2.0.16": {
-      "integrity": "sha512-wa1KFD5tSUhw3tuetVef/BCSxbbmS7auTDNdoLx3WFeuN5RS15woSN9+E8GPGOOY1g2HCsgdLrhrexEomulfjQ==",
+    "lefthook-freebsd-arm64@2.1.10": {
+      "integrity": "sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w==",
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
-    "lefthook-freebsd-x64@2.0.16": {
-      "integrity": "sha512-UXowfn2e94AwNk9UuoePRK+qiF15jZsssiyA15VK5GTtxpn6Sn+Z2QFciofxJczXXxM4abaf7qgx2OoJBt32VA==",
+    "lefthook-freebsd-x64@2.1.10": {
+      "integrity": "sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ==",
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
-    "lefthook-linux-arm64@2.0.16": {
-      "integrity": "sha512-U355elz4Z0AHSVqxfcglN09TGR86ov/GtYlliDknci2mmz6EWLiD3dTYnqJiwa4dYxqmuCDc/DvAL9rgb3YJiQ==",
+    "lefthook-linux-arm64@2.1.10": {
+      "integrity": "sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "lefthook-linux-x64@2.0.16": {
-      "integrity": "sha512-7eAvBeWGAgjOKZ23OQbjJINLPImDIuDeX8dXOfk+aI6IFt2X6KCzRkp+ASUvGQtrPuNZQZT43EhW0/1jZU14ZQ==",
+    "lefthook-linux-x64@2.1.10": {
+      "integrity": "sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "lefthook-openbsd-arm64@2.0.16": {
-      "integrity": "sha512-Fcd+E17ZkWGnRSQINb5gf+rNy2So5PYn5mBljiC31dl+TgWM8Wy46mSEGveHo7lKCO3q+DkmHIa50Qm58G03AQ==",
+    "lefthook-openbsd-arm64@2.1.10": {
+      "integrity": "sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ==",
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
-    "lefthook-openbsd-x64@2.0.16": {
-      "integrity": "sha512-uL5nOkz8eBtQHped0/tB5X8clZ5kfnyjQrv1fpKbGAjeFHI2J+GmRqcn6Awq2IeuBbQvkyV6jDjpATyHBp5mCA==",
+    "lefthook-openbsd-x64@2.1.10": {
+      "integrity": "sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg==",
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
-    "lefthook-windows-arm64@2.0.16": {
-      "integrity": "sha512-U61bNWzD6Vd2kjuJ7b4voPfTQ4mlBFOyTpCU3k/h0YjpKDQEFT1T5fDKkDothdnw/JVDSgrclIcfAY7Jyr/UIg==",
+    "lefthook-windows-arm64@2.1.10": {
+      "integrity": "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "lefthook-windows-x64@2.0.16": {
-      "integrity": "sha512-dCHi2+hebhPI0LQUGRNjPMsGRyXhrTN3Y/b8M4HO8KVyGamKB3Yemf67ya81tZopDkxNVy5XUBXLYWKGhnAfLQ==",
+    "lefthook-windows-x64@2.1.10": {
+      "integrity": "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "lefthook@2.0.16": {
-      "integrity": "sha512-ABs3M5V9c4nqxFnZO509HXuQTu8GM8hmqc9ruV0acQ81yKlxEq70MRoYP5Z1dr5le326X8vA5qj3arJA36yE3A==",
+    "lefthook@2.1.10": {
+      "integrity": "sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w==",
       "optionalDependencies": [
         "lefthook-darwin-arm64",
         "lefthook-darwin-x64",
@@ -1901,14 +2679,88 @@
         "type-check"
       ]
     },
+    "lightningcss-android-arm64@1.32.0": {
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-darwin-arm64@1.32.0": {
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-darwin-x64@1.32.0": {
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-freebsd-x64@1.32.0": {
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-linux-arm-gnueabihf@1.32.0": {
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "lightningcss-linux-arm64-gnu@1.32.0": {
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-linux-arm64-musl@1.32.0": {
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-linux-x64-gnu@1.32.0": {
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-linux-x64-musl@1.32.0": {
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-win32-arm64-msvc@1.32.0": {
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-win32-x64-msvc@1.32.0": {
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "lightningcss@1.32.0": {
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dependencies": [
+        "detect-libc"
+      ],
+      "optionalDependencies": [
+        "lightningcss-android-arm64",
+        "lightningcss-darwin-arm64",
+        "lightningcss-darwin-x64",
+        "lightningcss-freebsd-x64",
+        "lightningcss-linux-arm-gnueabihf",
+        "lightningcss-linux-arm64-gnu",
+        "lightningcss-linux-arm64-musl",
+        "lightningcss-linux-x64-gnu",
+        "lightningcss-linux-x64-musl",
+        "lightningcss-win32-arm64-msvc",
+        "lightningcss-win32-x64-msvc"
+      ]
+    },
     "lilconfig@3.1.3": {
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
     },
     "lines-and-columns@1.2.4": {
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
-    "linkify-it@5.0.0": {
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+    "linkify-it@5.0.2": {
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dependencies": [
         "uc.micro"
       ]
@@ -1922,8 +2774,17 @@
         "p-locate"
       ]
     },
+    "lodash.groupby@4.6.0": {
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+    },
     "lodash.merge@4.6.2": {
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lru-cache@5.1.1": {
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dependencies": [
+        "yallist"
+      ]
     },
     "lunr@2.3.9": {
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
@@ -1934,8 +2795,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "magicast@0.5.1": {
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+    "magicast@0.5.3": {
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
@@ -1945,11 +2806,11 @@
     "make-dir@4.0.0": {
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dependencies": [
-        "semver@7.7.3"
+        "semver@7.8.5"
       ]
     },
-    "markdown-it@14.1.0": {
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+    "markdown-it@14.3.0": {
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dependencies": [
         "argparse",
         "entities",
@@ -1970,19 +2831,22 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": [
         "braces",
-        "picomatch@2.3.1"
+        "picomatch@2.3.2"
+      ]
+    },
+    "minimalistic-assert@1.0.1": {
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimatch@10.2.5": {
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dependencies": [
+        "brace-expansion@5.0.7"
       ]
     },
     "minimatch@3.1.2": {
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": [
         "brace-expansion@1.1.12"
-      ]
-    },
-    "minimatch@9.0.5": {
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dependencies": [
-        "brace-expansion@2.0.2"
       ]
     },
     "minimist@1.2.8": {
@@ -2000,6 +2864,27 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "mutation-server-protocol@0.4.1": {
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dependencies": [
+        "zod@4.4.3"
+      ]
+    },
+    "mutation-testing-elements@3.7.3": {
+      "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ=="
+    },
+    "mutation-testing-metrics@3.7.3": {
+      "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
+      "dependencies": [
+        "mutation-testing-report-schema"
+      ]
+    },
+    "mutation-testing-report-schema@3.7.3": {
+      "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA=="
+    },
+    "mute-stream@3.0.0": {
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="
+    },
     "mz@2.7.0": {
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dependencies": [
@@ -2008,22 +2893,22 @@
         "thenify-all"
       ]
     },
-    "nanoid@3.3.11": {
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+    "nanoid@3.3.16": {
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "bin": true
-    },
-    "nanoid@5.1.6": {
-      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
-      "bin": true
-    },
-    "nanospinner@1.2.2": {
-      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
-      "dependencies": [
-        "picocolors"
-      ]
     },
     "natural-compare@1.4.0": {
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node-releases@2.0.51": {
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="
+    },
+    "npm-run-path@6.0.0": {
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dependencies": [
+        "path-key@4.0.0",
+        "unicorn-magic"
+      ]
     },
     "object-assign@4.1.1": {
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
@@ -2071,14 +2956,8 @@
         "es-object-atoms"
       ]
     },
-    "obug@2.1.1": {
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="
-    },
-    "once@1.4.0": {
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": [
-        "wrappy"
-      ]
+    "obug@2.1.4": {
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="
     },
     "optionator@0.9.4": {
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
@@ -2117,11 +2996,17 @@
         "callsites"
       ]
     },
+    "parse-ms@4.0.0": {
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
+    },
     "path-exists@4.0.0": {
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-key@4.0.0": {
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
     },
     "path-parse@1.0.7": {
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
@@ -2132,11 +3017,11 @@
     "picocolors@1.1.1": {
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
-    "picomatch@2.3.1": {
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    "picomatch@2.3.2": {
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
     },
-    "picomatch@4.0.3": {
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
+    "picomatch@4.0.5": {
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="
     },
     "pirates@4.0.7": {
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="
@@ -2162,10 +3047,10 @@
         "tsx"
       ]
     },
-    "postcss@8.5.6": {
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+    "postcss@8.5.19": {
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dependencies": [
-        "nanoid@3.3.11",
+        "nanoid",
         "picocolors",
         "source-map-js"
       ]
@@ -2173,9 +3058,18 @@
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
-    "prettier@3.8.1": {
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+    "prettier@3.9.5": {
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "bin": true
+    },
+    "pretty-ms@9.3.0": {
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dependencies": [
+        "parse-ms"
+      ]
+    },
+    "progress@2.0.3": {
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "punycode.js@2.3.1": {
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
@@ -2183,8 +3077,14 @@
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
-    "pure-rand@7.0.1": {
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="
+    "pure-rand@8.4.2": {
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="
+    },
+    "qs@6.15.1": {
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": [
+        "side-channel"
+      ]
     },
     "readdirp@4.1.2": {
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
@@ -2196,7 +3096,7 @@
         "glob-regex",
         "slash",
         "sucrase",
-        "tslib"
+        "tslib@1.14.1"
       ]
     },
     "reflect.getprototypeof@1.0.10": {
@@ -2226,6 +3126,9 @@
     "require-directory@2.1.1": {
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "resolve-from@4.0.0": {
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
@@ -2241,6 +3144,31 @@
         "is-core-module",
         "path-parse",
         "supports-preserve-symlinks-flag"
+      ],
+      "bin": true
+    },
+    "rolldown@1.1.5": {
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dependencies": [
+        "@oxc-project/types",
+        "@rolldown/pluginutils"
+      ],
+      "optionalDependencies": [
+        "@rolldown/binding-android-arm64",
+        "@rolldown/binding-darwin-arm64",
+        "@rolldown/binding-darwin-x64",
+        "@rolldown/binding-freebsd-x64",
+        "@rolldown/binding-linux-arm-gnueabihf",
+        "@rolldown/binding-linux-arm64-gnu",
+        "@rolldown/binding-linux-arm64-musl",
+        "@rolldown/binding-linux-ppc64-gnu",
+        "@rolldown/binding-linux-s390x-gnu",
+        "@rolldown/binding-linux-x64-gnu",
+        "@rolldown/binding-linux-x64-musl",
+        "@rolldown/binding-openharmony-arm64",
+        "@rolldown/binding-wasm32-wasi",
+        "@rolldown/binding-win32-arm64-msvc",
+        "@rolldown/binding-win32-x64-msvc"
       ],
       "bin": true
     },
@@ -2279,6 +3207,12 @@
       ],
       "bin": true
     },
+    "rxjs@7.8.2": {
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
+    },
     "safe-array-concat@1.1.3": {
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dependencies": [
@@ -2304,12 +3238,19 @@
         "is-regex"
       ]
     },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "semver@6.3.1": {
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": true
     },
-    "semver@7.7.3": {
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+    "semver@7.7.4": {
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": true
+    },
+    "semver@7.8.5": {
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "bin": true
     },
     "set-function-length@1.2.2": {
@@ -2388,16 +3329,8 @@
     "siginfo@2.0.0": {
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
     },
-    "size-limit@12.0.0": {
-      "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
-      "dependencies": [
-        "bytes-iec",
-        "lilconfig",
-        "nanospinner",
-        "picocolors",
-        "tinyglobby"
-      ],
-      "bin": true
+    "signal-exit@4.1.0": {
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "slash@3.0.0": {
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
@@ -2411,8 +3344,8 @@
     "stackback@0.0.2": {
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
     },
-    "std-env@3.10.0": {
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="
+    "std-env@4.2.0": {
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="
     },
     "stop-iteration-iterator@1.1.0": {
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
@@ -2424,7 +3357,7 @@
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": [
-        "emoji-regex",
+        "emoji-regex@8.0.0",
         "is-fullwidth-code-point",
         "strip-ansi"
       ]
@@ -2467,6 +3400,9 @@
     "strip-bom@3.0.0": {
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
+    "strip-final-newline@4.0.0": {
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
+    },
     "strip-json-comments@3.1.1": {
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
@@ -2474,7 +3410,7 @@
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "dependencies": [
         "@jridgewell/gen-mapping",
-        "commander",
+        "commander@4.1.1",
         "lines-and-columns",
         "mz",
         "pirates",
@@ -2510,18 +3446,18 @@
     "tinyexec@0.3.2": {
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
-    "tinyexec@1.0.2": {
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="
+    "tinyexec@1.2.4": {
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="
     },
-    "tinyglobby@0.2.15_picomatch@4.0.3": {
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+    "tinyglobby@0.2.17": {
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dependencies": [
         "fdir",
-        "picomatch@4.0.3"
+        "picomatch@4.0.5"
       ]
     },
-    "tinyrainbow@3.0.3": {
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="
+    "tinyrainbow@3.1.0": {
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -2533,8 +3469,8 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "bin": true
     },
-    "ts-api-utils@2.4.0_typescript@5.9.3": {
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+    "ts-api-utils@2.5.0_typescript@5.9.3": {
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dependencies": [
         "typescript"
       ]
@@ -2546,13 +3482,16 @@
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dependencies": [
         "@types/json5",
-        "json5",
+        "json5@1.0.2",
         "minimist",
         "strip-bom"
       ]
     },
     "tslib@1.14.1": {
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsup@8.5.1_typescript@5.9.3_esbuild@0.27.2_tsx@4.21.0": {
       "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
@@ -2595,45 +3534,15 @@
     "tunnel@0.0.6": {
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
-    "turbo-darwin-64@2.8.1": {
-      "integrity": "sha512-FQ6Uqxty/H1Nvn1dpBe8KUlMRclTuiyNSc1PCeDL/ad7M9ykpWutB51YpMpf9ibTA32M6wLdIRf+D96W6hDAtQ==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "turbo-darwin-arm64@2.8.1": {
-      "integrity": "sha512-4bCcEpGP2/aSXmeN2gl5SuAmS1q5ykjubnFvSoXjQoCKtDOV+vc4CTl/DduZzUUutCVUWXjl8OyfIQ+DGCaV4A==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "turbo-linux-64@2.8.1": {
-      "integrity": "sha512-m99JRlWlEgXPR7mkThAbKh6jbTmWSOXM/c6rt8yd4Uxh0+wjq7+DYcQbead6aoOqmCP9akswZ8EXIv1ogKBblg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "turbo-linux-arm64@2.8.1": {
-      "integrity": "sha512-AsPlza3AsavJdl2o7FE67qyv0aLfmT1XwFQGzvwpoAO6Bj7S4a03tpUchZKNuGjNAkKVProQRFnB7PgUAScFXA==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "turbo-windows-64@2.8.1": {
-      "integrity": "sha512-GdqNO6bYShRsr79B+2G/2ssjLEp9uBTvLBJSWRtRCiac/SEmv8T6RYv9hu+h5oGbFALtnKNp6BQBw78RJURsPw==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "turbo-windows-arm64@2.8.1": {
-      "integrity": "sha512-n40E6IpkzrShRo3yMdRpgnn1/sAbGC6tZXwyNu8fe9RsufeD7KBiaoRSvw8xLyqV3pd2yoTL2rdCXq24MnTCWA==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "turbo@2.8.1": {
-      "integrity": "sha512-pbSMlRflA0RAuk/0jnAt8pzOYh1+sKaT8nVtcs75OFGVWD0evleQRmKtHJJV42QOhaC3Hx9mUUSOom/irasbjA==",
+    "turbo@2.10.5": {
+      "integrity": "sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ==",
       "optionalDependencies": [
-        "turbo-darwin-64",
-        "turbo-darwin-arm64",
-        "turbo-linux-64",
-        "turbo-linux-arm64",
-        "turbo-windows-64",
-        "turbo-windows-arm64"
+        "@turbo/darwin-64",
+        "@turbo/darwin-arm64",
+        "@turbo/linux-64",
+        "@turbo/linux-arm64",
+        "@turbo/windows-64",
+        "@turbo/windows-arm64"
       ],
       "bin": true
     },
@@ -2684,32 +3593,45 @@
         "reflect.getprototypeof"
       ]
     },
-    "typedoc-plugin-markdown@4.9.0_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3": {
-      "integrity": "sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==",
+    "typed-inject@5.0.0": {
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA=="
+    },
+    "typed-rest-client@2.3.1": {
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dependencies": [
+        "des.js",
+        "js-md4",
+        "qs",
+        "tunnel",
+        "underscore"
+      ]
+    },
+    "typedoc-plugin-markdown@4.12.0_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3": {
+      "integrity": "sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==",
       "dependencies": [
         "typedoc"
       ]
     },
-    "typedoc-vitepress-theme@1.1.2_typedoc-plugin-markdown@4.9.0__typedoc@0.28.16___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.16__typescript@5.9.3_typescript@5.9.3": {
+    "typedoc-vitepress-theme@1.1.2_typedoc-plugin-markdown@4.12.0__typedoc@0.28.20___typescript@5.9.3__typescript@5.9.3_typedoc@0.28.20__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-hQvCZRr5uKDqY1bRuY1+eNTNn6d4TE4OP5pnw65Y7WGgajkJW9X1/lVJK2UJpcwCmwkdjw1QIO49H9JQlxWhhw==",
       "dependencies": [
         "typedoc-plugin-markdown"
       ]
     },
-    "typedoc@0.28.16_typescript@5.9.3": {
-      "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
+    "typedoc@0.28.20_typescript@5.9.3": {
+      "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dependencies": [
         "@gerrit0/mini-shiki",
         "lunr",
         "markdown-it",
-        "minimatch@9.0.5",
+        "minimatch@10.2.5",
         "typescript",
         "yaml"
       ],
       "bin": true
     },
-    "typescript-eslint@8.54.0_eslint@9.39.2_typescript@5.9.3_@typescript-eslint+parser@8.54.0__eslint@9.39.2__typescript@5.9.3": {
-      "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
+    "typescript-eslint@8.64.0_eslint@9.39.2_typescript@5.9.3": {
+      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
       "dependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
@@ -2738,17 +3660,20 @@
         "which-boxed-primitive"
       ]
     },
-    "undici-types@7.16.0": {
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+    "underscore@1.13.8": {
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
     },
-    "undici@5.29.0": {
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dependencies": [
-        "@fastify/busboy"
-      ]
+    "undici-types@7.24.6": {
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
     },
-    "universal-user-agent@6.0.1": {
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    "undici@6.27.0": {
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="
+    },
+    "unicorn-magic@0.3.0": {
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+    },
+    "universal-user-agent@7.0.3": {
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
     },
     "unplugin@1.16.1": {
       "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
@@ -2757,21 +3682,29 @@
         "webpack-virtual-modules"
       ]
     },
+    "update-browserslist-db@1.2.3_browserslist@4.28.6": {
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dependencies": [
+        "browserslist",
+        "escalade",
+        "picocolors"
+      ],
+      "bin": true
+    },
     "uri-js@4.4.1": {
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": [
         "punycode"
       ]
     },
-    "vite@7.3.1_@types+node@25.1.0_tsx@4.21.0_picomatch@4.0.3": {
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+    "vite@8.1.5_@types+node@25.9.5_tsx@4.21.0": {
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dependencies": [
         "@types/node",
-        "esbuild",
-        "fdir",
-        "picomatch@4.0.3",
+        "lightningcss",
+        "picomatch@4.0.5",
         "postcss",
-        "rollup",
+        "rolldown",
         "tinyglobby",
         "tsx"
       ],
@@ -2793,10 +3726,11 @@
         "tsconfig-paths"
       ]
     },
-    "vitest@4.0.18_@types+node@25.1.0_vite@7.3.1__@types+node@25.1.0__tsx@4.21.0__picomatch@4.0.3_tsx@4.21.0": {
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+    "vitest@4.1.10_@types+node@25.9.5_@vitest+coverage-v8@4.1.10_vite@8.1.5__@types+node@25.9.5__tsx@4.21.0_tsx@4.21.0": {
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dependencies": [
         "@types/node",
+        "@vitest/coverage-v8",
         "@vitest/expect",
         "@vitest/mocker",
         "@vitest/pretty-format",
@@ -2809,19 +3743,23 @@
         "magic-string",
         "obug",
         "pathe",
-        "picomatch@4.0.3",
+        "picomatch@4.0.5",
         "std-env",
         "tinybench",
-        "tinyexec@1.0.2",
+        "tinyexec@1.2.4",
         "tinyglobby",
         "tinyrainbow",
         "vite",
         "why-is-node-running"
       ],
       "optionalPeers": [
-        "@types/node"
+        "@types/node",
+        "@vitest/coverage-v8"
       ],
       "bin": true
+    },
+    "weapon-regex@1.3.6": {
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA=="
     },
     "webpack-virtual-modules@0.6.2": {
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="
@@ -2901,21 +3839,21 @@
         "strip-ansi"
       ]
     },
-    "wrappy@1.0.2": {
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "y18n@5.0.8": {
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
-    "yaml@2.8.2": {
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+    "yallist@3.1.1": {
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "yaml@2.9.0": {
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "bin": true
     },
     "yargs-parser@21.1.1": {
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
-    "yargs@17.7.2": {
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+    "yargs@17.7.3": {
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dependencies": [
         "cliui",
         "escalade",
@@ -2929,8 +3867,14 @@
     "yocto-queue@0.1.0": {
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
+    "yoctocolors@2.1.2": {
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="
+    },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    },
+    "zod@4.4.3": {
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     }
   },
   "remote": {
@@ -2963,10 +3907,28 @@
     "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
     "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
     "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/expect/_assert_equals.ts": "08a5ba74c1c7ca51c4c2c33158509746c560777ad3cb8996a55d85a8d57c351c",
+    "https://deno.land/std@0.224.0/expect/_assert_not_equals.ts": "f8c56aafbc12b2d49bb5e1478f02a3ae8a6fd884eff18ccbc899a94829eb1510",
+    "https://deno.land/std@0.224.0/expect/_asymmetric_matchers.ts": "bf2385fc9a943f0600f7870c8dfcbfd0ab5d633fe3c45b84339016e0d8069ac4",
+    "https://deno.land/std@0.224.0/expect/_build_message.ts": "5381029035b3ff64839167f1be3e36ee2c5c5f062878f50b8d060407945206c6",
+    "https://deno.land/std@0.224.0/expect/_constants.ts": "751a014c4b803ad21287529d55d213d8b5eb34d203cca9509e4c9b84ced440a8",
+    "https://deno.land/std@0.224.0/expect/_custom_equality_tester.ts": "9426916863d2b740ae3ec74e2de5f2ec79d36bb1a62bdd5965a9b9543c8ee46d",
+    "https://deno.land/std@0.224.0/expect/_equal.ts": "f2d4f3a10f91cd6c21deefc8facdbc9e6f07a828e68b8e50049a33f8a4c3c6d4",
+    "https://deno.land/std@0.224.0/expect/_extend.ts": "df775060bffb0756519aa20663ecea5503167a8f13f5aef9cf18c24f16161ca3",
+    "https://deno.land/std@0.224.0/expect/_inspect_args.ts": "6cc9b3809e6f9671b35d0305d1ed7cc340b00b0455731b0b47b6c2ae707f8f27",
+    "https://deno.land/std@0.224.0/expect/_matchers.ts": "5e1056b4243fc3094381c9db0783ce0d47559fa11745c63227cf01c0352cb4ed",
+    "https://deno.land/std@0.224.0/expect/_mock_util.ts": "7e79e07eb869ff71b96601ac76807c745465bd3c5a3df622abf44c28a0c4ca8c",
+    "https://deno.land/std@0.224.0/expect/_snapshot_serializer.ts": "de8cf3b1d7005789ea35ce0052146a4a42ce8d36fe947c712db7147b83ffa778",
+    "https://deno.land/std@0.224.0/expect/_utils.ts": "fc45069227d1c5a04f642b9224f060017eb02923159a4848d79a7a3fcef53c55",
+    "https://deno.land/std@0.224.0/expect/expect.ts": "474fa2c581c861be43bf4fcf58875d7d28b879bea1d2c671b833b2147ced24ab",
+    "https://deno.land/std@0.224.0/expect/fn.ts": "2508684de0a3147698b3b162f6fc99f7f9fe424ba3136fc4016f654aaff243cd",
+    "https://deno.land/std@0.224.0/expect/mod.ts": "dc79508c6f554d70ef087fdb726d09add7a48f5e612aabc2d951e5cc69c4529a",
     "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
     "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
     "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
+    "https://deno.land/std@0.224.0/testing/_test_suite.ts": "f10a8a6338b60c403f07a76f3f46bdc9f1e1a820c0a1decddeb2949f7a8a0546",
+    "https://deno.land/std@0.224.0/testing/bdd.ts": "3e4de4ff6d8f348b5574661cef9501b442046a59079e201b849d0e74120d476b"
   },
   "workspace": {
     "dependencies": [
@@ -2975,31 +3937,31 @@
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@codecov/bundle-analyzer@^1.9.1",
-        "npm:@eslint/js@^9.39.2",
-        "npm:@size-limit/preset-small-lib@12",
-        "npm:@types/node@^25.0.10",
-        "npm:@typescript-eslint/eslint-plugin@^8.54.0",
-        "npm:@typescript-eslint/parser@^8.54.0",
-        "npm:@vitest/coverage-v8@^4.0.18",
+        "npm:@codecov/bundle-analyzer@^2.0.1",
+        "npm:@eslint/js@^9.39.3",
+        "npm:@stryker-mutator/core@^9.6.1",
+        "npm:@stryker-mutator/vitest-runner@^9.6.1",
+        "npm:@types/node@^25.6.0",
+        "npm:@typescript-eslint/eslint-plugin@^8.59.2",
+        "npm:@typescript-eslint/parser@^8.59.2",
+        "npm:@vitest/coverage-v8@^4.1.5",
         "npm:eslint-config-prettier@^10.1.8",
         "npm:eslint-plugin-import@^2.32.0",
         "npm:eslint@^9.39.2",
-        "npm:fast-check@^4.5.3",
-        "npm:lefthook@^2.0.16",
-        "npm:prettier@^3.8.1",
-        "npm:size-limit@12",
+        "npm:fast-check@^4.7.0",
+        "npm:lefthook@^2.1.6",
+        "npm:prettier@^3.8.3",
         "npm:tsup@^8.5.1",
         "npm:tsx@^4.21.0",
-        "npm:turbo@^2.8.1",
-        "npm:typedoc-plugin-markdown@^4.9.0",
+        "npm:turbo@^2.9.14",
+        "npm:typedoc-plugin-markdown@^4.11.0",
         "npm:typedoc-vitepress-theme@^1.1.2",
-        "npm:typedoc@~0.28.16",
-        "npm:typescript-eslint@^8.54.0",
+        "npm:typedoc@~0.28.19",
+        "npm:typescript-eslint@^8.59.2",
         "npm:typescript@^5.9.3",
-        "npm:vite@^7.3.1",
+        "npm:vite@^8.0.11",
         "npm:vitest-tsconfig-paths@^3.4.1",
-        "npm:vitest@^4.0.18"
+        "npm:vitest@^4.1.5"
       ]
     }
   }

--- a/internal/fuzz-tests/package.json
+++ b/internal/fuzz-tests/package.json
@@ -14,6 +14,7 @@
     "@otplib/uri": "workspace:*",
     "@otplib/plugin-crypto-node": "workspace:*",
     "@otplib/plugin-crypto-noble": "workspace:*",
+    "@otplib/plugin-crypto-web": "workspace:*",
     "@otplib/plugin-base32-scure": "workspace:*",
     "@repo/testing": "workspace:*"
   },

--- a/internal/fuzz-tests/src/cross-plugin.test.ts
+++ b/internal/fuzz-tests/src/cross-plugin.test.ts
@@ -515,21 +515,22 @@ describe("Cross-plugin consistency tests", () => {
       },
     );
 
-    it("should have every plugin reject non-canonical algorithm names identically", async () => {
+    it("should have every plugin reject unsupported algorithm names identically", async () => {
+      // Matches core's normalization: case and `-`/`_` are ignored, so a
+      // generated "SHA-1" is a *supported* spelling and must not be fed in here.
       const canonical = ["sha1", "sha256", "sha512"];
-      const nonCanonicalAlgorithm = fc.oneof(
+      const isSupportedSpelling = (s: string) =>
+        canonical.includes(s.toLowerCase().replace(/[-_]/g, ""));
+
+      const unsupportedAlgorithm = fc.oneof(
         fc.constantFrom(
-          "SHA-1",
-          "sha-1",
-          "SHA-256",
-          "sha-256",
-          "SHA-512",
-          "sha-512",
           "md5",
           "sha384",
+          "sha-384",
           "sha3-256",
-          "sha_1",
+          "sha-224",
           "",
+          "----",
           " sha1",
           "sha1 ",
         ),
@@ -540,7 +541,7 @@ describe("Cross-plugin consistency tests", () => {
         fc.asyncProperty(
           fc.uint8Array({ minLength: 1, maxLength: 64 }),
           fc.uint8Array({ minLength: 0, maxLength: 256 }),
-          nonCanonicalAlgorithm.filter((s) => !canonical.includes(s.toLowerCase())),
+          unsupportedAlgorithm.filter((s) => !isSupportedSpelling(s)),
           async (key, data, algorithm) => {
             const outcomes = await Promise.all(
               cryptoPlugins.map((p) => captureHmac(p.plugin, algorithm, key, data)),

--- a/internal/fuzz-tests/src/cross-plugin.test.ts
+++ b/internal/fuzz-tests/src/cross-plugin.test.ts
@@ -518,8 +518,8 @@ describe("Cross-plugin consistency tests", () => {
     it("should have every plugin reject unsupported algorithm names identically", async () => {
       // Matches core's normalization: case-insensitive with at most one `-`/`_`
       // between "sha" and the digest size, so a generated "SHA-1" is a
-      // *supported* spelling and must not be fed in here.
-      const isSupportedSpelling = (s: string) => /^sha[-_]?(1|256|512)$/.test(s.toLowerCase());
+      // *supported* alias and must not be fed in here.
+      const isSupportedAlias = (s: string) => /^sha[-_]?(1|256|512)$/.test(s.toLowerCase());
 
       const unsupportedAlgorithm = fc.oneof(
         fc.constantFrom(
@@ -540,7 +540,7 @@ describe("Cross-plugin consistency tests", () => {
         fc.asyncProperty(
           fc.uint8Array({ minLength: 1, maxLength: 64 }),
           fc.uint8Array({ minLength: 0, maxLength: 256 }),
-          unsupportedAlgorithm.filter((s) => !isSupportedSpelling(s)),
+          unsupportedAlgorithm.filter((s) => !isSupportedAlias(s)),
           async (key, data, algorithm) => {
             const outcomes = await Promise.all(
               cryptoPlugins.map((p) => captureHmac(p.plugin, algorithm, key, data)),

--- a/internal/fuzz-tests/src/cross-plugin.test.ts
+++ b/internal/fuzz-tests/src/cross-plugin.test.ts
@@ -4,9 +4,12 @@ import { generate as generateHOTP, verify as verifyHOTP } from "@otplib/hotp";
 import { generate as generateTOTP, verify as verifyTOTP } from "@otplib/totp";
 import { NodeCryptoPlugin } from "@otplib/plugin-crypto-node";
 import { NobleCryptoPlugin } from "@otplib/plugin-crypto-noble";
+import { WebCryptoPlugin } from "@otplib/plugin-crypto-web";
 import { ScureBase32Plugin } from "@otplib/plugin-base32-scure";
 
-import type { CryptoPlugin } from "@otplib/core";
+import { AlgorithmUnsupportedError } from "@otplib/core";
+
+import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
 
 type NamedCryptoPlugin = {
   name: string;
@@ -17,6 +20,7 @@ type NamedCryptoPlugin = {
 const cryptoPlugins: NamedCryptoPlugin[] = [
   { name: "Node.js", plugin: new NodeCryptoPlugin() },
   { name: "Noble", plugin: new NobleCryptoPlugin() },
+  { name: "Web", plugin: new WebCryptoPlugin() },
 ];
 
 const base32 = new ScureBase32Plugin();
@@ -449,6 +453,115 @@ describe("Cross-plugin consistency tests", () => {
             const first = tokens[0];
             for (let i = 1; i < tokens.length; i++) {
               expect(tokens[i]).toBe(first);
+            }
+          },
+        ),
+      );
+    });
+  });
+
+  describe("Algorithm handling agreement across all plugins", () => {
+    // Captures either a synchronous throw or a rejected promise, so plugins
+    // with sync-capable hmac() and async-only hmac() are compared uniformly.
+    async function captureHmac(
+      plugin: CryptoPlugin,
+      algorithm: string,
+      key: Uint8Array,
+      data: Uint8Array,
+    ): Promise<{ ok: true; value: Uint8Array } | { ok: false; error: unknown }> {
+      try {
+        const value = await plugin.hmac(algorithm as HashAlgorithm, key, data);
+        return { ok: true, value };
+      } catch (error) {
+        return { ok: false, error };
+      }
+    }
+
+    it.each(["sha1", "sha256", "sha512"] as const)(
+      "should have every plugin return identical bytes for %s",
+      async (algorithm) => {
+        await fc.assert(
+          fc.asyncProperty(
+            fc.uint8Array({ minLength: 1, maxLength: 64 }),
+            fc.uint8Array({ minLength: 0, maxLength: 256 }),
+            async (key, data) => {
+              const outcomes = await Promise.all(
+                cryptoPlugins.map((p) => captureHmac(p.plugin, algorithm, key, data)),
+              );
+
+              for (let i = 0; i < outcomes.length; i++) {
+                const outcome = outcomes[i];
+                if (!outcome.ok) {
+                  throw new Error(
+                    `${cryptoPlugins[i].name} threw for canonical algorithm "${algorithm}": ${String(outcome.error)}`,
+                  );
+                }
+              }
+
+              const first = outcomes[0] as { ok: true; value: Uint8Array };
+              for (let i = 1; i < outcomes.length; i++) {
+                const current = outcomes[i] as { ok: true; value: Uint8Array };
+                expect({
+                  plugin: cryptoPlugins[i].name,
+                  bytes: Array.from(current.value),
+                }).toEqual({
+                  plugin: cryptoPlugins[i].name,
+                  bytes: Array.from(first.value),
+                });
+              }
+            },
+          ),
+        );
+      },
+    );
+
+    it("should have every plugin reject non-canonical algorithm names identically", async () => {
+      const canonical = ["sha1", "sha256", "sha512"];
+      const nonCanonicalAlgorithm = fc.oneof(
+        fc.constantFrom(
+          "SHA-1",
+          "sha-1",
+          "SHA-256",
+          "sha-256",
+          "SHA-512",
+          "sha-512",
+          "md5",
+          "sha384",
+          "sha3-256",
+          "sha_1",
+          "",
+          " sha1",
+          "sha1 ",
+        ),
+        fc.string({ maxLength: 20 }),
+      );
+
+      await fc.assert(
+        fc.asyncProperty(
+          fc.uint8Array({ minLength: 1, maxLength: 64 }),
+          fc.uint8Array({ minLength: 0, maxLength: 256 }),
+          nonCanonicalAlgorithm.filter((s) => !canonical.includes(s.toLowerCase())),
+          async (key, data, algorithm) => {
+            const outcomes = await Promise.all(
+              cryptoPlugins.map((p) => captureHmac(p.plugin, algorithm, key, data)),
+            );
+
+            // No plugin may be the odd one out: all must reject.
+            const threw = outcomes.map((o) => !o.ok);
+            expect(threw).toEqual(cryptoPlugins.map(() => true));
+
+            for (let i = 0; i < outcomes.length; i++) {
+              const outcome = outcomes[i];
+              if (outcome.ok) {
+                continue;
+              }
+              expect({
+                plugin: cryptoPlugins[i].name,
+                isAlgorithmUnsupported: outcome.error instanceof AlgorithmUnsupportedError,
+              }).toEqual({
+                plugin: cryptoPlugins[i].name,
+                isAlgorithmUnsupported: true,
+              });
             }
           },
         ),

--- a/internal/fuzz-tests/src/cross-plugin.test.ts
+++ b/internal/fuzz-tests/src/cross-plugin.test.ts
@@ -460,7 +460,12 @@ describe("Cross-plugin consistency tests", () => {
     });
   });
 
-  describe("Algorithm handling agreement across all plugins", () => {
+  // Canonical-algorithm byte equality is already covered by the pairwise
+  // "HMAC output consistency" suite above, which now includes Web Crypto. What
+  // is not covered anywhere else is that all plugins reject the *same*
+  // arbitrary inputs with the *same* error class - the divergence this change
+  // exists to fix.
+  describe("Algorithm rejection agreement across all plugins", () => {
     // Captures either a synchronous throw or a rejected promise, so plugins
     // with sync-capable hmac() and async-only hmac() are compared uniformly.
     async function captureHmac(
@@ -476,44 +481,6 @@ describe("Cross-plugin consistency tests", () => {
         return { ok: false, error };
       }
     }
-
-    it.each(["sha1", "sha256", "sha512"] as const)(
-      "should have every plugin return identical bytes for %s",
-      async (algorithm) => {
-        await fc.assert(
-          fc.asyncProperty(
-            fc.uint8Array({ minLength: 1, maxLength: 64 }),
-            fc.uint8Array({ minLength: 0, maxLength: 256 }),
-            async (key, data) => {
-              const outcomes = await Promise.all(
-                cryptoPlugins.map((p) => captureHmac(p.plugin, algorithm, key, data)),
-              );
-
-              for (let i = 0; i < outcomes.length; i++) {
-                const outcome = outcomes[i];
-                if (!outcome.ok) {
-                  throw new Error(
-                    `${cryptoPlugins[i].name} threw for canonical algorithm "${algorithm}": ${String(outcome.error)}`,
-                  );
-                }
-              }
-
-              const first = outcomes[0] as { ok: true; value: Uint8Array };
-              for (let i = 1; i < outcomes.length; i++) {
-                const current = outcomes[i] as { ok: true; value: Uint8Array };
-                expect({
-                  plugin: cryptoPlugins[i].name,
-                  bytes: Array.from(current.value),
-                }).toEqual({
-                  plugin: cryptoPlugins[i].name,
-                  bytes: Array.from(first.value),
-                });
-              }
-            },
-          ),
-        );
-      },
-    );
 
     it("should have every plugin reject unsupported algorithm names identically", async () => {
       // Matches core's normalization: case-insensitive with at most one `-`/`_`

--- a/internal/fuzz-tests/src/cross-plugin.test.ts
+++ b/internal/fuzz-tests/src/cross-plugin.test.ts
@@ -516,11 +516,10 @@ describe("Cross-plugin consistency tests", () => {
     );
 
     it("should have every plugin reject unsupported algorithm names identically", async () => {
-      // Matches core's normalization: case and `-`/`_` are ignored, so a
-      // generated "SHA-1" is a *supported* spelling and must not be fed in here.
-      const canonical = ["sha1", "sha256", "sha512"];
-      const isSupportedSpelling = (s: string) =>
-        canonical.includes(s.toLowerCase().replace(/[-_]/g, ""));
+      // Matches core's normalization: case-insensitive with at most one `-`/`_`
+      // between "sha" and the digest size, so a generated "SHA-1" is a
+      // *supported* spelling and must not be fed in here.
+      const isSupportedSpelling = (s: string) => /^sha[-_]?(1|256|512)$/.test(s.toLowerCase());
 
       const unsupportedAlgorithm = fc.oneof(
         fc.constantFrom(

--- a/internal/fuzz-tests/src/hotp.test.ts
+++ b/internal/fuzz-tests/src/hotp.test.ts
@@ -80,11 +80,7 @@ describe("HOTP fuzz tests", () => {
   });
 
   describe("counter tolerance", () => {
-    // A scalar counterTolerance is look-ahead only ([0, N]): the token's
-    // counter must be at or after the verifier's, never behind it. HOTP
-    // counters only move forward, so accepting past counters would reopen
-    // replay of already-used tokens.
-    it("should verify tokens within the look-ahead window and reject those behind it", async () => {
+    it("should verify tokens within counter tolerance", async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.uint8Array({ minLength: 16, maxLength: 64 }),
@@ -106,10 +102,7 @@ describe("HOTP fuzz tests", () => {
                 counterTolerance: tolerance,
               });
 
-              // The token sits `-offset` steps ahead of the verifier: inside
-              // the window when offset <= 0, behind the verifier when
-              // offset > 0.
-              expect(result.valid).toBe(offset <= 0);
+              expect(result.valid).toBe(true);
               if (result.valid && result.delta !== undefined) {
                 // Handle +0 vs -0 case - both should be treated as "no difference"
                 // Using == 0 check normalizes both -0 and +0
@@ -121,31 +114,6 @@ describe("HOTP fuzz tests", () => {
                 }
               }
             }
-          },
-        ),
-      );
-    });
-
-    it("should verify past counters only with an explicit [past, future] tolerance", async () => {
-      await fc.assert(
-        fc.asyncProperty(
-          fc.uint8Array({ minLength: 16, maxLength: 64 }),
-          fc.integer({ min: 10, max: 1000000 }),
-          fc.integer({ min: 1, max: 10 }),
-          async (secret, counter, tolerance) => {
-            const token = await generate({ secret, counter, crypto, base32 });
-
-            const result = await verify({
-              secret,
-              counter: counter + tolerance,
-              token,
-              crypto,
-              base32,
-              counterTolerance: [tolerance, 0],
-            });
-
-            expect(result.valid).toBe(true);
-            expect(result.delta).toBe(-tolerance);
           },
         ),
       );

--- a/internal/fuzz-tests/src/hotp.test.ts
+++ b/internal/fuzz-tests/src/hotp.test.ts
@@ -80,7 +80,11 @@ describe("HOTP fuzz tests", () => {
   });
 
   describe("counter tolerance", () => {
-    it("should verify tokens within counter tolerance", async () => {
+    // A scalar counterTolerance is look-ahead only ([0, N]): the token's
+    // counter must be at or after the verifier's, never behind it. HOTP
+    // counters only move forward, so accepting past counters would reopen
+    // replay of already-used tokens.
+    it("should verify tokens within the look-ahead window and reject those behind it", async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.uint8Array({ minLength: 16, maxLength: 64 }),
@@ -102,7 +106,10 @@ describe("HOTP fuzz tests", () => {
                 counterTolerance: tolerance,
               });
 
-              expect(result.valid).toBe(true);
+              // The token sits `-offset` steps ahead of the verifier: inside
+              // the window when offset <= 0, behind the verifier when
+              // offset > 0.
+              expect(result.valid).toBe(offset <= 0);
               if (result.valid && result.delta !== undefined) {
                 // Handle +0 vs -0 case - both should be treated as "no difference"
                 // Using == 0 check normalizes both -0 and +0
@@ -114,6 +121,31 @@ describe("HOTP fuzz tests", () => {
                 }
               }
             }
+          },
+        ),
+      );
+    });
+
+    it("should verify past counters only with an explicit [past, future] tolerance", async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.uint8Array({ minLength: 16, maxLength: 64 }),
+          fc.integer({ min: 10, max: 1000000 }),
+          fc.integer({ min: 1, max: 10 }),
+          async (secret, counter, tolerance) => {
+            const token = await generate({ secret, counter, crypto, base32 });
+
+            const result = await verify({
+              secret,
+              counter: counter + tolerance,
+              token,
+              crypto,
+              base32,
+              counterTolerance: [tolerance, 0],
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.delta).toBe(-tolerance);
           },
         ),
       );

--- a/internal/fuzz-tests/src/hotp.test.ts
+++ b/internal/fuzz-tests/src/hotp.test.ts
@@ -80,7 +80,7 @@ describe("HOTP fuzz tests", () => {
   });
 
   describe("counter tolerance", () => {
-    it("should verify tokens within counter tolerance", async () => {
+    it("should verify tokens within symmetric counter tolerance", async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.uint8Array({ minLength: 16, maxLength: 64 }),
@@ -99,7 +99,7 @@ describe("HOTP fuzz tests", () => {
                 token,
                 crypto,
                 base32,
-                counterTolerance: tolerance,
+                counterTolerance: [tolerance, tolerance],
               });
 
               expect(result.valid).toBe(true);

--- a/internal/fuzz-tests/src/uri.test.ts
+++ b/internal/fuzz-tests/src/uri.test.ts
@@ -300,7 +300,7 @@ describe("URI fuzz tests", () => {
 
   describe("parameter validation", () => {
     it("should accept valid algorithm variations and map them to the exact canonical value", () => {
-      // Case and `-`/`_` separators are ignored, because third-party issuers
+      // Case is ignored and a single `-`/`_` is accepted, because issuers
       // emit dashed aliases. Each input must map to its OWN canonical
       // algorithm - never a silent substitution.
       const acceptedAlgorithmCases: { input: string; expected: "sha1" | "sha256" | "sha512" }[] = [

--- a/internal/fuzz-tests/src/uri.test.ts
+++ b/internal/fuzz-tests/src/uri.test.ts
@@ -301,7 +301,7 @@ describe("URI fuzz tests", () => {
   describe("parameter validation", () => {
     it("should accept valid algorithm variations and map them to the exact canonical value", () => {
       // Case and `-`/`_` separators are ignored, because third-party issuers
-      // emit dashed spellings. Each input must resolve to its OWN canonical
+      // emit dashed aliases. Each input must map to its OWN canonical
       // algorithm - never a silent substitution.
       const acceptedAlgorithmCases: { input: string; expected: "sha1" | "sha256" | "sha512" }[] = [
         { input: "SHA1", expected: "sha1" },

--- a/internal/fuzz-tests/src/uri.test.ts
+++ b/internal/fuzz-tests/src/uri.test.ts
@@ -300,9 +300,9 @@ describe("URI fuzz tests", () => {
 
   describe("parameter validation", () => {
     it("should accept valid algorithm variations and map them to the exact canonical value", () => {
-      // URI parsing is deliberately more lenient than core: dashed spellings
-      // are accepted because third-party issuers emit them. Each input must
-      // resolve to its OWN canonical algorithm - never a silent substitution.
+      // Case and `-`/`_` separators are ignored, because third-party issuers
+      // emit dashed spellings. Each input must resolve to its OWN canonical
+      // algorithm - never a silent substitution.
       const acceptedAlgorithmCases: { input: string; expected: "sha1" | "sha256" | "sha512" }[] = [
         { input: "SHA1", expected: "sha1" },
         { input: "sha1", expected: "sha1" },
@@ -338,21 +338,25 @@ describe("URI fuzz tests", () => {
     });
 
     it("should reject algorithm values outside the accepted set", () => {
-      const acceptedNormalized = new Set([
-        "sha1",
-        "sha-1",
-        "sha256",
-        "sha-256",
-        "sha512",
-        "sha-512",
-      ]);
+      const accepted = new Set(["sha1", "sha256", "sha512"]);
+      const isAccepted = (s: string) => accepted.has(s.toLowerCase().replace(/[-_]/g, ""));
 
       const rejectedAlgorithm = fc
         .oneof(
-          fc.constantFrom("md5", "sha3-256", "sha_1", "sha384", "", "sha", "sha-", "sha1234"),
+          fc.constantFrom(
+            "md5",
+            "sha3-256",
+            "sha-384",
+            "sha384",
+            "",
+            "sha",
+            "sha-",
+            "----",
+            "sha1234",
+          ),
           fc.string({ maxLength: 20 }),
         )
-        .filter((s) => !acceptedNormalized.has(s.toLowerCase()));
+        .filter((s) => !isAccepted(s));
 
       fc.assert(
         fc.property(rejectedAlgorithm, (invalidAlgo) => {
@@ -367,7 +371,7 @@ describe("URI fuzz tests", () => {
       await fc.assert(
         fc.asyncProperty(
           fc.string({ minLength: 1, maxLength: 20 }).filter((s) => {
-            const normalized = s.toLowerCase().replace(/-/g, "");
+            const normalized = s.toLowerCase().replace(/[-_]/g, "");
             return !["sha1", "sha256", "sha512"].includes(normalized);
           }),
           async (invalidAlgo) => {

--- a/internal/fuzz-tests/src/uri.test.ts
+++ b/internal/fuzz-tests/src/uri.test.ts
@@ -299,22 +299,67 @@ describe("URI fuzz tests", () => {
   });
 
   describe("parameter validation", () => {
-    it("should accept valid algorithm variations", async () => {
-      await fc.assert(
-        fc.asyncProperty(
-          fc.constantFrom("SHA1", "sha1", "SHA-1", "sha-1", "SHA256", "sha256", "SHA-256"),
-          async (algo) => {
-            const uri = `otpauth://totp/test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${algo}`;
+    it("should accept valid algorithm variations and map them to the exact canonical value", () => {
+      // URI parsing is deliberately more lenient than core: dashed spellings
+      // are accepted because third-party issuers emit them. Each input must
+      // resolve to its OWN canonical algorithm - never a silent substitution.
+      const acceptedAlgorithmCases: { input: string; expected: "sha1" | "sha256" | "sha512" }[] = [
+        { input: "SHA1", expected: "sha1" },
+        { input: "sha1", expected: "sha1" },
+        { input: "Sha1", expected: "sha1" },
+        { input: "sHa1", expected: "sha1" },
+        { input: "SHA-1", expected: "sha1" },
+        { input: "sha-1", expected: "sha1" },
+        { input: "Sha-1", expected: "sha1" },
+        { input: "SHA256", expected: "sha256" },
+        { input: "sha256", expected: "sha256" },
+        { input: "Sha256", expected: "sha256" },
+        { input: "SHA-256", expected: "sha256" },
+        { input: "sha-256", expected: "sha256" },
+        { input: "Sha-256", expected: "sha256" },
+        { input: "SHA512", expected: "sha512" },
+        { input: "sha512", expected: "sha512" },
+        { input: "Sha512", expected: "sha512" },
+        { input: "SHA-512", expected: "sha512" },
+        { input: "sha-512", expected: "sha512" },
+        { input: "Sha-512", expected: "sha512" },
+      ];
 
-            try {
-              const result = parse(uri);
-              expect(result.params.algorithm).toMatch(/^sha(1|256|512)$/);
-            } catch (err) {
-              // Invalid algorithm format throws
-              expect(err).toBeInstanceOf(InvalidParameterError);
-            }
-          },
-        ),
+      fc.assert(
+        fc.property(fc.constantFrom(...acceptedAlgorithmCases), ({ input, expected }) => {
+          const uri = `otpauth://totp/test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${input}`;
+
+          const result = parse(uri);
+
+          expect(result.params.algorithm).toBe(expected);
+        }),
+        { numRuns: 200 },
+      );
+    });
+
+    it("should reject algorithm values outside the accepted set", () => {
+      const acceptedNormalized = new Set([
+        "sha1",
+        "sha-1",
+        "sha256",
+        "sha-256",
+        "sha512",
+        "sha-512",
+      ]);
+
+      const rejectedAlgorithm = fc
+        .oneof(
+          fc.constantFrom("md5", "sha3-256", "sha_1", "sha384", "", "sha", "sha-", "sha1234"),
+          fc.string({ maxLength: 20 }),
+        )
+        .filter((s) => !acceptedNormalized.has(s.toLowerCase()));
+
+      fc.assert(
+        fc.property(rejectedAlgorithm, (invalidAlgo) => {
+          const uri = `otpauth://totp/test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${encodeURIComponent(invalidAlgo)}`;
+
+          expect(() => parse(uri)).toThrow(InvalidParameterError);
+        }),
       );
     });
 

--- a/internal/fuzz-tests/src/uri.test.ts
+++ b/internal/fuzz-tests/src/uri.test.ts
@@ -338,8 +338,7 @@ describe("URI fuzz tests", () => {
     });
 
     it("should reject algorithm values outside the accepted set", () => {
-      const accepted = new Set(["sha1", "sha256", "sha512"]);
-      const isAccepted = (s: string) => accepted.has(s.toLowerCase().replace(/[-_]/g, ""));
+      const isAccepted = (s: string) => /^sha[-_]?(1|256|512)$/.test(s.toLowerCase());
 
       const rejectedAlgorithm = fc
         .oneof(
@@ -370,10 +369,9 @@ describe("URI fuzz tests", () => {
     it("should reject invalid algorithm values", async () => {
       await fc.assert(
         fc.asyncProperty(
-          fc.string({ minLength: 1, maxLength: 20 }).filter((s) => {
-            const normalized = s.toLowerCase().replace(/[-_]/g, "");
-            return !["sha1", "sha256", "sha512"].includes(normalized);
-          }),
+          fc
+            .string({ minLength: 1, maxLength: 20 })
+            .filter((s) => !/^sha[-_]?(1|256|512)$/.test(s.toLowerCase())),
           async (invalidAlgo) => {
             const uri = `otpauth://totp/test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${encodeURIComponent(invalidAlgo)}`;
 

--- a/internal/fuzz-tests/src/uri.test.ts
+++ b/internal/fuzz-tests/src/uri.test.ts
@@ -338,7 +338,8 @@ describe("URI fuzz tests", () => {
     });
 
     it("should reject algorithm values outside the accepted set", () => {
-      const isAccepted = (s: string) => /^sha[-_]?(1|256|512)$/.test(s.toLowerCase());
+      const isAcceptedUriValue = (s: string) =>
+        s === "" || /^sha[-_]?(1|256|512)$/.test(s.toLowerCase());
 
       const rejectedAlgorithm = fc
         .oneof(
@@ -355,7 +356,7 @@ describe("URI fuzz tests", () => {
           ),
           fc.string({ maxLength: 20 }),
         )
-        .filter((s) => !isAccepted(s));
+        .filter((s) => !isAcceptedUriValue(s));
 
       fc.assert(
         fc.property(rejectedAlgorithm, (invalidAlgo) => {

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -11,6 +11,7 @@ import type { TestContext } from "./types.js";
  */
 interface CryptoPluginUnderTest {
   name: string;
+  algorithms?: readonly string[];
   hmac(algorithm: string, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> | Uint8Array;
 }
 
@@ -62,13 +63,22 @@ const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
     " sha1",
     "",
     "----",
-    // Degenerate spellings: only a single separator between "sha" and the
-    // digest size names an algorithm, so these must not be reassembled.
+    // Degenerate spellings: only the exact spellings in core's lookup table
+    // name an algorithm, so these must not be reassembled into one.
     "sha-2-5-6",
     "s-h-a-1",
     "-sha1",
     "sha512-",
     "sha__1",
+    // Inherited property names. A plugin resolving these is looking the
+    // algorithm up in an object literal instead of a prototype-free container,
+    // which hands back a Function rather than throwing.
+    "__proto__",
+    "constructor",
+    "prototype",
+    "toString",
+    "valueOf",
+    "hasOwnProperty",
   ].map((value) => ({ label: `"${value}"`, value })),
   { label: "undefined", value: undefined },
   { label: "null", value: null },
@@ -169,6 +179,24 @@ export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): voi
       it('should never return a 64-byte digest for "sha1"', async () => {
         const digest = await crypto.hmac("sha1", key, data);
         expect(digest).toHaveLength(20);
+      });
+    });
+
+    describe("declared algorithms", () => {
+      // The declaration drives CryptoContext's pre-delegation check, so a
+      // plugin claiming an algorithm it cannot compute would surface as an
+      // HMAC failure rather than a clear rejection.
+      it("should compute every algorithm it declares", async () => {
+        for (const algorithm of crypto.algorithms ?? []) {
+          const digest = await crypto.hmac(algorithm, key, data);
+          expect(digest).toBeInstanceOf(Uint8Array);
+        }
+      });
+
+      it("should declare nothing outside the supported set", () => {
+        for (const algorithm of crypto.algorithms ?? []) {
+          expect(DIGEST_SIZES.map((entry) => entry.algorithm)).toContain(algorithm);
+        }
       });
     });
 

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -1,0 +1,168 @@
+import { RFC_TEST_SECRET } from "./rfc-test-vectors.js";
+import { counterToBytes, stringToBytes } from "./utils.js";
+
+import type { TestContext } from "./types.js";
+
+/**
+ * Minimal interface for a crypto plugin under test
+ *
+ * Declared locally rather than imported from `@otplib/core` so this package
+ * stays dependency-free and can also run against built `dist/` output.
+ */
+interface CryptoPluginUnderTest {
+  name: string;
+  hmac(algorithm: string, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> | Uint8Array;
+}
+
+/**
+ * Digest sizes in bytes for each supported algorithm
+ */
+const DIGEST_SIZES = [
+  { algorithm: "sha1", bytes: 20 },
+  { algorithm: "sha256", bytes: 32 },
+  { algorithm: "sha512", bytes: 64 },
+] as const;
+
+/**
+ * Case variants that must resolve to a canonical algorithm
+ */
+const CASE_VARIANTS = [
+  { input: "SHA1", canonical: "sha1" },
+  { input: "Sha1", canonical: "sha1" },
+  { input: "sHa1", canonical: "sha1" },
+  { input: "SHA256", canonical: "sha256" },
+  { input: "Sha256", canonical: "sha256" },
+  { input: "SHA512", canonical: "sha512" },
+  { input: "Sha512", canonical: "sha512" },
+] as const;
+
+/**
+ * Values that must be rejected
+ *
+ * Separator variants are included deliberately: they are only tolerated when
+ * parsing third-party `otpauth://` URIs, never at the crypto layer.
+ */
+const REJECTED_ALGORITHMS: readonly unknown[] = [
+  "SHA-1",
+  "sha-1",
+  "SHA-256",
+  "sha-512",
+  "sha_1",
+  "sha 1",
+  "md5",
+  "sha3-256",
+  "sha384",
+  "sha1 ",
+  " sha1",
+  "",
+  undefined,
+  null,
+  0,
+  1,
+  {},
+  [],
+  ["sha1"],
+];
+
+/**
+ * Context for the crypto algorithm conformance suite
+ */
+export type CryptoAlgorithmTestContext = TestContext<CryptoPluginUnderTest> & {
+  /**
+   * The `AlgorithmUnsupportedError` class, injected by the caller so this
+   * package does not need to depend on `@otplib/core`.
+   */
+  errorClass: new (...args: any[]) => Error;
+};
+
+/**
+ * Capture the error thrown by an operation
+ *
+ * Works for both synchronous plugins (node, noble) and asynchronous ones
+ * (web), so a single assertion covers all implementations.
+ */
+async function captureError(fn: () => unknown): Promise<unknown> {
+  try {
+    await fn();
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+/**
+ * Shared conformance suite for crypto plugin algorithm handling
+ *
+ * Every crypto plugin must behave identically here. The three plugins
+ * previously hand-rolled their own algorithm dispatch and silently diverged -
+ * `@otplib/plugin-crypto-noble` computed HMAC-SHA512 for any unrecognised
+ * value, producing tokens that never matched other implementations.
+ *
+ * @param ctx - Test context including the plugin and the expected error class
+ *
+ * @example
+ * ```ts
+ * import { describe, it, expect } from "vitest";
+ * import { AlgorithmUnsupportedError } from "@otplib/core";
+ * import { createCryptoAlgorithmTests } from "@repo/testing";
+ * import { NodeCryptoPlugin } from "./index";
+ *
+ * createCryptoAlgorithmTests({
+ *   describe,
+ *   it,
+ *   expect,
+ *   crypto: new NodeCryptoPlugin(),
+ *   errorClass: AlgorithmUnsupportedError,
+ * });
+ * ```
+ */
+export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): void {
+  const { describe, it, expect, crypto, errorClass } = ctx;
+
+  const key = stringToBytes(RFC_TEST_SECRET);
+  const data = counterToBytes(0);
+
+  describe(`${crypto.name} crypto plugin - algorithm handling`, () => {
+    describe("canonical algorithms", () => {
+      for (const { algorithm, bytes } of DIGEST_SIZES) {
+        it(`should produce a ${bytes}-byte digest for "${algorithm}"`, async () => {
+          const digest = await crypto.hmac(algorithm, key, data);
+          expect(digest).toHaveLength(bytes);
+        });
+      }
+
+      // Regression guard for the silent SHA-512 fallback: an unrecognised
+      // algorithm used to fall through to sha512, so sha1 returning 64 bytes
+      // is the exact signature of the bug.
+      it('should never return a 64-byte digest for "sha1"', async () => {
+        const digest = await crypto.hmac("sha1", key, data);
+        expect(digest).toHaveLength(20);
+      });
+    });
+
+    describe("case-insensitive matching", () => {
+      for (const { input, canonical } of CASE_VARIANTS) {
+        // Compares bytes rather than just asserting "did not throw": a plugin
+        // that accepted "SHA1" and quietly computed SHA-512 would pass a
+        // does-not-throw check, which is the bug being guarded against.
+        it(`should treat "${input}" as "${canonical}"`, async () => {
+          const actual = await crypto.hmac(input, key, data);
+          const expected = await crypto.hmac(canonical, key, data);
+          expect(actual).toEqual(expected);
+        });
+      }
+    });
+
+    describe("unsupported algorithms", () => {
+      for (const value of REJECTED_ALGORITHMS) {
+        const label = typeof value === "string" ? `"${value}"` : String(value);
+
+        it(`should throw AlgorithmUnsupportedError for ${label}`, async () => {
+          const error = await captureError(() => crypto.hmac(value as string, key, data));
+
+          expect(error).toBeInstanceOf(errorClass);
+        });
+      }
+    });
+  });
+}

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -27,8 +27,8 @@ const DIGEST_SIZES = [
 /**
  * Aliases that must resolve to a canonical algorithm
  *
- * Case and `-`/`_` separators are ignored, so every entry here maps to the
- * canonical name of the same algorithm.
+ * Case is ignored and a single `-` or `_` before the digest size is accepted,
+ * so every entry here maps to the canonical name of the same algorithm.
  */
 const ALIASES = [
   { input: "SHA1", canonical: "sha1" },

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -42,26 +42,45 @@ const CASE_VARIANTS = [
  * Separator variants are included deliberately: they are only tolerated when
  * parsing third-party `otpauth://` URIs, never at the crypto layer.
  */
-const REJECTED_ALGORITHMS: readonly unknown[] = [
-  "SHA-1",
-  "sha-1",
-  "SHA-256",
-  "sha-512",
-  "sha_1",
-  "sha 1",
-  "md5",
-  "sha3-256",
-  "sha384",
-  "sha1 ",
-  " sha1",
-  "",
-  undefined,
-  null,
-  0,
-  1,
-  {},
-  [],
-  ["sha1"],
+const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
+  ...[
+    "SHA-1",
+    "sha-1",
+    "SHA-256",
+    "sha-512",
+    "sha_1",
+    "sha 1",
+    "md5",
+    "sha3-256",
+    "sha384",
+    "sha1 ",
+    " sha1",
+    "",
+  ].map((value) => ({ label: `"${value}"`, value })),
+  { label: "undefined", value: undefined },
+  { label: "null", value: null },
+  { label: "0", value: 0 },
+  { label: "1", value: 1 },
+  { label: "{}", value: {} },
+  { label: "[]", value: [] },
+  { label: '["sha1"]', value: ["sha1"] },
+
+  // Labels are written out rather than derived via String(), because these
+  // values are precisely the ones String() cannot handle - deriving the label
+  // would throw while collecting the suite.
+  { label: "a null-prototype object", value: Object.create(null) },
+  {
+    label: "an object whose toString throws",
+    value: {
+      toString() {
+        throw new Error("boom");
+      },
+    },
+  },
+  {
+    label: "a boxed string",
+    value: new String("sha1"),
+  },
 ];
 
 /**
@@ -154,9 +173,10 @@ export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): voi
     });
 
     describe("unsupported algorithms", () => {
-      for (const value of REJECTED_ALGORITHMS) {
-        const label = typeof value === "string" ? `"${value}"` : String(value);
-
+      for (const { label, value } of REJECTED_ALGORITHMS) {
+        // Asserts the exact error class, not merely "threw": a plugin that
+        // rejects by crashing on the value (rather than validating it) would
+        // pass a did-it-throw check while breaking the documented contract.
         it(`should throw AlgorithmUnsupportedError for ${label}`, async () => {
           const error = await captureError(() => crypto.hmac(value as string, key, data));
 

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -227,3 +227,76 @@ export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): voi
     });
   });
 }
+
+/**
+ * Context for the restricted-plugin conformance suite
+ */
+export type RestrictedCryptoTestContext = CryptoAlgorithmTestContext & {
+  /**
+   * Wraps a plugin so its calls go through `CryptoContext`, injected by the
+   * caller so this package does not need to depend on `@otplib/core`.
+   */
+  createContext: (plugin: CryptoPluginUnderTest) => {
+    hmac(algorithm: string, key: Uint8Array, data: Uint8Array): Promise<Uint8Array>;
+  };
+};
+
+/**
+ * Conformance suite for a plugin that declares fewer algorithms than the full
+ * set
+ *
+ * `algorithms` is a capability contract rather than advisory metadata: a plugin
+ * declaring `['sha1']` must reject `sha256` whether it is called directly or
+ * through `CryptoContext`. Only the direct path is the plugin's own doing - the
+ * context path proves the declaration is read rather than ignored.
+ *
+ * @param ctx - Test context whose `crypto` declares only `['sha1']`
+ */
+export function createRestrictedCryptoAlgorithmTests(ctx: RestrictedCryptoTestContext): void {
+  const { describe, it, expect, crypto, errorClass, createContext } = ctx;
+
+  const key = stringToBytes(RFC_TEST_SECRET);
+  const data = counterToBytes(0);
+
+  describe(`${crypto.name} crypto plugin - declared capability enforcement`, () => {
+    it("should declare only sha1", () => {
+      expect(crypto.algorithms).toEqual(["sha1"]);
+    });
+
+    describe("the declared algorithm", () => {
+      // The canonical name and its aliases must all still work - narrowing the
+      // set must not also narrow which names resolve to what is left.
+      for (const input of ["sha1", "SHA1", "Sha1", "SHA-1", "sha_1"]) {
+        it(`should compute a 20-byte digest for "${input}" directly`, async () => {
+          expect(await crypto.hmac(input, key, data)).toHaveLength(20);
+        });
+
+        it(`should compute a 20-byte digest for "${input}" through CryptoContext`, async () => {
+          expect(await createContext(crypto).hmac(input, key, data)).toHaveLength(20);
+        });
+      }
+    });
+
+    describe("undeclared algorithms", () => {
+      for (const input of ["sha256", "sha512", "SHA-256", "sha_512"]) {
+        it(`should reject "${input}" when called directly`, async () => {
+          const error = await captureError(() => crypto.hmac(input, key, data));
+
+          expect(error).toBeInstanceOf(errorClass);
+        });
+
+        it(`should reject "${input}" through CryptoContext`, async () => {
+          const error = await captureError(() => createContext(crypto).hmac(input, key, data));
+
+          expect(error).toBeInstanceOf(errorClass);
+        });
+      }
+
+      it("should name only the declared set in the error", async () => {
+        const error = await captureError(() => crypto.hmac("sha256", key, data));
+
+        expect((error as Error).message).toContain("Expected one of: sha1 ");
+      });
+    });
+  });
+}

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -138,7 +138,8 @@ async function captureError(fn: () => unknown): Promise<unknown> {
  * Every crypto plugin must behave identically here. The three plugins
  * previously hand-rolled their own algorithm dispatch and silently diverged -
  * `@otplib/plugin-crypto-noble` computed HMAC-SHA512 for any unrecognised
- * value, producing tokens that never matched other implementations.
+ * value, producing tokens that did not match implementations using the
+ * requested algorithm.
  *
  * @param ctx - Test context including the plugin and the expected error class
  *

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -27,10 +27,10 @@ const DIGEST_SIZES = [
 /**
  * Aliases that must resolve to a canonical algorithm
  *
- * Case and `-`/`_` separators are ignored, so every entry here names the same
- * algorithm as its canonical form.
+ * Case and `-`/`_` separators are ignored, so every entry here maps to the
+ * canonical name of the same algorithm.
  */
-const ALIAS_VARIANTS = [
+const ALIASES = [
   { input: "SHA1", canonical: "sha1" },
   { input: "Sha1", canonical: "sha1" },
   { input: "sHa1", canonical: "sha1" },
@@ -48,8 +48,8 @@ const ALIAS_VARIANTS = [
 /**
  * Values that must be rejected
  *
- * Includes the near misses that make separator stripping safe: `sha3-256` and
- * `sha-384` must not collapse onto a supported algorithm.
+ * Includes the near misses that make the alias table safe: `sha3-256` and
+ * `sha-384` must not map onto a supported algorithm.
  */
 const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
   ...[
@@ -63,8 +63,8 @@ const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
     " sha1",
     "",
     "----",
-    // Degenerate forms: only the exact aliases in core's lookup table name an
-    // algorithm, so these must not be reassembled into one.
+    // Not aliases of anything: only the exact entries in core's lookup table
+    // map to an algorithm, so these must not be assembled into one.
     "sha-2-5-6",
     "s-h-a-1",
     "-sha1",
@@ -200,8 +200,8 @@ export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): voi
       });
     });
 
-    describe("case- and separator-insensitive matching", () => {
-      for (const { input, canonical } of ALIAS_VARIANTS) {
+    describe("alias resolution", () => {
+      for (const { input, canonical } of ALIASES) {
         // Compares bytes rather than just asserting "did not throw": a plugin
         // that accepted "SHA1" and quietly computed SHA-512 would pass a
         // does-not-throw check, which is the bug being guarded against.

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -51,9 +51,25 @@ const SPELLING_VARIANTS = [
  * `sha-384` must not collapse onto a supported algorithm.
  */
 const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
-  ...["md5", "sha3-256", "sha-384", "sha384", "sha-224", "sha 1", "sha1 ", " sha1", "", "----"].map(
-    (value) => ({ label: `"${value}"`, value }),
-  ),
+  ...[
+    "md5",
+    "sha3-256",
+    "sha-384",
+    "sha384",
+    "sha-224",
+    "sha 1",
+    "sha1 ",
+    " sha1",
+    "",
+    "----",
+    // Degenerate spellings: only a single separator between "sha" and the
+    // digest size names an algorithm, so these must not be reassembled.
+    "sha-2-5-6",
+    "s-h-a-1",
+    "-sha1",
+    "sha512-",
+    "sha__1",
+  ].map((value) => ({ label: `"${value}"`, value })),
   { label: "undefined", value: undefined },
   { label: "null", value: null },
   { label: "0", value: 0 },

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -24,9 +24,12 @@ const DIGEST_SIZES = [
 ] as const;
 
 /**
- * Case variants that must resolve to a canonical algorithm
+ * Alternate spellings that must resolve to a canonical algorithm
+ *
+ * Case and `-`/`_` separators are ignored, so every entry here names the same
+ * algorithm as its canonical form.
  */
-const CASE_VARIANTS = [
+const SPELLING_VARIANTS = [
   { input: "SHA1", canonical: "sha1" },
   { input: "Sha1", canonical: "sha1" },
   { input: "sHa1", canonical: "sha1" },
@@ -34,29 +37,23 @@ const CASE_VARIANTS = [
   { input: "Sha256", canonical: "sha256" },
   { input: "SHA512", canonical: "sha512" },
   { input: "Sha512", canonical: "sha512" },
+  { input: "SHA-1", canonical: "sha1" },
+  { input: "sha-1", canonical: "sha1" },
+  { input: "sha_1", canonical: "sha1" },
+  { input: "SHA-256", canonical: "sha256" },
+  { input: "sha-512", canonical: "sha512" },
 ] as const;
 
 /**
  * Values that must be rejected
  *
- * Separator variants are included deliberately: they are only tolerated when
- * parsing third-party `otpauth://` URIs, never at the crypto layer.
+ * Includes the near misses that make separator stripping safe: `sha3-256` and
+ * `sha-384` must not collapse onto a supported algorithm.
  */
 const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
-  ...[
-    "SHA-1",
-    "sha-1",
-    "SHA-256",
-    "sha-512",
-    "sha_1",
-    "sha 1",
-    "md5",
-    "sha3-256",
-    "sha384",
-    "sha1 ",
-    " sha1",
-    "",
-  ].map((value) => ({ label: `"${value}"`, value })),
+  ...["md5", "sha3-256", "sha-384", "sha384", "sha-224", "sha 1", "sha1 ", " sha1", "", "----"].map(
+    (value) => ({ label: `"${value}"`, value }),
+  ),
   { label: "undefined", value: undefined },
   { label: "null", value: null },
   { label: "0", value: 0 },
@@ -159,8 +156,8 @@ export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): voi
       });
     });
 
-    describe("case-insensitive matching", () => {
-      for (const { input, canonical } of CASE_VARIANTS) {
+    describe("case- and separator-insensitive matching", () => {
+      for (const { input, canonical } of SPELLING_VARIANTS) {
         // Compares bytes rather than just asserting "did not throw": a plugin
         // that accepted "SHA1" and quietly computed SHA-512 would pass a
         // does-not-throw check, which is the bug being guarded against.

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -25,12 +25,12 @@ const DIGEST_SIZES = [
 ] as const;
 
 /**
- * Alternate spellings that must resolve to a canonical algorithm
+ * Aliases that must resolve to a canonical algorithm
  *
  * Case and `-`/`_` separators are ignored, so every entry here names the same
  * algorithm as its canonical form.
  */
-const SPELLING_VARIANTS = [
+const ALIAS_VARIANTS = [
   { input: "SHA1", canonical: "sha1" },
   { input: "Sha1", canonical: "sha1" },
   { input: "sHa1", canonical: "sha1" },
@@ -63,8 +63,8 @@ const REJECTED_ALGORITHMS: readonly { label: string; value: unknown }[] = [
     " sha1",
     "",
     "----",
-    // Degenerate spellings: only the exact spellings in core's lookup table
-    // name an algorithm, so these must not be reassembled into one.
+    // Degenerate forms: only the exact aliases in core's lookup table name an
+    // algorithm, so these must not be reassembled into one.
     "sha-2-5-6",
     "s-h-a-1",
     "-sha1",
@@ -201,7 +201,7 @@ export function createCryptoAlgorithmTests(ctx: CryptoAlgorithmTestContext): voi
     });
 
     describe("case- and separator-insensitive matching", () => {
-      for (const { input, canonical } of SPELLING_VARIANTS) {
+      for (const { input, canonical } of ALIAS_VARIANTS) {
         // Compares bytes rather than just asserting "did not throw": a plugin
         // that accepted "SHA1" and quietly computed SHA-512 would pass a
         // does-not-throw check, which is the bug being guarded against.

--- a/internal/testing/src/crypto-algorithm-tests.ts
+++ b/internal/testing/src/crypto-algorithm-tests.ts
@@ -263,6 +263,35 @@ export function createRestrictedCryptoAlgorithmTests(ctx: RestrictedCryptoTestCo
       expect(crypto.algorithms).toEqual(["sha1"]);
     });
 
+    // `readonly` is erased at compile time, so the declaration has to be frozen
+    // to actually hold. An unfrozen array could be pushed to in-process to
+    // broaden what the plugin accepts.
+    describe("immutability of the declaration", () => {
+      it("should expose a frozen array", () => {
+        expect(Object.isFrozen(crypto.algorithms)).toBe(true);
+      });
+
+      it("should not accept a pushed algorithm", () => {
+        expect(() => (crypto.algorithms as unknown as string[]).push("sha256")).toThrow();
+        expect(crypto.algorithms).toEqual(["sha1"]);
+      });
+
+      it("should still reject sha256 after an attempted mutation", async () => {
+        try {
+          (crypto.algorithms as unknown as string[]).push("sha256");
+        } catch {
+          // Frozen, as asserted above - the point is what happens next.
+        }
+
+        expect(await captureError(() => crypto.hmac("sha256", key, data))).toBeInstanceOf(
+          errorClass,
+        );
+        expect(
+          await captureError(() => createContext(crypto).hmac("sha256", key, data)),
+        ).toBeInstanceOf(errorClass);
+      });
+    });
+
     describe("the declared algorithm", () => {
       // The canonical name and its aliases must all still work - narrowing the
       // set must not also narrow which names resolve to what is left.

--- a/internal/testing/src/index.ts
+++ b/internal/testing/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./crypto-algorithm-tests.js";
 export * from "./hooks.js";
 export * from "./rfc-hmac-tests.js";
 export * from "./rfc-test-vectors.js";

--- a/internal/testing/src/rfc-test-vectors.ts
+++ b/internal/testing/src/rfc-test-vectors.ts
@@ -33,6 +33,16 @@ export const RFC_TEST_SECRET = "12345678901234567890";
 export const RFC_TEST_SECRET_HEX = "3132333435363738393031323334353637383930";
 
 /**
+ * Base32 (RFC 4648) encoding of the RFC base secret
+ *
+ * The encoding every public API here accepts by default, so this is the form
+ * needed to drive RFC 6238 vectors through `otplib` rather than through the
+ * lower-level packages. Sits alongside the ASCII and hex forms above because
+ * they are the same 20 bytes in three encodings.
+ */
+export const RFC_TEST_SECRET_BASE32 = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+
+/**
  * RFC 4226 Appendix D - HOTP Test Vectors
  * Secret: "12345678901234567890" in ASCII (20 bytes)
  *

--- a/packages/core/src/crypto-context.test.ts
+++ b/packages/core/src/crypto-context.test.ts
@@ -164,21 +164,32 @@ describe("CryptoContext", () => {
       await expect(context.hmac("sha1", key, data)).rejects.toThrow(HMACError);
     });
 
-    // The context validates against the full set before delegating, so a
-    // narrowed plugin's rejection happens inside the try block. It must escape
-    // as the algorithm error it is, not disguised as an HMAC failure.
-    it("should not rewrap a narrowed plugin's algorithm rejection", async () => {
+    it("should surface a plugin's algorithm restriction when called directly", () => {
+      const plugin = createSha1OnlyPlugin();
+
+      expect(() => plugin.hmac("sha256", stringToBytes("key"), stringToBytes("data"))).toThrow(
+        AlgorithmUnsupportedError,
+      );
+    });
+
+    it("should wrap an undeclared plugin restriction as an HMAC failure", async () => {
       const context = new CryptoContext(createSha1OnlyPlugin());
 
       const key = stringToBytes("key");
       const data = stringToBytes("data");
 
-      await expect(context.hmac("sha256", key, data)).rejects.toThrow(AlgorithmUnsupportedError);
-      await expect(context.hmac("sha256", key, data)).rejects.toThrow("[plugin: sha1-only]");
+      try {
+        await context.hmac("sha256", key, data);
+        expect.unreachable("expected HMAC computation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(HMACError);
+        expect((error as HMACError).cause).toBeInstanceOf(AlgorithmUnsupportedError);
+      }
+
       await expect(context.hmac("sha1", key, data)).resolves.toBeInstanceOf(Uint8Array);
     });
 
-    it("should reject an algorithm a plugin declares it cannot compute", async () => {
+    it("should reject a declared unsupported algorithm before plugin delegation", async () => {
       const plugin = createDeclaredSha1OnlyPlugin();
       const context = new CryptoContext(plugin);
 
@@ -274,6 +285,27 @@ describe("CryptoContext", () => {
       );
     });
 
+    it("should wrap a plugin HMACError with cause preserved", () => {
+      const originalError = new HMACError("Plugin failure");
+      const mockPlugin: CryptoPlugin = {
+        name: "mock",
+        hmac: vi.fn().mockImplementation(() => {
+          throw originalError;
+        }),
+        randomBytes: vi.fn(),
+      };
+      const context = new CryptoContext(mockPlugin);
+
+      try {
+        context.hmacSync("sha1", stringToBytes("key"), stringToBytes("data"));
+        expect.unreachable("expected HMAC computation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(HMACError);
+        expect(error).not.toBe(originalError);
+        expect((error as HMACError).cause).toBe(originalError);
+      }
+    });
+
     it("should throw HMACError with string error message", () => {
       const mockPlugin: CryptoPlugin = {
         name: "mock",
@@ -290,15 +322,31 @@ describe("CryptoContext", () => {
       expect(() => context.hmacSync("sha1", key, data)).toThrow(HMACError);
     });
 
-    it("should not rewrap a narrowed plugin's algorithm rejection", () => {
+    it("should wrap an undeclared plugin restriction as an HMAC failure", () => {
       const context = new CryptoContext(createSha1OnlyPlugin());
 
       const key = stringToBytes("key");
       const data = stringToBytes("data");
 
-      expect(() => context.hmacSync("sha256", key, data)).toThrow(AlgorithmUnsupportedError);
-      expect(() => context.hmacSync("sha256", key, data)).toThrow("[plugin: sha1-only]");
+      try {
+        context.hmacSync("sha256", key, data);
+        expect.unreachable("expected HMAC computation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(HMACError);
+        expect((error as HMACError).cause).toBeInstanceOf(AlgorithmUnsupportedError);
+      }
+
       expect(context.hmacSync("sha1", key, data)).toBeInstanceOf(Uint8Array);
+    });
+
+    it("should reject a declared unsupported algorithm before plugin delegation", () => {
+      const plugin = createDeclaredSha1OnlyPlugin();
+      const context = new CryptoContext(plugin);
+
+      expect(() => context.hmacSync("sha512", stringToBytes("key"), stringToBytes("data"))).toThrow(
+        AlgorithmUnsupportedError,
+      );
+      expect(plugin.hmac).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/crypto-context.test.ts
+++ b/packages/core/src/crypto-context.test.ts
@@ -9,17 +9,31 @@ import type { CryptoPlugin, HashAlgorithm } from "./types.js";
 import { AlgorithmUnsupportedError, HMACError, RandomBytesError } from "./errors.js";
 
 /**
- * A plugin narrowed to sha1 only, the documented use of the `supported`
- * parameter. Its rejection fires inside the context's try block, after the
- * context's own full-set check has passed.
+ * A plugin narrowed to sha1 only that validates internally but does not declare
+ * `algorithms`, so its rejection fires inside the context's try block after the
+ * context's own check has passed.
  */
 function createSha1OnlyPlugin(): CryptoPlugin {
   return {
     name: "sha1-only",
     hmac: (algorithm: HashAlgorithm) => {
-      normalizeHashAlgorithm(algorithm, ["sha1"], "sha1-only");
+      normalizeHashAlgorithm(algorithm, { supported: ["sha1"], plugin: "sha1-only" });
       return stringToBytes("digest");
     },
+    randomBytes: vi.fn(),
+  };
+}
+
+/**
+ * A plugin that declares its narrowed set, so the context can reject an
+ * unsupported algorithm before delegating. `hmac` is a spy with no validation
+ * of its own, which is what lets the tests assert it was never reached.
+ */
+function createDeclaredSha1OnlyPlugin(): CryptoPlugin {
+  return {
+    name: "declared-sha1-only",
+    algorithms: ["sha1"],
+    hmac: vi.fn().mockReturnValue(stringToBytes("digest")),
     randomBytes: vi.fn(),
   };
 }
@@ -162,6 +176,45 @@ describe("CryptoContext", () => {
       await expect(context.hmac("sha256", key, data)).rejects.toThrow(AlgorithmUnsupportedError);
       await expect(context.hmac("sha256", key, data)).rejects.toThrow("[plugin: sha1-only]");
       await expect(context.hmac("sha1", key, data)).resolves.toBeInstanceOf(Uint8Array);
+    });
+
+    it("should reject an algorithm a plugin declares it cannot compute", async () => {
+      const plugin = createDeclaredSha1OnlyPlugin();
+      const context = new CryptoContext(plugin);
+
+      const key = stringToBytes("key");
+      const data = stringToBytes("data");
+
+      await expect(context.hmac("sha512", key, data)).rejects.toThrow(AlgorithmUnsupportedError);
+      // Rejected by the context, so the plugin is never asked.
+      expect(plugin.hmac).not.toHaveBeenCalled();
+
+      await expect(context.hmac("sha1", key, data)).resolves.toBeInstanceOf(Uint8Array);
+      expect(plugin.hmac).toHaveBeenCalledTimes(1);
+    });
+
+    it("should report only the plugin's own set when it declares one", async () => {
+      const context = new CryptoContext(createDeclaredSha1OnlyPlugin());
+
+      await expect(
+        context.hmac("sha512", stringToBytes("key"), stringToBytes("data")),
+      ).rejects.toThrow("Expected one of: sha1 ");
+    });
+
+    // A declaration must never re-enable a digest the library refuses.
+    it("should not let a plugin declaration widen the allowlist", async () => {
+      const plugin: CryptoPlugin = {
+        name: "widened",
+        algorithms: ["md5", "sha1"] as unknown as HashAlgorithm[],
+        hmac: vi.fn().mockReturnValue(stringToBytes("digest")),
+        randomBytes: vi.fn(),
+      };
+      const context = new CryptoContext(plugin);
+
+      await expect(
+        context.hmac("md5" as HashAlgorithm, stringToBytes("key"), stringToBytes("data")),
+      ).rejects.toThrow(AlgorithmUnsupportedError);
+      expect(plugin.hmac).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/crypto-context.test.ts
+++ b/packages/core/src/crypto-context.test.ts
@@ -1,7 +1,28 @@
 import { describe, it, expect, vi } from "vitest";
-import { CryptoContext, createCryptoContext, stringToBytes } from "./index.js";
+import {
+  CryptoContext,
+  createCryptoContext,
+  normalizeHashAlgorithm,
+  stringToBytes,
+} from "./index.js";
 import type { CryptoPlugin, HashAlgorithm } from "./types.js";
-import { HMACError, RandomBytesError } from "./errors.js";
+import { AlgorithmUnsupportedError, HMACError, RandomBytesError } from "./errors.js";
+
+/**
+ * A plugin narrowed to sha1 only, the documented use of the `supported`
+ * parameter. Its rejection fires inside the context's try block, after the
+ * context's own full-set check has passed.
+ */
+function createSha1OnlyPlugin(): CryptoPlugin {
+  return {
+    name: "sha1-only",
+    hmac: (algorithm: HashAlgorithm) => {
+      normalizeHashAlgorithm(algorithm, ["sha1"], "sha1-only");
+      return stringToBytes("digest");
+    },
+    randomBytes: vi.fn(),
+  };
+}
 
 describe("CryptoContext", () => {
   describe("constructor", () => {
@@ -128,6 +149,20 @@ describe("CryptoContext", () => {
 
       await expect(context.hmac("sha1", key, data)).rejects.toThrow(HMACError);
     });
+
+    // The context validates against the full set before delegating, so a
+    // narrowed plugin's rejection happens inside the try block. It must escape
+    // as the algorithm error it is, not disguised as an HMAC failure.
+    it("should not rewrap a narrowed plugin's algorithm rejection", async () => {
+      const context = new CryptoContext(createSha1OnlyPlugin());
+
+      const key = stringToBytes("key");
+      const data = stringToBytes("data");
+
+      await expect(context.hmac("sha256", key, data)).rejects.toThrow(AlgorithmUnsupportedError);
+      await expect(context.hmac("sha256", key, data)).rejects.toThrow("[plugin: sha1-only]");
+      await expect(context.hmac("sha1", key, data)).resolves.toBeInstanceOf(Uint8Array);
+    });
   });
 
   describe("hmacSync", () => {
@@ -200,6 +235,17 @@ describe("CryptoContext", () => {
       const data = stringToBytes("data");
 
       expect(() => context.hmacSync("sha1", key, data)).toThrow(HMACError);
+    });
+
+    it("should not rewrap a narrowed plugin's algorithm rejection", () => {
+      const context = new CryptoContext(createSha1OnlyPlugin());
+
+      const key = stringToBytes("key");
+      const data = stringToBytes("data");
+
+      expect(() => context.hmacSync("sha256", key, data)).toThrow(AlgorithmUnsupportedError);
+      expect(() => context.hmacSync("sha256", key, data)).toThrow("[plugin: sha1-only]");
+      expect(context.hmacSync("sha1", key, data)).toBeInstanceOf(Uint8Array);
     });
   });
 

--- a/packages/core/src/crypto-context.test.ts
+++ b/packages/core/src/crypto-context.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "node:vm";
 import { describe, it, expect, vi } from "vitest";
 import {
   CryptoContext,
@@ -7,6 +8,14 @@ import {
 } from "./index.js";
 import type { CryptoPlugin, HashAlgorithm } from "./types.js";
 import { AlgorithmUnsupportedError, HMACError, RandomBytesError } from "./errors.js";
+
+const foreignPromises = runInNewContext(`({
+  resolve: (value) => Promise.resolve(value),
+  reject: (reason) => Promise.reject(reason),
+})`) as {
+  resolve<T>(value: T): Promise<T>;
+  reject<T = never>(reason: unknown): Promise<T>;
+};
 
 /**
  * A plugin narrowed to sha1 only that validates internally but does not declare
@@ -36,6 +45,14 @@ function createDeclaredSha1OnlyPlugin(): CryptoPlugin {
     hmac: vi.fn().mockReturnValue(stringToBytes("digest")),
     randomBytes: vi.fn(),
   };
+}
+
+function createContextReturning(result: Uint8Array | Promise<Uint8Array>): CryptoContext {
+  return new CryptoContext({
+    name: "async-result",
+    hmac: vi.fn().mockReturnValue(result),
+    randomBytes: vi.fn(),
+  });
 }
 
 describe("CryptoContext", () => {
@@ -86,6 +103,57 @@ describe("CryptoContext", () => {
 
       expect(result).toEqual(mockResult);
       expect(mockPlugin.hmac).toHaveBeenCalledWith("sha256", key, data);
+    });
+
+    it.each([
+      [
+        "thenable",
+        (value: Uint8Array) =>
+          ({
+            then: (resolve: (resolved: Uint8Array) => void) => resolve(value),
+          }) as unknown as Promise<Uint8Array>,
+      ],
+      ["foreign Promise", (value: Uint8Array) => foreignPromises.resolve(value)],
+    ])("should await a resolving %s", async (_name, createResult) => {
+      const mockResult = stringToBytes("test");
+      const asyncResult = createResult(mockResult);
+      expect(asyncResult).not.toBeInstanceOf(Promise);
+
+      await expect(
+        createContextReturning(asyncResult).hmac(
+          "sha1",
+          stringToBytes("key"),
+          stringToBytes("data"),
+        ),
+      ).resolves.toEqual(mockResult);
+    });
+
+    it.each([
+      [
+        "thenable",
+        (reason: unknown) =>
+          ({
+            then: (_resolve: (value: Uint8Array) => void, reject: (rejected: unknown) => void) =>
+              reject(reason),
+          }) as unknown as Promise<Uint8Array>,
+      ],
+      ["foreign Promise", (reason: unknown) => foreignPromises.reject<Uint8Array>(reason)],
+    ])("should wrap a rejecting %s", async (_name, createResult) => {
+      const originalError = new Error("Async rejection");
+      const asyncResult = createResult(originalError);
+      expect(asyncResult).not.toBeInstanceOf(Promise);
+
+      try {
+        await createContextReturning(asyncResult).hmac(
+          "sha1",
+          stringToBytes("key"),
+          stringToBytes("data"),
+        );
+        expect.unreachable("expected HMAC computation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(HMACError);
+        expect((error as HMACError).cause).toBe(originalError);
+      }
     });
 
     it("should support all hash algorithms", async () => {
@@ -290,6 +358,35 @@ describe("CryptoContext", () => {
         expect((error as HMACError).cause).toBeUndefined();
       }
       expect(mockPlugin.hmac).toHaveBeenCalledTimes(1);
+    });
+
+    it("should reject a resolving foreign Promise", () => {
+      const foreignPromise = foreignPromises.resolve(stringToBytes("test"));
+      expect(foreignPromise).not.toBeInstanceOf(Promise);
+      const context = createContextReturning(foreignPromise);
+
+      expect(() => context.hmacSync("sha1", stringToBytes("key"), stringToBytes("data"))).toThrow(
+        "Crypto plugin does not support synchronous HMAC operations",
+      );
+    });
+
+    it("should observe and reject a rejecting thenable", async () => {
+      const originalError = new Error("Thenable rejection");
+      let observed = false;
+      const thenable = {
+        then: (_resolve: (value: Uint8Array) => void, reject: (reason: unknown) => void) => {
+          observed = true;
+          reject(originalError);
+        },
+      } as unknown as Promise<Uint8Array>;
+      const context = createContextReturning(thenable);
+
+      expect(() => context.hmacSync("sha1", stringToBytes("key"), stringToBytes("data"))).toThrow(
+        "Crypto plugin does not support synchronous HMAC operations",
+      );
+
+      await Promise.resolve();
+      expect(observed).toBe(true);
     });
 
     it("should throw HMACError on plugin error", () => {

--- a/packages/core/src/crypto-context.test.ts
+++ b/packages/core/src/crypto-context.test.ts
@@ -148,6 +148,25 @@ describe("CryptoContext", () => {
       );
     });
 
+    it("should wrap a rejected plugin HMACError with cause preserved", async () => {
+      const originalError = new HMACError("Plugin failure");
+      const mockPlugin: CryptoPlugin = {
+        name: "mock",
+        hmac: vi.fn().mockRejectedValue(originalError),
+        randomBytes: vi.fn(),
+      };
+      const context = new CryptoContext(mockPlugin);
+
+      try {
+        await context.hmac("sha1", stringToBytes("key"), stringToBytes("data"));
+        expect.unreachable("expected HMAC computation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(HMACError);
+        expect(error).not.toBe(originalError);
+        expect((error as HMACError).cause).toBe(originalError);
+      }
+    });
+
     it("should throw HMACError with string error message", async () => {
       const mockPlugin: CryptoPlugin = {
         name: "mock",
@@ -260,10 +279,17 @@ describe("CryptoContext", () => {
       const key = stringToBytes("key");
       const data = stringToBytes("data");
 
-      expect(() => context.hmacSync("sha1", key, data)).toThrow(HMACError);
-      expect(() => context.hmacSync("sha1", key, data)).toThrow(
-        "HMAC computation failed: Crypto plugin does not support synchronous HMAC operations",
-      );
+      try {
+        context.hmacSync("sha1", key, data);
+        expect.unreachable("expected synchronous HMAC computation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(HMACError);
+        expect((error as HMACError).message).toBe(
+          "HMAC computation failed: Crypto plugin does not support synchronous HMAC operations",
+        );
+        expect((error as HMACError).cause).toBeUndefined();
+      }
+      expect(mockPlugin.hmac).toHaveBeenCalledTimes(1);
     });
 
     it("should throw HMACError on plugin error", () => {

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -1,4 +1,5 @@
 import { HMACError, RandomBytesError } from "./errors.js";
+import { normalizeHashAlgorithm } from "./utils.js";
 
 import type { CryptoPlugin, HashAlgorithm } from "./types.js";
 
@@ -28,11 +29,16 @@ export class CryptoContext {
    * @param key - The secret key as a byte array
    * @param data - The data to authenticate as a byte array
    * @returns HMAC digest as a byte array
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    * @throws {HMACError} If HMAC computation fails
    */
   async hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
+    // Normalized outside the try so the algorithm error surfaces as-is rather
+    // than being rewrapped as an HMACError.
+    const normalized = normalizeHashAlgorithm(algorithm, undefined, this.crypto.name);
+
     try {
-      const result = this.crypto.hmac(algorithm, key, data);
+      const result = this.crypto.hmac(normalized, key, data);
       return result instanceof Promise ? await result : result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -47,11 +53,14 @@ export class CryptoContext {
    * @param key - The secret key as a byte array
    * @param data - The data to authenticate as a byte array
    * @returns HMAC digest as a byte array
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    * @throws {HMACError} If HMAC computation fails or if crypto plugin doesn't support sync operations
    */
   hmacSync(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
+    const normalized = normalizeHashAlgorithm(algorithm, undefined, this.crypto.name);
+
     try {
-      const result = this.crypto.hmac(algorithm, key, data);
+      const result = this.crypto.hmac(normalized, key, data);
       if (result instanceof Promise) {
         throw new HMACError("Crypto plugin does not support synchronous HMAC operations");
       }

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -23,6 +23,23 @@ export class CryptoContext {
   }
 
   /**
+   * Resolve an algorithm against the plugin's own supported set
+   *
+   * A plugin that declares `algorithms` is rejected here, before delegating,
+   * rather than being left to discover the value it cannot handle.
+   *
+   * @param algorithm - The hash algorithm to resolve
+   * @returns The canonical lowercase algorithm
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
+   */
+  private normalize(algorithm: HashAlgorithm): HashAlgorithm {
+    return normalizeHashAlgorithm(algorithm, {
+      supported: this.crypto.algorithms,
+      plugin: this.crypto.name,
+    });
+  }
+
+  /**
    * Compute HMAC using the configured crypto plugin
    *
    * @param algorithm - The hash algorithm to use
@@ -35,7 +52,7 @@ export class CryptoContext {
   async hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
     // Normalized outside the try so the algorithm error surfaces as-is rather
     // than being rewrapped as an HMACError.
-    const normalized = normalizeHashAlgorithm(algorithm, undefined, this.crypto.name);
+    const normalized = this.normalize(algorithm);
 
     try {
       const result = this.crypto.hmac(normalized, key, data);
@@ -63,7 +80,7 @@ export class CryptoContext {
    * @throws {HMACError} If HMAC computation fails or if crypto plugin doesn't support sync operations
    */
   hmacSync(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
-    const normalized = normalizeHashAlgorithm(algorithm, undefined, this.crypto.name);
+    const normalized = this.normalize(algorithm);
 
     try {
       const result = this.crypto.hmac(normalized, key, data);

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -1,4 +1,4 @@
-import { HMACError, RandomBytesError } from "./errors.js";
+import { AlgorithmError, HMACError, RandomBytesError } from "./errors.js";
 import { normalizeHashAlgorithm } from "./utils.js";
 
 import type { CryptoPlugin, HashAlgorithm } from "./types.js";
@@ -41,6 +41,12 @@ export class CryptoContext {
       const result = this.crypto.hmac(normalized, key, data);
       return result instanceof Promise ? await result : result;
     } catch (error) {
+      // A plugin supporting fewer algorithms than the full set rejects here,
+      // after the context's own check passed. That is still an algorithm
+      // rejection, not an HMAC failure - surface it as-is.
+      if (error instanceof AlgorithmError) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       throw new HMACError(message, { cause: error });
     }
@@ -66,7 +72,7 @@ export class CryptoContext {
       }
       return result;
     } catch (error) {
-      if (error instanceof HMACError) {
+      if (error instanceof HMACError || error instanceof AlgorithmError) {
         throw error;
       }
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -1,4 +1,4 @@
-import { AlgorithmError, HMACError, RandomBytesError } from "./errors.js";
+import { HMACError, RandomBytesError } from "./errors.js";
 import { normalizeHashAlgorithm } from "./utils.js";
 
 import type { CryptoPlugin, HashAlgorithm } from "./types.js";
@@ -58,12 +58,6 @@ export class CryptoContext {
       const result = this.crypto.hmac(normalized, key, data);
       return result instanceof Promise ? await result : result;
     } catch (error) {
-      // Reachable when a plugin narrows its own set without declaring
-      // `algorithms` - the check above passed, so the plugin rejects instead.
-      // That is still an algorithm rejection, not an HMAC failure.
-      if (error instanceof AlgorithmError) {
-        throw error;
-      }
       const message = error instanceof Error ? error.message : String(error);
       throw new HMACError(message, { cause: error });
     }
@@ -82,19 +76,18 @@ export class CryptoContext {
   hmacSync(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
     const normalized = this.normalize(algorithm);
 
+    let result: Uint8Array | Promise<Uint8Array>;
     try {
-      const result = this.crypto.hmac(normalized, key, data);
-      if (result instanceof Promise) {
-        throw new HMACError("Crypto plugin does not support synchronous HMAC operations");
-      }
-      return result;
+      result = this.crypto.hmac(normalized, key, data);
     } catch (error) {
-      if (error instanceof HMACError || error instanceof AlgorithmError) {
-        throw error;
-      }
       const message = error instanceof Error ? error.message : String(error);
       throw new HMACError(message, { cause: error });
     }
+
+    if (result instanceof Promise) {
+      throw new HMACError("Crypto plugin does not support synchronous HMAC operations");
+    }
+    return result;
   }
 
   /**

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -25,8 +25,8 @@ export class CryptoContext {
   /**
    * Resolve an algorithm against the plugin's own supported set
    *
-   * A plugin that declares `algorithms` is rejected here, before delegating,
-   * rather than being left to discover the value it cannot handle.
+   * When a plugin declares `algorithms`, an unsupported value is rejected here
+   * rather than the plugin being left to discover it after delegation.
    *
    * @param algorithm - The hash algorithm to resolve
    * @returns The canonical lowercase algorithm
@@ -58,9 +58,9 @@ export class CryptoContext {
       const result = this.crypto.hmac(normalized, key, data);
       return result instanceof Promise ? await result : result;
     } catch (error) {
-      // A plugin supporting fewer algorithms than the full set rejects here,
-      // after the context's own check passed. That is still an algorithm
-      // rejection, not an HMAC failure - surface it as-is.
+      // Reachable when a plugin narrows its own set without declaring
+      // `algorithms` - the check above passed, so the plugin rejects instead.
+      // That is still an algorithm rejection, not an HMAC failure.
       if (error instanceof AlgorithmError) {
         throw error;
       }

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -79,23 +79,22 @@ export class CryptoContext {
   hmacSync(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
     const normalized = this.normalize(algorithm);
 
-    let result: Uint8Array | Promise<Uint8Array>;
-    let asyncResult: PromiseLike<unknown> | undefined;
     try {
-      result = this.crypto.hmac(normalized, key, data);
-      asyncResult = isPromiseLike(result) ? (result as PromiseLike<unknown>) : undefined;
+      const result = this.crypto.hmac(normalized, key, data);
+
+      if (!isPromiseLike(result)) {
+        return result as Uint8Array;
+      }
+
+      // Attach a rejection handler before throwing the synchronous guard.
+      // Promise.resolve assimilates cross-realm promises and generic thenables.
+      void Promise.resolve(result).catch(() => undefined);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new HMACError(message, { cause: error });
     }
 
-    if (asyncResult) {
-      // Attach a rejection handler before throwing the synchronous guard.
-      // Promise.resolve assimilates cross-realm promises and generic thenables.
-      void Promise.resolve(asyncResult).catch(() => undefined);
-      throw new HMACError("Crypto plugin does not support synchronous HMAC operations");
-    }
-    return result as Uint8Array;
+    throw new HMACError("Crypto plugin does not support synchronous HMAC operations");
   }
 
   /**

--- a/packages/core/src/crypto-context.ts
+++ b/packages/core/src/crypto-context.ts
@@ -3,6 +3,10 @@ import { normalizeHashAlgorithm } from "./utils.js";
 
 import type { CryptoPlugin, HashAlgorithm } from "./types.js";
 
+function isPromiseLike(value: Uint8Array | Promise<Uint8Array>): boolean {
+  return typeof (value as { then?: unknown }).then === "function";
+}
+
 /**
  * CryptoContext provides a unified interface for crypto operations
  * using a pluggable crypto backend
@@ -55,8 +59,7 @@ export class CryptoContext {
     const normalized = this.normalize(algorithm);
 
     try {
-      const result = this.crypto.hmac(normalized, key, data);
-      return result instanceof Promise ? await result : result;
+      return await this.crypto.hmac(normalized, key, data);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new HMACError(message, { cause: error });
@@ -77,17 +80,22 @@ export class CryptoContext {
     const normalized = this.normalize(algorithm);
 
     let result: Uint8Array | Promise<Uint8Array>;
+    let asyncResult: PromiseLike<unknown> | undefined;
     try {
       result = this.crypto.hmac(normalized, key, data);
+      asyncResult = isPromiseLike(result) ? (result as PromiseLike<unknown>) : undefined;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new HMACError(message, { cause: error });
     }
 
-    if (result instanceof Promise) {
+    if (asyncResult) {
+      // Attach a rejection handler before throwing the synchronous guard.
+      // Promise.resolve assimilates cross-realm promises and generic thenables.
+      void Promise.resolve(asyncResult).catch(() => undefined);
       throw new HMACError("Crypto plugin does not support synchronous HMAC operations");
     }
-    return result;
+    return result as Uint8Array;
   }
 
   /**

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -14,6 +14,7 @@ import {
   PeriodTooLargeError,
   DigitsError,
   AlgorithmError,
+  AlgorithmUnsupportedError,
   TokenError,
   TokenLengthError,
   TokenFormatError,
@@ -162,6 +163,47 @@ describe("AlgorithmError", () => {
     expect(error.message).toBe("Invalid algorithm");
     expect(error.name).toBe("AlgorithmError");
     expect(error).toBeInstanceOf(OTPError);
+  });
+});
+
+describe("AlgorithmUnsupportedError", () => {
+  it("should extend AlgorithmError and OTPError", () => {
+    const error = new AlgorithmUnsupportedError("md5");
+    expect(error.name).toBe("AlgorithmUnsupportedError");
+    expect(error).toBeInstanceOf(AlgorithmError);
+    expect(error).toBeInstanceOf(OTPError);
+  });
+
+  it("should quote a string value and list the supported algorithms", () => {
+    const error = new AlgorithmUnsupportedError("md5");
+    expect(error.message).toContain('"md5"');
+    expect(error.message).toContain("sha1, sha256, sha512");
+  });
+
+  it("should render non-string values without quotes", () => {
+    expect(new AlgorithmUnsupportedError(undefined).message).toContain("undefined");
+    expect(new AlgorithmUnsupportedError(null).message).toContain("null");
+    expect(new AlgorithmUnsupportedError(0).message).toContain("0");
+  });
+
+  it("should suggest the canonical form when only separators differ", () => {
+    expect(new AlgorithmUnsupportedError("SHA-1").message).toContain('did you mean "sha1"?');
+    expect(new AlgorithmUnsupportedError("sha_256").message).toContain('did you mean "sha256"?');
+  });
+
+  it("should not suggest anything for an unrelated algorithm", () => {
+    expect(new AlgorithmUnsupportedError("md5").message).not.toContain("did you mean");
+    expect(new AlgorithmUnsupportedError(undefined).message).not.toContain("did you mean");
+  });
+
+  it("should name the plugin when given", () => {
+    const error = new AlgorithmUnsupportedError("md5", { plugin: "noble" });
+    expect(error.message).toContain("[plugin: noble]");
+  });
+
+  it("should list a narrowed supported set", () => {
+    const error = new AlgorithmUnsupportedError("sha512", { supported: ["sha1", "sha256"] });
+    expect(error.message).toContain("Expected one of: sha1, sha256 (case-insensitive)");
   });
 });
 

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -205,6 +205,65 @@ describe("AlgorithmUnsupportedError", () => {
     const error = new AlgorithmUnsupportedError("sha512", { supported: ["sha1", "sha256"] });
     expect(error.message).toContain("Expected one of: sha1, sha256 (case-insensitive)");
   });
+
+  describe("hostile and awkward values", () => {
+    // Constructing the error must never throw: a caller that gets a foreign
+    // error instead of an AlgorithmUnsupportedError cannot handle it, and the
+    // `@throws` contract this class documents would be a lie.
+    it("should not throw for an object with no primitive conversion", () => {
+      const error = new AlgorithmUnsupportedError(Object.create(null));
+
+      expect(error).toBeInstanceOf(AlgorithmUnsupportedError);
+      expect(error.message).toContain("object");
+    });
+
+    it("should not throw for an object whose toString throws", () => {
+      const hostile = {
+        toString() {
+          throw new Error("boom");
+        },
+      };
+
+      const error = new AlgorithmUnsupportedError(hostile);
+
+      expect(error).toBeInstanceOf(AlgorithmUnsupportedError);
+      expect(error.message).not.toContain("boom");
+    });
+
+    it("should not throw for an object whose Symbol.toPrimitive throws", () => {
+      const hostile = {
+        [Symbol.toPrimitive]() {
+          throw new Error("boom");
+        },
+      };
+
+      const error = new AlgorithmUnsupportedError(hostile);
+
+      expect(error).toBeInstanceOf(AlgorithmUnsupportedError);
+      expect(error.message).not.toContain("boom");
+    });
+
+    // Without the type tag this reads "Unsupported hash algorithm: sha1.
+    // Expected one of: sha1, ..." which looks like a library bug.
+    it("should tag a boxed string with its type so the message is not self-contradictory", () => {
+      const error = new AlgorithmUnsupportedError(new String("sha1"));
+
+      expect(error.message).toContain("object (sha1)");
+    });
+
+    it("should truncate an oversized value rather than echoing it whole", () => {
+      const error = new AlgorithmUnsupportedError("x".repeat(5000));
+
+      expect(error.message.length).toBeLessThan(300);
+      expect(error.message).toContain("(5000 characters)");
+    });
+
+    it("should not suggest anything for an oversized value", () => {
+      const error = new AlgorithmUnsupportedError(`sha1${" ".repeat(5000)}`);
+
+      expect(error.message).not.toContain("did you mean");
+    });
+  });
 });
 
 describe("TokenError", () => {

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -186,16 +186,6 @@ describe("AlgorithmUnsupportedError", () => {
     expect(new AlgorithmUnsupportedError(0).message).toContain("0");
   });
 
-  it("should suggest the canonical form when only separators differ", () => {
-    expect(new AlgorithmUnsupportedError("SHA-1").message).toContain('did you mean "sha1"?');
-    expect(new AlgorithmUnsupportedError("sha_256").message).toContain('did you mean "sha256"?');
-  });
-
-  it("should not suggest anything for an unrelated algorithm", () => {
-    expect(new AlgorithmUnsupportedError("md5").message).not.toContain("did you mean");
-    expect(new AlgorithmUnsupportedError(undefined).message).not.toContain("did you mean");
-  });
-
   it("should name the plugin when given", () => {
     const error = new AlgorithmUnsupportedError("md5", { plugin: "noble" });
     expect(error.message).toContain("[plugin: noble]");
@@ -203,7 +193,9 @@ describe("AlgorithmUnsupportedError", () => {
 
   it("should list a narrowed supported set", () => {
     const error = new AlgorithmUnsupportedError("sha512", { supported: ["sha1", "sha256"] });
-    expect(error.message).toContain("Expected one of: sha1, sha256 (case-insensitive)");
+    expect(error.message).toContain(
+      "Expected one of: sha1, sha256 (case-insensitive, separators ignored)",
+    );
   });
 
   describe("hostile and awkward values", () => {
@@ -256,12 +248,6 @@ describe("AlgorithmUnsupportedError", () => {
 
       expect(error.message.length).toBeLessThan(300);
       expect(error.message).toContain("(5000 characters)");
-    });
-
-    it("should not suggest anything for an oversized value", () => {
-      const error = new AlgorithmUnsupportedError(`sha1${" ".repeat(5000)}`);
-
-      expect(error.message).not.toContain("did you mean");
     });
   });
 });

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -194,7 +194,7 @@ describe("AlgorithmUnsupportedError", () => {
   it("should list a narrowed supported set", () => {
     const error = new AlgorithmUnsupportedError("sha512", { supported: ["sha1", "sha256"] });
     expect(error.message).toContain(
-      "Expected one of: sha1, sha256 (case-insensitive, separators ignored)",
+      "Expected one of: sha1, sha256 (case-insensitive, optional '-' or '_')",
     );
   });
 

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -175,9 +175,28 @@ describe("AlgorithmUnsupportedError", () => {
   });
 
   it("should quote a string value and list the supported algorithms", () => {
-    const error = new AlgorithmUnsupportedError("md5");
+    const error = new AlgorithmUnsupportedError("md5", {
+      supported: ["sha1", "sha256", "sha512"],
+    });
     expect(error.message).toContain('"md5"');
     expect(error.message).toContain("sha1, sha256, sha512");
+  });
+
+  // The allowlist lives in utils.ts, which this module cannot import without a
+  // cycle. Rather than restate it here and risk the two drifting, the clause is
+  // dropped when the thrower does not supply one - every thrower in the library
+  // does.
+  it("should omit the expected-set clause when no supported set is given", () => {
+    const error = new AlgorithmUnsupportedError("md5");
+
+    expect(error.message).toBe('Unsupported hash algorithm: "md5".');
+    expect(error.message).not.toContain("Expected one of");
+  });
+
+  it("should render an empty supported set legibly", () => {
+    const error = new AlgorithmUnsupportedError("sha1", { supported: [] });
+
+    expect(error.message).toContain("Expected one of: (none)");
   });
 
   it("should render non-string values without quotes", () => {

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -174,12 +174,12 @@ describe("AlgorithmUnsupportedError", () => {
     expect(error).toBeInstanceOf(OTPError);
   });
 
-  it("should quote a string value and list the supported algorithms", () => {
+  it("should describe the supported algorithms without echoing the rejected value", () => {
     const error = new AlgorithmUnsupportedError("md5", {
       supported: ["sha1", "sha256", "sha512"],
     });
-    expect(error.message).toContain('"md5"');
-    expect(error.message).toContain("sha1, sha256, sha512");
+
+    expect(error.message).toBe("Unsupported hash algorithm. Expected one of: sha1, sha256, sha512");
   });
 
   // The allowlist lives in utils.ts, which this module cannot import without a
@@ -189,7 +189,7 @@ describe("AlgorithmUnsupportedError", () => {
   it("should omit the expected-set clause when no supported set is given", () => {
     const error = new AlgorithmUnsupportedError("md5");
 
-    expect(error.message).toBe('Unsupported hash algorithm: "md5".');
+    expect(error.message).toBe("Unsupported hash algorithm.");
     expect(error.message).not.toContain("Expected one of");
   });
 
@@ -199,75 +199,14 @@ describe("AlgorithmUnsupportedError", () => {
     expect(error.message).toContain("Expected one of: (none)");
   });
 
-  it("should render non-string values without quotes", () => {
-    expect(new AlgorithmUnsupportedError(undefined).message).toContain("undefined");
-    expect(new AlgorithmUnsupportedError(null).message).toContain("null");
-    expect(new AlgorithmUnsupportedError(0).message).toContain("0");
-  });
-
   it("should name the plugin when given", () => {
     const error = new AlgorithmUnsupportedError("md5", { plugin: "noble" });
-    expect(error.message).toContain("[plugin: noble]");
+    expect(error.message).toBe("Unsupported hash algorithm. [plugin: noble]");
   });
 
   it("should list a narrowed supported set", () => {
     const error = new AlgorithmUnsupportedError("sha512", { supported: ["sha1", "sha256"] });
-    expect(error.message).toContain(
-      "Expected one of: sha1, sha256 (case-insensitive, optional '-' or '_')",
-    );
-  });
-
-  describe("hostile and awkward values", () => {
-    // Constructing the error must never throw: a caller that gets a foreign
-    // error instead of an AlgorithmUnsupportedError cannot handle it, and the
-    // `@throws` contract this class documents would be a lie.
-    it("should not throw for an object with no primitive conversion", () => {
-      const error = new AlgorithmUnsupportedError(Object.create(null));
-
-      expect(error).toBeInstanceOf(AlgorithmUnsupportedError);
-      expect(error.message).toContain("object");
-    });
-
-    it("should not throw for an object whose toString throws", () => {
-      const hostile = {
-        toString() {
-          throw new Error("boom");
-        },
-      };
-
-      const error = new AlgorithmUnsupportedError(hostile);
-
-      expect(error).toBeInstanceOf(AlgorithmUnsupportedError);
-      expect(error.message).not.toContain("boom");
-    });
-
-    it("should not throw for an object whose Symbol.toPrimitive throws", () => {
-      const hostile = {
-        [Symbol.toPrimitive]() {
-          throw new Error("boom");
-        },
-      };
-
-      const error = new AlgorithmUnsupportedError(hostile);
-
-      expect(error).toBeInstanceOf(AlgorithmUnsupportedError);
-      expect(error.message).not.toContain("boom");
-    });
-
-    // Without the type tag this reads "Unsupported hash algorithm: sha1.
-    // Expected one of: sha1, ..." which looks like a library bug.
-    it("should tag a boxed string with its type so the message is not self-contradictory", () => {
-      const error = new AlgorithmUnsupportedError(new String("sha1"));
-
-      expect(error.message).toContain("object (sha1)");
-    });
-
-    it("should truncate an oversized value rather than echoing it whole", () => {
-      const error = new AlgorithmUnsupportedError("x".repeat(5000));
-
-      expect(error.message.length).toBeLessThan(300);
-      expect(error.message).toContain("(5000 characters)");
-    });
+    expect(error.message).toBe("Unsupported hash algorithm. Expected one of: sha1, sha256");
   });
 });
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -189,8 +189,11 @@ export type AlgorithmUnsupportedContext = {
   /**
    * The algorithms accepted at the point of failure.
    *
-   * Defaults to the full set. A crypto plugin backed by a restricted
-   * implementation may support fewer.
+   * Supplied by the caller rather than defaulted here: this module has no
+   * business restating the allowlist, and `errors.ts` cannot import it from
+   * `utils.ts` without an import cycle. Every thrower inside the library
+   * passes it. Omitting it drops the "Expected one of" clause rather than
+   * guessing, so the message never names a set the caller did not vouch for.
    */
   supported?: readonly string[];
 
@@ -225,11 +228,13 @@ export type AlgorithmUnsupportedContext = {
  */
 export class AlgorithmUnsupportedError extends AlgorithmError {
   constructor(value: unknown, context: AlgorithmUnsupportedContext = {}) {
-    const { supported = ["sha1", "sha256", "sha512"], plugin } = context;
+    const { supported, plugin } = context;
 
     super(
-      `Unsupported hash algorithm: ${describeAlgorithmValue(value)}. ` +
-        `Expected one of: ${supported.join(", ")} (case-insensitive, optional '-' or '_')` +
+      `Unsupported hash algorithm: ${describeAlgorithmValue(value)}.` +
+        (supported
+          ? ` Expected one of: ${supported.join(", ") || "(none)"} (case-insensitive, optional '-' or '_')`
+          : "") +
         (plugin ? ` [plugin: ${plugin}]` : ""),
     );
     this.name = "AlgorithmUnsupportedError";

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -183,6 +183,75 @@ export class AlgorithmError extends OTPError {
 }
 
 /**
+ * Additional context for {@link AlgorithmUnsupportedError}
+ */
+export type AlgorithmUnsupportedContext = {
+  /**
+   * The algorithms accepted at the point of failure.
+   *
+   * Defaults to the full set. A crypto plugin backed by a restricted
+   * implementation may support fewer.
+   */
+  supported?: readonly string[];
+
+  /**
+   * Name of the crypto plugin that rejected the value, when applicable.
+   */
+  plugin?: string;
+};
+
+/**
+ * Error thrown when a hash algorithm is not recognised
+ *
+ * Algorithms are matched case-insensitively, so `'SHA1'` is accepted as
+ * `'sha1'`. Anything else - including separator variants such as `'SHA-1'` -
+ * is rejected rather than guessed at, because silently substituting a
+ * different algorithm produces tokens that never match other implementations.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   crypto.hmac('SHA-1', key, data);
+ * } catch (error) {
+ *   if (error instanceof AlgorithmUnsupportedError) {
+ *     console.log(error.message);
+ *     // Unsupported hash algorithm: "SHA-1". Expected one of: sha1, sha256,
+ *     // sha512 (case-insensitive) - did you mean "sha1"?
+ *   }
+ * }
+ * ```
+ */
+export class AlgorithmUnsupportedError extends AlgorithmError {
+  constructor(value: unknown, context: AlgorithmUnsupportedContext = {}) {
+    const { supported = ["sha1", "sha256", "sha512"], plugin } = context;
+
+    const received = typeof value === "string" ? `"${value}"` : String(value);
+    const suggestion = typeof value === "string" ? findAlgorithmSuggestion(value, supported) : null;
+
+    super(
+      `Unsupported hash algorithm: ${received}. ` +
+        `Expected one of: ${supported.join(", ")} (case-insensitive)` +
+        (plugin ? ` [plugin: ${plugin}]` : "") +
+        (suggestion ? ` - did you mean "${suggestion}"?` : ""),
+    );
+    this.name = "AlgorithmUnsupportedError";
+  }
+}
+
+/**
+ * Find the supported algorithm a value was probably meant to be
+ *
+ * Only considers separator noise (`SHA-1`, `sha_1`, `sha 1`), so genuinely
+ * unrelated values such as `md5` produce no suggestion.
+ *
+ * @internal
+ */
+function findAlgorithmSuggestion(value: string, supported: readonly string[]): string | null {
+  const stripped = value.toLowerCase().replace(/[-_\s]/g, "");
+  return supported.find((algorithm) => algorithm === stripped) ?? null;
+}
+
+/**
  * Error thrown when token is invalid
  */
 export class TokenError extends OTPError {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -203,20 +203,21 @@ export type AlgorithmUnsupportedContext = {
 /**
  * Error thrown when a hash algorithm is not recognised
  *
- * Algorithms are matched case-insensitively, so `'SHA1'` is accepted as
- * `'sha1'`. Anything else - including separator variants such as `'SHA-1'` -
- * is rejected rather than guessed at, because silently substituting a
- * different algorithm produces tokens that never match other implementations.
+ * Names are matched ignoring case and separators, so `'SHA1'`, `'SHA-1'` and
+ * `'sha_1'` are all accepted as `'sha1'`. A value that is not a spelling of a
+ * supported algorithm is rejected rather than guessed at, because silently
+ * substituting a different algorithm produces tokens that never match other
+ * implementations.
  *
  * @example
  * ```typescript
  * try {
- *   crypto.hmac('SHA-1', key, data);
+ *   crypto.hmac('md5', key, data);
  * } catch (error) {
  *   if (error instanceof AlgorithmUnsupportedError) {
  *     console.log(error.message);
- *     // Unsupported hash algorithm: "SHA-1". Expected one of: sha1, sha256,
- *     // sha512 (case-insensitive) - did you mean "sha1"?
+ *     // Unsupported hash algorithm: "md5". Expected one of: sha1, sha256,
+ *     // sha512 (case-insensitive, separators ignored)
  *   }
  * }
  * ```
@@ -225,14 +226,10 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
   constructor(value: unknown, context: AlgorithmUnsupportedContext = {}) {
     const { supported = ["sha1", "sha256", "sha512"], plugin } = context;
 
-    const received = describeAlgorithmValue(value);
-    const suggestion = typeof value === "string" ? findAlgorithmSuggestion(value, supported) : null;
-
     super(
-      `Unsupported hash algorithm: ${received}. ` +
-        `Expected one of: ${supported.join(", ")} (case-insensitive)` +
-        (plugin ? ` [plugin: ${plugin}]` : "") +
-        (suggestion ? ` - did you mean "${suggestion}"?` : ""),
+      `Unsupported hash algorithm: ${describeAlgorithmValue(value)}. ` +
+        `Expected one of: ${supported.join(", ")} (case-insensitive, separators ignored)` +
+        (plugin ? ` [plugin: ${plugin}]` : ""),
     );
     this.name = "AlgorithmUnsupportedError";
   }
@@ -242,7 +239,7 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
  * Longest rejected value echoed back in an error message
  *
  * The value is caller-supplied and unbounded, while the message it lands in is
- * typically logged. Six characters cover every supported spelling, so anything
+ * typically logged. No supported spelling exceeds seven characters, so anything
  * past this is noise.
  *
  * @internal
@@ -291,25 +288,6 @@ function truncateForMessage(value: string): string {
   }
 
   return `${value.slice(0, MAX_DESCRIBED_VALUE_LENGTH)}... (${value.length} characters)`;
-}
-
-/**
- * Find the supported algorithm a value was probably meant to be
- *
- * Only considers separator noise (`SHA-1`, `sha_1`, `sha 1`), so genuinely
- * unrelated values such as `md5` produce no suggestion.
- *
- * @internal
- */
-function findAlgorithmSuggestion(value: string, supported: readonly string[]): string | null {
-  // No supported spelling survives stripping to more than this, so long values
-  // cannot match and are not worth scanning.
-  if (value.length > MAX_DESCRIBED_VALUE_LENGTH) {
-    return null;
-  }
-
-  const stripped = value.toLowerCase().replace(/[-_\s]/g, "");
-  return supported.find((algorithm) => algorithm === stripped) ?? null;
 }
 
 /**

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -204,7 +204,7 @@ export type AlgorithmUnsupportedContext = {
  * Error thrown when a hash algorithm is not recognised
  *
  * Names are matched ignoring case and separators, so `'SHA1'`, `'SHA-1'` and
- * `'sha_1'` are all accepted as `'sha1'`. A value that is not a spelling of a
+ * `'sha_1'` are all accepted as `'sha1'`. A value that is not an alias of a
  * supported algorithm is rejected rather than guessed at, because silently
  * substituting a different algorithm produces tokens that never match other
  * implementations.
@@ -239,7 +239,7 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
  * Longest rejected value echoed back in an error message
  *
  * The value is caller-supplied and unbounded, while the message it lands in is
- * typically logged. No supported spelling exceeds seven characters, so anything
+ * typically logged. No supported alias exceeds seven characters, so anything
  * past this is noise.
  *
  * @internal

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -204,7 +204,8 @@ export type AlgorithmUnsupportedContext = {
 };
 
 /**
- * Error thrown when a hash algorithm is not recognised
+ * Error thrown when a hash algorithm is not recognised or is outside a
+ * plugin's declared supported set
  *
  * The message identifies the declared supported algorithms and, when
  * applicable, the plugin that rejected the request. It deliberately does not

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -203,7 +203,8 @@ export type AlgorithmUnsupportedContext = {
 /**
  * Error thrown when a hash algorithm is not recognised
  *
- * Names are matched ignoring case and separators, so `'SHA1'`, `'SHA-1'` and
+ * Names are matched ignoring case, with an optional `-` or `_` before the
+ * digest size, so `'SHA1'`, `'SHA-1'` and
  * `'sha_1'` are all accepted as `'sha1'`. A value that is not an alias of a
  * supported algorithm is rejected rather than guessed at, because silently
  * substituting a different algorithm produces tokens that never match other
@@ -217,7 +218,7 @@ export type AlgorithmUnsupportedContext = {
  *   if (error instanceof AlgorithmUnsupportedError) {
  *     console.log(error.message);
  *     // Unsupported hash algorithm: "md5". Expected one of: sha1, sha256,
- *     // sha512 (case-insensitive, separators ignored)
+ *     // sha512 (case-insensitive, optional '-' or '_')
  *   }
  * }
  * ```
@@ -228,7 +229,7 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
 
     super(
       `Unsupported hash algorithm: ${describeAlgorithmValue(value)}. ` +
-        `Expected one of: ${supported.join(", ")} (case-insensitive, separators ignored)` +
+        `Expected one of: ${supported.join(", ")} (case-insensitive, optional '-' or '_')` +
         (plugin ? ` [plugin: ${plugin}]` : ""),
     );
     this.name = "AlgorithmUnsupportedError";

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -225,7 +225,7 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
   constructor(value: unknown, context: AlgorithmUnsupportedContext = {}) {
     const { supported = ["sha1", "sha256", "sha512"], plugin } = context;
 
-    const received = typeof value === "string" ? `"${value}"` : String(value);
+    const received = describeAlgorithmValue(value);
     const suggestion = typeof value === "string" ? findAlgorithmSuggestion(value, supported) : null;
 
     super(
@@ -239,6 +239,61 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
 }
 
 /**
+ * Longest rejected value echoed back in an error message
+ *
+ * The value is caller-supplied and unbounded, while the message it lands in is
+ * typically logged. Six characters cover every supported spelling, so anything
+ * past this is noise.
+ *
+ * @internal
+ */
+const MAX_DESCRIBED_VALUE_LENGTH = 64;
+
+/**
+ * Render a rejected value for an error message
+ *
+ * Constructing an error must never itself throw, or the caller sees a foreign
+ * error instead of the `AlgorithmUnsupportedError` this module documents.
+ * `String(value)` is not safe for that: a null-prototype object throws
+ * `TypeError: Cannot convert object to primitive value`, and a hostile
+ * `toString`/`Symbol.toPrimitive` throws whatever it likes.
+ *
+ * Non-strings are tagged with their type so a boxed `new String('sha1')` does
+ * not produce the self-contradictory `Unsupported hash algorithm: sha1`.
+ *
+ * @internal
+ */
+function describeAlgorithmValue(value: unknown): string {
+  if (typeof value === "string") {
+    return `"${truncateForMessage(value)}"`;
+  }
+
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  try {
+    return `${typeof value} (${truncateForMessage(String(value))})`;
+  } catch {
+    // Unstringifiable - the type alone is all we can safely report.
+    return typeof value;
+  }
+}
+
+/**
+ * Clamp a value echoed into an error message
+ *
+ * @internal
+ */
+function truncateForMessage(value: string): string {
+  if (value.length <= MAX_DESCRIBED_VALUE_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_DESCRIBED_VALUE_LENGTH)}... (${value.length} characters)`;
+}
+
+/**
  * Find the supported algorithm a value was probably meant to be
  *
  * Only considers separator noise (`SHA-1`, `sha_1`, `sha 1`), so genuinely
@@ -247,6 +302,12 @@ export class AlgorithmUnsupportedError extends AlgorithmError {
  * @internal
  */
 function findAlgorithmSuggestion(value: string, supported: readonly string[]): string | null {
+  // No supported spelling survives stripping to more than this, so long values
+  // cannot match and are not worth scanning.
+  if (value.length > MAX_DESCRIBED_VALUE_LENGTH) {
+    return null;
+  }
+
   const stripped = value.toLowerCase().replace(/[-_\s]/g, "");
   return supported.find((algorithm) => algorithm === stripped) ?? null;
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -206,12 +206,10 @@ export type AlgorithmUnsupportedContext = {
 /**
  * Error thrown when a hash algorithm is not recognised
  *
- * Names are matched ignoring case, with an optional `-` or `_` before the
- * digest size, so `'SHA1'`, `'SHA-1'` and
- * `'sha_1'` are all accepted as `'sha1'`. A value that is not an alias of a
- * supported algorithm is rejected rather than guessed at, because silently
- * substituting a different algorithm produces tokens that never match other
- * implementations.
+ * The message identifies the declared supported algorithms and, when
+ * applicable, the plugin that rejected the request. It deliberately does not
+ * render the caller-supplied value; callers should retain that input in their
+ * own error context.
  *
  * @example
  * ```typescript
@@ -220,80 +218,22 @@ export type AlgorithmUnsupportedContext = {
  * } catch (error) {
  *   if (error instanceof AlgorithmUnsupportedError) {
  *     console.log(error.message);
- *     // Unsupported hash algorithm: "md5". Expected one of: sha1, sha256,
- *     // sha512 (case-insensitive, optional '-' or '_')
+ *     // Unsupported hash algorithm. Expected one of: sha1, sha256, sha512
  *   }
  * }
  * ```
  */
 export class AlgorithmUnsupportedError extends AlgorithmError {
-  constructor(value: unknown, context: AlgorithmUnsupportedContext = {}) {
+  constructor(_value: unknown, context: AlgorithmUnsupportedContext = {}) {
     const { supported, plugin } = context;
 
     super(
-      `Unsupported hash algorithm: ${describeAlgorithmValue(value)}.` +
-        (supported
-          ? ` Expected one of: ${supported.join(", ") || "(none)"} (case-insensitive, optional '-' or '_')`
-          : "") +
+      "Unsupported hash algorithm." +
+        (supported ? ` Expected one of: ${supported.join(", ") || "(none)"}` : "") +
         (plugin ? ` [plugin: ${plugin}]` : ""),
     );
     this.name = "AlgorithmUnsupportedError";
   }
-}
-
-/**
- * Longest rejected value echoed back in an error message
- *
- * The value is caller-supplied and unbounded, while the message it lands in is
- * typically logged. No supported alias exceeds seven characters, so anything
- * past this is noise.
- *
- * @internal
- */
-const MAX_DESCRIBED_VALUE_LENGTH = 64;
-
-/**
- * Render a rejected value for an error message
- *
- * Constructing an error must never itself throw, or the caller sees a foreign
- * error instead of the `AlgorithmUnsupportedError` this module documents.
- * `String(value)` is not safe for that: a null-prototype object throws
- * `TypeError: Cannot convert object to primitive value`, and a hostile
- * `toString`/`Symbol.toPrimitive` throws whatever it likes.
- *
- * Non-strings are tagged with their type so a boxed `new String('sha1')` does
- * not produce the self-contradictory `Unsupported hash algorithm: sha1`.
- *
- * @internal
- */
-function describeAlgorithmValue(value: unknown): string {
-  if (typeof value === "string") {
-    return `"${truncateForMessage(value)}"`;
-  }
-
-  if (value === null || value === undefined) {
-    return String(value);
-  }
-
-  try {
-    return `${typeof value} (${truncateForMessage(String(value))})`;
-  } catch {
-    // Unstringifiable - the type alone is all we can safely report.
-    return typeof value;
-  }
-}
-
-/**
- * Clamp a value echoed into an error message
- *
- * @internal
- */
-function truncateForMessage(value: string): string {
-  if (value.length <= MAX_DESCRIBED_VALUE_LENGTH) {
-    return value;
-  }
-
-  return `${value.slice(0, MAX_DESCRIBED_VALUE_LENGTH)}... (${value.length} characters)`;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,8 @@ export {
   PeriodTooLargeError,
   DigitsError,
   AlgorithmError,
+  AlgorithmUnsupportedError,
+  type AlgorithmUnsupportedContext,
   TokenError,
   TokenLengthError,
   TokenFormatError,
@@ -63,6 +65,8 @@ export {
 export {
   createGuardrails,
   hasGuardrailOverrides,
+  HASH_ALGORITHMS,
+  normalizeHashAlgorithm,
   validateSecret,
   validateCounter,
   validateTime,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export {
   hasGuardrailOverrides,
   HASH_ALGORITHMS,
   normalizeHashAlgorithm,
+  type NormalizeHashAlgorithmOptions,
   validateSecret,
   validateCounter,
   validateTime,

--- a/packages/core/src/plugin-factories.test.ts
+++ b/packages/core/src/plugin-factories.test.ts
@@ -1,13 +1,39 @@
 import { describe, it, expect, vi } from "vitest";
+import { createRestrictedCryptoAlgorithmTests } from "@repo/testing";
 import {
   createBase32Plugin,
+  createCryptoContext,
   createCryptoPlugin,
   stringToBytes,
   bytesToString,
+  AlgorithmUnsupportedError,
   Base32DecodeError,
   Base32EncodeError,
 } from "./index.js";
 import type { Base32Plugin, CryptoPlugin, HashAlgorithm } from "./types.js";
+
+/**
+ * A plugin restricted to sha1, built through the documented factory.
+ *
+ * `hmac` deliberately performs no validation of its own: the factory is
+ * responsible for enforcing the declared capability, so any rejection proves
+ * the factory did it rather than the implementation.
+ */
+const sha1OnlyPlugin = createCryptoPlugin({
+  name: "sha1-only",
+  algorithms: ["sha1"],
+  hmac: () => new Uint8Array(20),
+  randomBytes: (length: number) => new Uint8Array(length),
+});
+
+createRestrictedCryptoAlgorithmTests({
+  describe,
+  it,
+  expect,
+  crypto: sha1OnlyPlugin,
+  errorClass: AlgorithmUnsupportedError,
+  createContext: (plugin) => createCryptoContext(plugin as CryptoPlugin),
+});
 
 describe("createBase32Plugin", () => {
   describe("basic functionality", () => {

--- a/packages/core/src/plugin-factories.test.ts
+++ b/packages/core/src/plugin-factories.test.ts
@@ -35,6 +35,55 @@ createRestrictedCryptoAlgorithmTests({
   createContext: (plugin) => createCryptoContext(plugin as CryptoPlugin),
 });
 
+describe("createCryptoPlugin capability immutability", () => {
+  // The factory must not retain the caller's array. Holding it by reference
+  // would let the caller push to their own copy after construction and broaden
+  // a restricted plugin, since `readonly` is erased at compile time.
+  it("should not let the caller broaden capability by mutating the input array", async () => {
+    const callerOwned: HashAlgorithm[] = ["sha1"];
+    const plugin = createCryptoPlugin({
+      name: "sha1-only",
+      algorithms: callerOwned,
+      hmac: () => new Uint8Array(20),
+      randomBytes: (length: number) => new Uint8Array(length),
+    });
+
+    callerOwned.push("sha256");
+
+    expect(plugin.algorithms).toEqual(["sha1"]);
+    expect(() => plugin.hmac("sha256", new Uint8Array(8), new Uint8Array(8))).toThrow(
+      AlgorithmUnsupportedError,
+    );
+    await expect(
+      createCryptoContext(plugin).hmac("sha256", new Uint8Array(8), new Uint8Array(8)),
+    ).rejects.toThrow(AlgorithmUnsupportedError);
+  });
+
+  it("should expose a frozen copy rather than the caller's array", () => {
+    const callerOwned: HashAlgorithm[] = ["sha1"];
+    const plugin = createCryptoPlugin({
+      name: "sha1-only",
+      algorithms: callerOwned,
+      hmac: () => new Uint8Array(20),
+      randomBytes: (length: number) => new Uint8Array(length),
+    });
+
+    expect(plugin.algorithms).not.toBe(callerOwned);
+    expect(Object.isFrozen(plugin.algorithms)).toBe(true);
+  });
+
+  it("should leave an undeclared plugin at the full set", () => {
+    const plugin = createCryptoPlugin({
+      name: "unrestricted",
+      hmac: () => new Uint8Array(20),
+      randomBytes: (length: number) => new Uint8Array(length),
+    });
+
+    expect(plugin.algorithms).toBeUndefined();
+    expect(() => plugin.hmac("sha512", new Uint8Array(8), new Uint8Array(8))).not.toThrow();
+  });
+});
+
 describe("createBase32Plugin", () => {
   describe("basic functionality", () => {
     it("should create a Base32Plugin with custom encode/decode", () => {

--- a/packages/core/src/plugin-factories.ts
+++ b/packages/core/src/plugin-factories.ts
@@ -1,5 +1,5 @@
 import { Base32DecodeError, Base32EncodeError } from "./errors.js";
-import { constantTimeEqual } from "./utils.js";
+import { constantTimeEqual, normalizeHashAlgorithm } from "./utils.js";
 
 import type { Base32EncodeOptions, Base32Plugin, CryptoPlugin, HashAlgorithm } from "./types.js";
 
@@ -33,7 +33,24 @@ export type CreateCryptoPluginOptions = {
   name?: string;
 
   /**
+   * The algorithms this plugin can compute, when it supports fewer than all of
+   * {@link HASH_ALGORITHMS}
+   *
+   * Omit it unless the backing implementation is genuinely restricted - an
+   * absent value means the full set. Declaring it is enforced, not advisory:
+   * the factory rejects an undeclared algorithm before `hmac` is called, so the
+   * implementation below never sees a value it cannot handle.
+   *
+   * This can only narrow. The value is intersected with `HASH_ALGORITHMS`, so
+   * listing a digest outside that set does not enable it.
+   */
+  algorithms?: readonly HashAlgorithm[];
+
+  /**
    * Compute HMAC using the specified hash algorithm
+   *
+   * Receives the canonical lowercase name, already checked against
+   * `algorithms` - no validation is needed here.
    */
   hmac: (
     algorithm: HashAlgorithm,
@@ -107,6 +124,12 @@ export function createBase32Plugin(options: CreateBase32PluginOptions): Base32Pl
  * Use this factory when you need a custom cryptographic implementation
  * that doesn't fit the existing plugins (node, web, noble).
  *
+ * The returned plugin validates the algorithm before delegating, so `hmac`
+ * receives the canonical lowercase name and never has to guess at an
+ * unrecognised one. A plugin declaring `algorithms` is held to that
+ * declaration: anything outside it throws `AlgorithmUnsupportedError`, whether
+ * the plugin is called directly or through `CryptoContext`.
+ *
  * @example
  * ```ts
  * import { createCryptoPlugin } from '@otplib/core';
@@ -114,20 +137,32 @@ export function createBase32Plugin(options: CreateBase32PluginOptions): Base32Pl
  * const customCrypto = createCryptoPlugin({
  *   name: 'my-crypto',
  *   hmac: async (algorithm, key, data) => {
- *     // Custom HMAC implementation
+ *     // Custom HMAC implementation - `algorithm` is already validated
  *   },
  *   randomBytes: (length) => {
  *     // Custom random bytes implementation
  *   },
  * });
+ *
+ * // A plugin backed by a restricted implementation
+ * const sha1Only = createCryptoPlugin({
+ *   name: 'sha1-only',
+ *   algorithms: ['sha1'],
+ *   hmac: (algorithm, key, data) => computeSha1Hmac(key, data),
+ *   randomBytes: (length) => crypto.getRandomValues(new Uint8Array(length)),
+ * });
+ *
+ * sha1Only.hmac('sha256', key, data); // throws AlgorithmUnsupportedError
  * ```
  */
 export function createCryptoPlugin(options: CreateCryptoPluginOptions): CryptoPlugin {
-  const { name = "custom", hmac, randomBytes, constantTimeEqual: cte } = options;
+  const { name = "custom", algorithms, hmac, randomBytes, constantTimeEqual: cte } = options;
 
   return Object.freeze({
     name,
-    hmac,
+    ...(algorithms ? { algorithms } : {}),
+    hmac: (algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array) =>
+      hmac(normalizeHashAlgorithm(algorithm, { supported: algorithms, plugin: name }), key, data),
     randomBytes,
     constantTimeEqual: cte ?? constantTimeEqual,
   });

--- a/packages/core/src/plugin-factories.ts
+++ b/packages/core/src/plugin-factories.ts
@@ -158,11 +158,22 @@ export function createBase32Plugin(options: CreateBase32PluginOptions): Base32Pl
 export function createCryptoPlugin(options: CreateCryptoPluginOptions): CryptoPlugin {
   const { name = "custom", algorithms, hmac, randomBytes, constantTimeEqual: cte } = options;
 
+  // Copied and frozen, never held by reference. `readonly` is erased at compile
+  // time, so retaining the caller's array would let them push to it after
+  // construction and broaden a restricted plugin's capability - and the copy is
+  // what both the declaration and the check below read, so the two cannot
+  // diverge.
+  const supportedAlgorithms = algorithms ? Object.freeze([...algorithms]) : undefined;
+
   return Object.freeze({
     name,
-    ...(algorithms ? { algorithms } : {}),
+    ...(supportedAlgorithms ? { algorithms: supportedAlgorithms } : {}),
     hmac: (algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array) =>
-      hmac(normalizeHashAlgorithm(algorithm, { supported: algorithms, plugin: name }), key, data),
+      hmac(
+        normalizeHashAlgorithm(algorithm, { supported: supportedAlgorithms, plugin: name }),
+        key,
+        data,
+      ),
     randomBytes,
     constantTimeEqual: cte ?? constantTimeEqual,
   });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,8 +106,9 @@ export type CryptoPlugin = {
   /**
    * Compute HMAC using the specified hash algorithm
    *
-   * Implementations must match the algorithm ignoring case and separators
-   * (`'SHA1'`, `'Sha1'` and `'SHA-1'` all mean `'sha1'`) and throw
+   * Implementations must match the algorithm ignoring case, with an optional
+   * `-` or `_` before the digest size (`'SHA1'`, `'Sha1'` and `'SHA-1'` all
+   * mean `'sha1'`), and throw
    * `AlgorithmUnsupportedError` for anything else, rather than falling back to
    * a default. Use `normalizeHashAlgorithm` from this package to get that
    * behaviour for free. If the underlying implementation spells algorithms

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,7 +88,8 @@ export type CryptoPlugin = {
   /**
    * Compute HMAC using the specified hash algorithm
    *
-   * Implementations must match the algorithm case-insensitively and throw
+   * Implementations must match the algorithm ignoring case and separators
+   * (`'SHA1'`, `'Sha1'` and `'SHA-1'` all mean `'sha1'`) and throw
    * `AlgorithmUnsupportedError` for anything else, rather than falling back to
    * a default. Use `normalizeHashAlgorithm` from this package to get that
    * behaviour for free. If the underlying implementation spells algorithms

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,10 +88,18 @@ export type CryptoPlugin = {
   /**
    * Compute HMAC using the specified hash algorithm
    *
+   * Implementations must match the algorithm case-insensitively and throw
+   * `AlgorithmUnsupportedError` for anything else, rather than falling back to
+   * a default. Use `normalizeHashAlgorithm` from this package to get that
+   * behaviour for free. If the underlying implementation spells algorithms
+   * differently (for example Web Crypto's `SHA-1`), map the canonical name
+   * inside the plugin.
+   *
    * @param algorithm - The hash algorithm to use
    * @param key - The secret key as a byte array
    * @param data - The data to authenticate as a byte array
    * @returns HMAC digest as a byte array
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   hmac(
     algorithm: HashAlgorithm,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,6 +86,24 @@ export type CryptoPlugin = {
   readonly name: string;
 
   /**
+   * The algorithms this plugin can compute, when it supports fewer than all of
+   * `HASH_ALGORITHMS`
+   *
+   * Omit it unless the backing implementation is genuinely restricted - an
+   * absent value means the full set. `CryptoContext` reads this to reject an
+   * unsupported algorithm before delegating, rather than leaving the plugin to
+   * discover it.
+   *
+   * This can only narrow. The value is intersected with `HASH_ALGORITHMS`, so
+   * listing a digest outside that set does not enable it.
+   *
+   * Derive it from the plugin's own dispatch map (`Object.keys(HASH_FNS)`)
+   * rather than writing a parallel array, so the two cannot disagree about
+   * what the plugin actually handles.
+   */
+  readonly algorithms?: readonly HashAlgorithm[];
+
+  /**
    * Compute HMAC using the specified hash algorithm
    *
    * Implementations must match the algorithm ignoring case and separators

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -968,13 +968,32 @@ describe("normalizeHashAlgorithm", () => {
       });
     }
 
-    // Only a single separator between "sha" and the digest size is a real
-    // spelling. These name no algorithm at all, so they are reported rather
-    // than reassembled into one.
+    // Only the exact spellings in the lookup table are accepted. These name no
+    // algorithm at all, so they are reported rather than reassembled into one.
     const degenerateSpellings = ["sha-2-5-6", "s-h-a-1", "-sha1", "sha1-", "sha512-", "sha__1"];
 
     for (const value of degenerateSpellings) {
       it(`should reject the degenerate spelling "${value}"`, () => {
+        expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
+      });
+    }
+  });
+
+  // The lookup is a Map precisely so these cannot resolve. An object literal
+  // would hand back inherited members - `normalizeHashAlgorithm('toString')`
+  // returning a Function rather than throwing.
+  describe("inherited property names", () => {
+    const inherited = [
+      "__proto__",
+      "constructor",
+      "prototype",
+      "toString",
+      "valueOf",
+      "hasOwnProperty",
+    ];
+
+    for (const value of inherited) {
+      it(`should reject "${value}"`, () => {
         expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
       });
     }
@@ -1037,27 +1056,51 @@ describe("normalizeHashAlgorithm", () => {
 
   describe("narrowed support", () => {
     it("should reject an algorithm outside the supported set", () => {
-      expect(() => normalizeHashAlgorithm("sha512", ["sha1", "sha256"])).toThrow(
+      expect(() => normalizeHashAlgorithm("sha512", { supported: ["sha1", "sha256"] })).toThrow(
         AlgorithmUnsupportedError,
       );
     });
 
     it("should still case-fold within the supported set", () => {
-      expect(normalizeHashAlgorithm("SHA256", ["sha1", "sha256"])).toBe("sha256");
+      expect(normalizeHashAlgorithm("SHA256", { supported: ["sha1", "sha256"] })).toBe("sha256");
     });
 
-    it("should still strip separators within the supported set", () => {
-      expect(normalizeHashAlgorithm("SHA-256", ["sha1", "sha256"])).toBe("sha256");
+    it("should still accept separator spellings within the supported set", () => {
+      expect(normalizeHashAlgorithm("SHA-256", { supported: ["sha1", "sha256"] })).toBe("sha256");
     });
 
     it("should not let a separator spelling escape the supported set", () => {
-      expect(() => normalizeHashAlgorithm("SHA-512", ["sha1", "sha256"])).toThrow(
+      expect(() => normalizeHashAlgorithm("SHA-512", { supported: ["sha1", "sha256"] })).toThrow(
         AlgorithmUnsupportedError,
       );
     });
 
     it("should name the plugin in the error", () => {
-      expect(() => normalizeHashAlgorithm("md5", undefined, "noble")).toThrow("[plugin: noble]");
+      expect(() => normalizeHashAlgorithm("md5", { plugin: "noble" })).toThrow("[plugin: noble]");
+    });
+
+    it("should list only the narrowed set in the error", () => {
+      expect(() => normalizeHashAlgorithm("sha512", { supported: ["sha1"] })).toThrow(
+        "Expected one of: sha1 ",
+      );
+    });
+
+    // `supported` arrives from crypto plugins, including untyped ones. It is
+    // intersected with HASH_ALGORITHMS so it can only ever narrow - otherwise a
+    // plugin could re-enable a weak digest for anything holding it.
+    it("should not let a plugin widen the allowlist", () => {
+      const widened = ["md5", "sha1"] as unknown as HashAlgorithm[];
+
+      expect(() => normalizeHashAlgorithm("md5", { supported: widened })).toThrow(
+        AlgorithmUnsupportedError,
+      );
+      expect(normalizeHashAlgorithm("sha1", { supported: widened })).toBe("sha1");
+    });
+
+    it("should treat an empty supported set as accepting nothing", () => {
+      expect(() => normalizeHashAlgorithm("sha1", { supported: [] })).toThrow(
+        AlgorithmUnsupportedError,
+      );
     });
   });
 });

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -929,7 +929,7 @@ describe("normalizeHashAlgorithm", () => {
       { input: "SHA256", expected: "sha256" },
       { input: "Sha256", expected: "sha256" },
       { input: "SHA512", expected: "sha512" },
-      { input: "SHA512", expected: "sha512" },
+      { input: "Sha512", expected: "sha512" },
     ] as const;
 
     for (const { input, expected } of variants) {
@@ -958,12 +958,23 @@ describe("normalizeHashAlgorithm", () => {
       });
     }
 
-    // The whole safety argument for stripping separators is that no other
+    // The whole safety argument for tolerating separators is that no other
     // digest collapses onto a supported one. Pin the near misses.
     const nearMisses = ["sha-3-256", "sha3-256", "sha-384", "sha-224", "sha-512-256", "sha-2"];
 
     for (const value of nearMisses) {
       it(`should still reject "${value}"`, () => {
+        expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
+      });
+    }
+
+    // Only a single separator between "sha" and the digest size is a real
+    // spelling. These name no algorithm at all, so they are reported rather
+    // than reassembled into one.
+    const degenerateSpellings = ["sha-2-5-6", "s-h-a-1", "-sha1", "sha1-", "sha512-", "sha__1"];
+
+    for (const value of degenerateSpellings) {
+      it(`should reject the degenerate spelling "${value}"`, () => {
         expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
       });
     }

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1096,7 +1096,7 @@ describe("normalizeHashAlgorithm", () => {
 
     it("should list only the narrowed set in the error", () => {
       expect(() => normalizeHashAlgorithm("sha512", { supported: ["sha1"] })).toThrow(
-        "Expected one of: sha1 ",
+        "Expected one of: sha1",
       );
     });
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -936,8 +936,8 @@ describe("normalizeHashAlgorithm", () => {
     }
   });
 
-  describe("case-insensitive matching", () => {
-    const variants = [
+  describe("case-insensitive aliases", () => {
+    const aliases = [
       { input: "SHA1", expected: "sha1" },
       { input: "Sha1", expected: "sha1" },
       { input: "sHa1", expected: "sha1" },
@@ -947,17 +947,17 @@ describe("normalizeHashAlgorithm", () => {
       { input: "Sha512", expected: "sha512" },
     ] as const;
 
-    for (const { input, expected } of variants) {
-      it(`should normalize "${input}" to "${expected}"`, () => {
+    for (const { input, expected } of aliases) {
+      it(`should map "${input}" to "${expected}"`, () => {
         expect(normalizeHashAlgorithm(input)).toBe(expected);
       });
     }
   });
 
-  describe("separator-insensitive matching", () => {
-    // Every one of these names the same algorithm as its canonical form,
-    // so accepting them cannot silently substitute a different digest.
-    const variants = [
+  describe("separator aliases", () => {
+    // Every one of these is an alias of the canonical name it maps to, so
+    // accepting them cannot silently substitute a different digest.
+    const aliases = [
       { input: "SHA-1", expected: "sha1" },
       { input: "sha-1", expected: "sha1" },
       { input: "sha_1", expected: "sha1" },
@@ -967,8 +967,8 @@ describe("normalizeHashAlgorithm", () => {
       { input: "sha-512", expected: "sha512" },
     ] as const;
 
-    for (const { input, expected } of variants) {
-      it(`should normalize "${input}" to "${expected}"`, () => {
+    for (const { input, expected } of aliases) {
+      it(`should map "${input}" to "${expected}"`, () => {
         expect(normalizeHashAlgorithm(input)).toBe(expected);
       });
     }
@@ -983,12 +983,12 @@ describe("normalizeHashAlgorithm", () => {
       });
     }
 
-    // Only the exact aliases in the lookup table are accepted. These name no
-    // algorithm at all, so they are reported rather than reassembled into one.
-    const degenerateAliases = ["sha-2-5-6", "s-h-a-1", "-sha1", "sha1-", "sha512-", "sha__1"];
+    // Only the exact aliases in the lookup table are accepted. These are not
+    // aliases of anything, so they are reported rather than assembled into one.
+    const notAliases = ["sha-2-5-6", "s-h-a-1", "-sha1", "sha1-", "sha512-", "sha__1"];
 
-    for (const value of degenerateAliases) {
-      it(`should reject the degenerate form "${value}"`, () => {
+    for (const value of notAliases) {
+      it(`should reject "${value}"`, () => {
         expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
       });
     }

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -910,6 +910,21 @@ describe("HASH_ALGORITHMS", () => {
     expect(HASH_ALGORITHMS).toEqual(["sha1", "sha256", "sha512"]);
     expect(() => normalizeHashAlgorithm("md5")).toThrow(AlgorithmUnsupportedError);
   });
+
+  // Derived from the alias table rather than written out again. This array is
+  // both the default `supported` set and the intersection base, so an algorithm
+  // present in the table but missing here would be rejected at runtime while
+  // type-checking everywhere.
+  it("should contain exactly the algorithms that have aliases", () => {
+    for (const algorithm of HASH_ALGORITHMS) {
+      expect(normalizeHashAlgorithm(algorithm)).toBe(algorithm);
+      expect(normalizeHashAlgorithm(algorithm.replace("sha", "sha-"))).toBe(algorithm);
+    }
+  });
+
+  it("should list each algorithm exactly once", () => {
+    expect(new Set(HASH_ALGORITHMS).size).toBe(HASH_ALGORITHMS.length);
+  });
 });
 
 describe("normalizeHashAlgorithm", () => {
@@ -940,7 +955,7 @@ describe("normalizeHashAlgorithm", () => {
   });
 
   describe("separator-insensitive matching", () => {
-    // Every one of these names the same algorithm as its canonical spelling,
+    // Every one of these names the same algorithm as its canonical form,
     // so accepting them cannot silently substitute a different digest.
     const variants = [
       { input: "SHA-1", expected: "sha1" },
@@ -968,12 +983,12 @@ describe("normalizeHashAlgorithm", () => {
       });
     }
 
-    // Only the exact spellings in the lookup table are accepted. These name no
+    // Only the exact aliases in the lookup table are accepted. These name no
     // algorithm at all, so they are reported rather than reassembled into one.
-    const degenerateSpellings = ["sha-2-5-6", "s-h-a-1", "-sha1", "sha1-", "sha512-", "sha__1"];
+    const degenerateAliases = ["sha-2-5-6", "s-h-a-1", "-sha1", "sha1-", "sha512-", "sha__1"];
 
-    for (const value of degenerateSpellings) {
-      it(`should reject the degenerate spelling "${value}"`, () => {
+    for (const value of degenerateAliases) {
+      it(`should reject the degenerate form "${value}"`, () => {
         expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
       });
     }
@@ -1065,11 +1080,11 @@ describe("normalizeHashAlgorithm", () => {
       expect(normalizeHashAlgorithm("SHA256", { supported: ["sha1", "sha256"] })).toBe("sha256");
     });
 
-    it("should still accept separator spellings within the supported set", () => {
+    it("should still accept separator aliases within the supported set", () => {
       expect(normalizeHashAlgorithm("SHA-256", { supported: ["sha1", "sha256"] })).toBe("sha256");
     });
 
-    it("should not let a separator spelling escape the supported set", () => {
+    it("should not let a separator alias escape the supported set", () => {
       expect(() => normalizeHashAlgorithm("SHA-512", { supported: ["sha1", "sha256"] })).toThrow(
         AlgorithmUnsupportedError,
       );

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -37,8 +37,11 @@ import {
   requireBase32String,
   wrapResult,
   wrapResultAsync,
+  HASH_ALGORITHMS,
+  normalizeHashAlgorithm,
   type OTPGuardrails,
 } from "./utils.js";
+import type { HashAlgorithm } from "./types.js";
 import {
   OTPError,
   SecretTooShortError,
@@ -65,6 +68,7 @@ import {
   LabelMissingError,
   IssuerMissingError,
   SecretTypeError,
+  AlgorithmUnsupportedError,
 } from "./errors.js";
 
 describe("Constants", () => {
@@ -882,6 +886,97 @@ describe("getDigestSize", () => {
 
   it("should return correct size for SHA-512", () => {
     expect(getDigestSize("sha512")).toBe(64);
+  });
+
+  it("should throw for an unsupported algorithm", () => {
+    // Typed as HashAlgorithm, but untyped JS callers can still reach here.
+    expect(() => getDigestSize("md5" as HashAlgorithm)).toThrow(AlgorithmUnsupportedError);
+  });
+});
+
+describe("HASH_ALGORITHMS", () => {
+  it("should list the supported algorithms", () => {
+    expect(HASH_ALGORITHMS).toEqual(["sha1", "sha256", "sha512"]);
+  });
+});
+
+describe("normalizeHashAlgorithm", () => {
+  describe("canonical values", () => {
+    for (const algorithm of HASH_ALGORITHMS) {
+      it(`should pass through "${algorithm}"`, () => {
+        expect(normalizeHashAlgorithm(algorithm)).toBe(algorithm);
+      });
+    }
+  });
+
+  describe("case-insensitive matching", () => {
+    const variants = [
+      { input: "SHA1", expected: "sha1" },
+      { input: "Sha1", expected: "sha1" },
+      { input: "sHa1", expected: "sha1" },
+      { input: "SHA256", expected: "sha256" },
+      { input: "Sha256", expected: "sha256" },
+      { input: "SHA512", expected: "sha512" },
+      { input: "SHA512", expected: "sha512" },
+    ] as const;
+
+    for (const { input, expected } of variants) {
+      it(`should normalize "${input}" to "${expected}"`, () => {
+        expect(normalizeHashAlgorithm(input)).toBe(expected);
+      });
+    }
+  });
+
+  describe("rejected values", () => {
+    // Separator variants are rejected here on purpose. They are tolerated only
+    // when parsing third-party otpauth:// URIs (see @otplib/uri).
+    const rejected = [
+      "SHA-1",
+      "sha-1",
+      "sha-256",
+      "sha-512",
+      "sha_1",
+      "sha 1",
+      "md5",
+      "sha3-256",
+      "sha384",
+      "sha1 ",
+      " sha1",
+      "",
+      undefined,
+      null,
+      0,
+      1,
+      true,
+      {},
+      [],
+      ["sha1"],
+      Symbol("sha1"),
+    ];
+
+    for (const value of rejected) {
+      const label = typeof value === "string" ? `"${value}"` : String(value);
+
+      it(`should throw for ${label}`, () => {
+        expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
+      });
+    }
+  });
+
+  describe("narrowed support", () => {
+    it("should reject an algorithm outside the supported set", () => {
+      expect(() => normalizeHashAlgorithm("sha512", ["sha1", "sha256"])).toThrow(
+        AlgorithmUnsupportedError,
+      );
+    });
+
+    it("should still case-fold within the supported set", () => {
+      expect(normalizeHashAlgorithm("SHA256", ["sha1", "sha256"])).toBe("sha256");
+    });
+
+    it("should name the plugin in the error", () => {
+      expect(() => normalizeHashAlgorithm("md5", undefined, "noble")).toThrow("[plugin: noble]");
+    });
   });
 });
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -973,8 +973,8 @@ describe("normalizeHashAlgorithm", () => {
       });
     }
 
-    // The whole safety argument for tolerating separators is that no other
-    // digest collapses onto a supported one. Pin the near misses.
+    // The whole safety argument for accepting separator aliases is that no
+    // other digest has one. Pin the near misses.
     const nearMisses = ["sha-3-256", "sha3-256", "sha-384", "sha-224", "sha-512-256", "sha-2"];
 
     for (const value of nearMisses) {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -900,7 +900,7 @@ describe("HASH_ALGORITHMS", () => {
   });
 
   // This array is the runtime allowlist, not just a type-level constant, so a
-  // mutation here would re-enable a weak digest for every caller in the process.
+  // mutation here would corrupt validation policy for every caller in the process.
   it("should be frozen", () => {
     expect(Object.isFrozen(HASH_ALGORITHMS)).toBe(true);
   });
@@ -1102,7 +1102,7 @@ describe("normalizeHashAlgorithm", () => {
 
     // `supported` arrives from crypto plugins, including untyped ones. It is
     // intersected with HASH_ALGORITHMS so it can only ever narrow - otherwise a
-    // plugin could re-enable a weak digest for anything holding it.
+    // plugin could widen the library allowlist for anything holding it.
     it("should not let a plugin widen the allowlist", () => {
       const widened = ["md5", "sha1"] as unknown as HashAlgorithm[];
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -898,6 +898,18 @@ describe("HASH_ALGORITHMS", () => {
   it("should list the supported algorithms", () => {
     expect(HASH_ALGORITHMS).toEqual(["sha1", "sha256", "sha512"]);
   });
+
+  // This array is the runtime allowlist, not just a type-level constant, so a
+  // mutation here would re-enable a weak digest for every caller in the process.
+  it("should be frozen", () => {
+    expect(Object.isFrozen(HASH_ALGORITHMS)).toBe(true);
+  });
+
+  it("should not accept a pushed algorithm", () => {
+    expect(() => (HASH_ALGORITHMS as unknown as string[]).push("md5")).toThrow();
+    expect(HASH_ALGORITHMS).toEqual(["sha1", "sha256", "sha512"]);
+    expect(() => normalizeHashAlgorithm("md5")).toThrow(AlgorithmUnsupportedError);
+  });
 });
 
 describe("normalizeHashAlgorithm", () => {
@@ -961,6 +973,29 @@ describe("normalizeHashAlgorithm", () => {
         expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
       });
     }
+  });
+
+  describe("hostile values", () => {
+    // These must surface as AlgorithmUnsupportedError, not as a TypeError from
+    // stringifying the value. CryptoContext normalizes outside its try block,
+    // so a foreign error here escapes unwrapped to the caller.
+    it("should reject an object with no primitive conversion", () => {
+      expect(() => normalizeHashAlgorithm(Object.create(null))).toThrow(AlgorithmUnsupportedError);
+    });
+
+    it("should reject an object whose toString throws", () => {
+      const hostile = {
+        toString() {
+          throw new Error("boom");
+        },
+      };
+
+      expect(() => normalizeHashAlgorithm(hostile)).toThrow(AlgorithmUnsupportedError);
+    });
+
+    it("should reject a boxed string", () => {
+      expect(() => normalizeHashAlgorithm(new String("sha1"))).toThrow(AlgorithmUnsupportedError);
+    });
   });
 
   describe("narrowed support", () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -939,21 +939,47 @@ describe("normalizeHashAlgorithm", () => {
     }
   });
 
+  describe("separator-insensitive matching", () => {
+    // Every one of these names the same algorithm as its canonical spelling,
+    // so accepting them cannot silently substitute a different digest.
+    const variants = [
+      { input: "SHA-1", expected: "sha1" },
+      { input: "sha-1", expected: "sha1" },
+      { input: "sha_1", expected: "sha1" },
+      { input: "SHA-256", expected: "sha256" },
+      { input: "sha-256", expected: "sha256" },
+      { input: "SHA-512", expected: "sha512" },
+      { input: "sha-512", expected: "sha512" },
+    ] as const;
+
+    for (const { input, expected } of variants) {
+      it(`should normalize "${input}" to "${expected}"`, () => {
+        expect(normalizeHashAlgorithm(input)).toBe(expected);
+      });
+    }
+
+    // The whole safety argument for stripping separators is that no other
+    // digest collapses onto a supported one. Pin the near misses.
+    const nearMisses = ["sha-3-256", "sha3-256", "sha-384", "sha-224", "sha-512-256", "sha-2"];
+
+    for (const value of nearMisses) {
+      it(`should still reject "${value}"`, () => {
+        expect(() => normalizeHashAlgorithm(value)).toThrow(AlgorithmUnsupportedError);
+      });
+    }
+  });
+
   describe("rejected values", () => {
-    // Separator variants are rejected here on purpose. They are tolerated only
-    // when parsing third-party otpauth:// URIs (see @otplib/uri).
+    // Whitespace is not a separator: it is never part of an identifier, so it
+    // is reported rather than swallowed.
     const rejected = [
-      "SHA-1",
-      "sha-1",
-      "sha-256",
-      "sha-512",
-      "sha_1",
       "sha 1",
       "md5",
       "sha3-256",
       "sha384",
       "sha1 ",
       " sha1",
+      "----",
       "",
       undefined,
       null,
@@ -1007,6 +1033,16 @@ describe("normalizeHashAlgorithm", () => {
 
     it("should still case-fold within the supported set", () => {
       expect(normalizeHashAlgorithm("SHA256", ["sha1", "sha256"])).toBe("sha256");
+    });
+
+    it("should still strip separators within the supported set", () => {
+      expect(normalizeHashAlgorithm("SHA-256", ["sha1", "sha256"])).toBe("sha256");
+    });
+
+    it("should not let a separator spelling escape the supported set", () => {
+      expect(() => normalizeHashAlgorithm("SHA-512", ["sha1", "sha256"])).toThrow(
+        AlgorithmUnsupportedError,
+      );
     });
 
     it("should name the plugin in the error", () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1112,10 +1112,41 @@ describe("normalizeHashAlgorithm", () => {
       expect(normalizeHashAlgorithm("sha1", { supported: widened })).toBe("sha1");
     });
 
-    it("should treat an empty supported set as accepting nothing", () => {
-      expect(() => normalizeHashAlgorithm("sha1", { supported: [] })).toThrow(
-        AlgorithmUnsupportedError,
-      );
+    // Omitted and empty are different declarations and must stay that way.
+    // Omitted is the backward-compatible reading for a plugin written before
+    // `algorithms` existed; empty is a plugin declaring it supports nothing.
+    describe("omitted versus explicitly empty", () => {
+      for (const algorithm of HASH_ALGORITHMS) {
+        it(`should accept "${algorithm}" when supported is omitted`, () => {
+          expect(normalizeHashAlgorithm(algorithm)).toBe(algorithm);
+          expect(normalizeHashAlgorithm(algorithm, {})).toBe(algorithm);
+          expect(normalizeHashAlgorithm(algorithm, { supported: undefined })).toBe(algorithm);
+        });
+
+        it(`should reject "${algorithm}" when supported is empty`, () => {
+          expect(() => normalizeHashAlgorithm(algorithm, { supported: [] })).toThrow(
+            AlgorithmUnsupportedError,
+          );
+        });
+
+        it(`should reject "${algorithm}" unless a restricted set names it`, () => {
+          const restricted: HashAlgorithm[] = ["sha256"];
+
+          if (algorithm === "sha256") {
+            expect(normalizeHashAlgorithm(algorithm, { supported: restricted })).toBe(algorithm);
+          } else {
+            expect(() => normalizeHashAlgorithm(algorithm, { supported: restricted })).toThrow(
+              AlgorithmUnsupportedError,
+            );
+          }
+        });
+      }
+
+      // An empty set has nothing to list, so the message must not read
+      // "Expected one of: " with nothing after it.
+      it("should render an empty supported set legibly", () => {
+        expect(() => normalizeHashAlgorithm("sha1", { supported: [] })).toThrow("(none)");
+      });
     });
   });
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -24,6 +24,7 @@ import {
   LabelMissingError,
   IssuerMissingError,
   SecretTypeError,
+  AlgorithmUnsupportedError,
 } from "./errors.js";
 
 import type {
@@ -303,6 +304,53 @@ export function createGuardrails(custom?: Partial<OTPGuardrailsConfig>): OTPGuar
  */
 export function hasGuardrailOverrides(guardrails: OTPGuardrails): boolean {
   return guardrails[OVERRIDE_SYMBOL] ?? false;
+}
+
+/**
+ * The hash algorithms supported for HMAC operations
+ */
+export const HASH_ALGORITHMS = ["sha1", "sha256", "sha512"] as const;
+
+/**
+ * Normalize and validate a hash algorithm
+ *
+ * Matching is case-insensitive, so `'SHA1'` and `'Sha1'` both resolve to
+ * `'sha1'`. Everything else is rejected - including separator variants such as
+ * `'SHA-1'`, which are only tolerated when parsing third-party `otpauth://`
+ * URIs (see `@otplib/uri`).
+ *
+ * Rejecting rather than guessing is deliberate: substituting a different
+ * algorithm produces self-consistent tokens that never match any other
+ * implementation, which fails silently at enrollment time.
+ *
+ * @param value - The algorithm to normalize
+ * @param supported - Accepted algorithms (defaults to all of {@link HASH_ALGORITHMS})
+ * @param plugin - Name of the calling crypto plugin, used to enrich the error message
+ * @returns The canonical lowercase algorithm
+ * @throws {AlgorithmUnsupportedError} If the value is not a supported algorithm
+ *
+ * @example
+ * ```typescript
+ * normalizeHashAlgorithm('SHA1');   // 'sha1'
+ * normalizeHashAlgorithm('SHA-1');  // throws AlgorithmUnsupportedError
+ * ```
+ */
+export function normalizeHashAlgorithm(
+  value: unknown,
+  supported: readonly HashAlgorithm[] = HASH_ALGORITHMS,
+  plugin?: string,
+): HashAlgorithm {
+  if (typeof value !== "string") {
+    throw new AlgorithmUnsupportedError(value, { supported, plugin });
+  }
+
+  const normalized = value.toLowerCase() as HashAlgorithm;
+
+  if (!supported.includes(normalized)) {
+    throw new AlgorithmUnsupportedError(value, { supported, plugin });
+  }
+
+  return normalized;
 }
 
 /**
@@ -618,6 +666,7 @@ export function constantTimeEqual(a: string | Uint8Array, b: string | Uint8Array
  *
  * @param algorithm - The hash algorithm
  * @returns Digest size in bytes
+ * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
  */
 export function getDigestSize(algorithm: HashAlgorithm): number {
   switch (algorithm) {
@@ -627,6 +676,8 @@ export function getDigestSize(algorithm: HashAlgorithm): number {
       return 32;
     case "sha512":
       return 64;
+    default:
+      throw new AlgorithmUnsupportedError(algorithm);
   }
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -336,7 +336,7 @@ const HASH_ALGORITHM_ALIASES = {
 /**
  * The hash algorithms supported for HMAC operations
  *
- * Derived from {@link HASH_ALGORITHM_ALIASES} rather than written out again, so
+ * Derived from `HASH_ALGORITHM_ALIASES` rather than written out again, so
  * the runtime allowlist cannot disagree with the names that resolve to it. That
  * matters because this array is both the default `supported` set and the
  * intersection base in `normalizeHashAlgorithm`: an algorithm missing here is
@@ -344,7 +344,8 @@ const HASH_ALGORITHM_ALIASES = {
  *
  * Frozen because it is a runtime allowlist, not merely a type-level constant -
  * types are erased at compile time and would leave the exported array mutable,
- * letting any in-process code re-enable a weak digest globally.
+ * allowing in-process code to corrupt the validation policy and its reported
+ * supported set globally.
  */
 export const HASH_ALGORITHMS = Object.freeze(
   Object.keys(HASH_ALGORITHM_ALIASES) as (keyof typeof HASH_ALGORITHM_ALIASES)[],
@@ -381,7 +382,7 @@ export type NormalizeHashAlgorithmOptions = {
    * must never fall back to the full set, or a plugin could not express that.
    *
    * Intersected with {@link HASH_ALGORITHMS}, so this can only ever narrow the
-   * allowlist - a crypto plugin cannot use it to re-enable a weak digest.
+   * allowlist - a crypto plugin cannot widen the library's supported set.
    */
   supported?: readonly HashAlgorithm[];
 
@@ -402,8 +403,9 @@ export type NormalizeHashAlgorithmOptions = {
  *
  * Anything that is not an alias of a supported algorithm is rejected rather
  * than guessed at, because substituting a *different* algorithm produces
- * self-consistent tokens that never match any other implementation - a failure
- * that only surfaces at enrollment time.
+ * self-consistent tokens that do not match conforming implementations using the
+ * requested algorithm - a failure that can remain hidden until interoperability
+ * is tested.
  *
  * @param value - The algorithm to normalize
  * @param options - Narrowed algorithm set and calling plugin name

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -317,26 +317,69 @@ export function hasGuardrailOverrides(guardrails: OTPGuardrails): boolean {
 export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as const);
 
 /**
- * Recognised spellings of a supported algorithm: at most one `-` or `_`
- * between `sha` and the digest size (`SHA-1`, `sha_256`)
+ * Every accepted spelling of each supported algorithm, grouped by the canonical
+ * name it resolves to
  *
- * A single dash is how NIST and Web Crypto spell these algorithms, so it is
- * tolerated. Whitespace, stray or repeated separators (`'sha 1'`, `'-sha1'`,
- * `'sha-2-5-6'`) are not spellings of any algorithm and are better reported
- * than silently swallowed.
+ * Enumerated rather than derived from a pattern. A pattern is a compressed
+ * encoding of this list that can generalize past its intent - an earlier
+ * separator-stripping implementation accepted `'sha-2-5-6'` and `'s-h-a-1'`
+ * for exactly that reason. Nothing here can drift: the accepted set is the
+ * list.
+ *
+ * The `satisfies` constraint is load-bearing. It requires an entry for every
+ * member of {@link HashAlgorithm} and forbids keys outside it, so widening the
+ * union fails to compile until spellings are supplied here.
  *
  * @internal
  */
-const ALGORITHM_SPELLING = /^sha[-_]?(1|256|512)$/;
+const HASH_ALGORITHM_SPELLINGS = {
+  sha1: ["sha1", "sha-1", "sha_1"],
+  sha256: ["sha256", "sha-256", "sha_256"],
+  sha512: ["sha512", "sha-512", "sha_512"],
+} as const satisfies Record<HashAlgorithm, readonly string[]>;
+
+/**
+ * Lowercased spelling to canonical algorithm
+ *
+ * A `Map` rather than an object literal: `ALIAS_LOOKUP.get('__proto__')` is
+ * `undefined`, whereas an object would resolve `'__proto__'`, `'constructor'`
+ * and `'toString'` through the prototype chain and hand back inherited junk.
+ * That safety holds by construction, with no `Object.hasOwn` guard to forget.
+ *
+ * @internal
+ */
+const ALIAS_LOOKUP: ReadonlyMap<string, HashAlgorithm> = new Map(
+  Object.entries(HASH_ALGORITHM_SPELLINGS).flatMap(([canonical, spellings]) =>
+    spellings.map((spelling) => [spelling, canonical as HashAlgorithm] as const),
+  ),
+);
+
+/**
+ * Options for {@link normalizeHashAlgorithm}
+ */
+export type NormalizeHashAlgorithmOptions = {
+  /**
+   * Accepted algorithms, defaulting to all of {@link HASH_ALGORITHMS}
+   *
+   * Intersected with {@link HASH_ALGORITHMS}, so this can only ever narrow the
+   * allowlist - a crypto plugin cannot use it to re-enable a weak digest.
+   */
+  supported?: readonly HashAlgorithm[];
+
+  /**
+   * Name of the calling crypto plugin, used to enrich the error message
+   */
+  plugin?: string;
+};
 
 /**
  * Normalize and validate a hash algorithm
  *
- * Matching ignores case and tolerates one `-` or `_` separator, so `'SHA1'`,
- * `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is safe to
- * be forgiving about: every accepted spelling names the *same* algorithm, and
- * no other digest's spelling collapses onto a supported one (`'sha3-256'` and
- * `'sha-384'` are rejected outright).
+ * Matching ignores case and accepts the `-`/`_` separated spellings, so
+ * `'SHA1'`, `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is
+ * safe to be forgiving about: every accepted spelling names the *same*
+ * algorithm. No spelling of any other digest appears in the table, so
+ * `'sha3-256'` and `'sha-384'` are rejected outright.
  *
  * Anything that is not a spelling of a supported algorithm is rejected rather
  * than guessed at, because substituting a *different* algorithm produces
@@ -344,8 +387,7 @@ const ALGORITHM_SPELLING = /^sha[-_]?(1|256|512)$/;
  * that only surfaces at enrollment time.
  *
  * @param value - The algorithm to normalize
- * @param supported - Accepted algorithms (defaults to all of {@link HASH_ALGORITHMS})
- * @param plugin - Name of the calling crypto plugin, used to enrich the error message
+ * @param options - Narrowed algorithm set and calling plugin name
  * @returns The canonical lowercase algorithm
  * @throws {AlgorithmUnsupportedError} If the value is not a supported algorithm
  *
@@ -354,23 +396,25 @@ const ALGORITHM_SPELLING = /^sha[-_]?(1|256|512)$/;
  * normalizeHashAlgorithm('SHA1');   // 'sha1'
  * normalizeHashAlgorithm('SHA-1');  // 'sha1'
  * normalizeHashAlgorithm('sha384'); // throws AlgorithmUnsupportedError
+ *
+ * // A plugin backed by a restricted implementation
+ * normalizeHashAlgorithm('sha256', { supported: ['sha1'], plugin: 'custom' });
  * ```
  */
 export function normalizeHashAlgorithm(
   value: unknown,
-  supported: readonly HashAlgorithm[] = HASH_ALGORITHMS,
-  plugin?: string,
+  options: NormalizeHashAlgorithmOptions = {},
 ): HashAlgorithm {
-  if (typeof value !== "string") {
-    throw new AlgorithmUnsupportedError(value, { supported, plugin });
-  }
+  // Intersected rather than trusted: `supported` reaches here from crypto
+  // plugins, including untyped ones, and must only ever narrow.
+  const supported = options.supported
+    ? HASH_ALGORITHMS.filter((algorithm) => options.supported?.includes(algorithm))
+    : HASH_ALGORITHMS;
+  const plugin = options.plugin;
 
-  const match = ALGORITHM_SPELLING.exec(value.toLowerCase());
-  if (match) {
-    // Checked with `includes` rather than looked up in a map, so nothing can
-    // resolve through inherited properties.
-    const canonical = `sha${match[1]}` as HashAlgorithm;
-    if (supported.includes(canonical)) {
+  if (typeof value === "string") {
+    const canonical = ALIAS_LOOKUP.get(value.toLowerCase());
+    if (canonical !== undefined && supported.includes(canonical)) {
       return canonical;
     }
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -371,7 +371,14 @@ const ALIAS_LOOKUP: ReadonlyMap<string, HashAlgorithm> = new Map(
  */
 export type NormalizeHashAlgorithmOptions = {
   /**
-   * Accepted algorithms, defaulting to all of {@link HASH_ALGORITHMS}
+   * Accepted algorithms
+   *
+   * **Omitted and empty mean different things, deliberately.** Omitting it (or
+   * passing `undefined`) accepts all of {@link HASH_ALGORITHMS} - the
+   * backward-compatible reading for a `CryptoPlugin` written before
+   * `algorithms` existed, which supports the full set by definition. An
+   * explicit `[]` declares support for nothing and rejects every algorithm; it
+   * must never fall back to the full set, or a plugin could not express that.
    *
    * Intersected with {@link HASH_ALGORITHMS}, so this can only ever narrow the
    * allowlist - a crypto plugin cannot use it to re-enable a weak digest.
@@ -417,12 +424,20 @@ export function normalizeHashAlgorithm(
   value: unknown,
   options: NormalizeHashAlgorithmOptions = {},
 ): HashAlgorithm {
-  // Intersected rather than trusted: `supported` reaches here from crypto
-  // plugins, including untyped ones, and must only ever narrow.
-  const supported = options.supported
-    ? HASH_ALGORITHMS.filter((algorithm) => options.supported?.includes(algorithm))
-    : HASH_ALGORITHMS;
-  const plugin = options.plugin;
+  // Tested against `undefined` rather than truthiness, because `[]` must not
+  // take the same branch as an omitted value: omitted means "the full set"
+  // (a plugin predating `algorithms` supports all of them), while `[]` means
+  // "none" and has to reject everything. Simplifying this to a `.length` check
+  // would silently turn an empty declaration back into the full set.
+  //
+  // The intersection is applied rather than trusting the input: `supported`
+  // reaches here from crypto plugins, including untyped ones, so it may only
+  // ever narrow.
+  const { supported: declared, plugin } = options;
+  const supported =
+    declared === undefined
+      ? HASH_ALGORITHMS
+      : HASH_ALGORITHMS.filter((algorithm) => declared.includes(algorithm));
 
   if (typeof value === "string") {
     const canonical = ALIAS_LOOKUP.get(value.toLowerCase());
@@ -758,7 +773,7 @@ export function getDigestSize(algorithm: HashAlgorithm): number {
     case "sha512":
       return 64;
     default:
-      throw new AlgorithmUnsupportedError(algorithm);
+      throw new AlgorithmUnsupportedError(algorithm, { supported: HASH_ALGORITHMS });
   }
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -317,24 +317,26 @@ export function hasGuardrailOverrides(guardrails: OTPGuardrails): boolean {
 export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as const);
 
 /**
- * Separator noise tolerated in an algorithm name (`SHA-1`, `sha_1`)
+ * Recognised spellings of a supported algorithm: at most one `-` or `_`
+ * between `sha` and the digest size (`SHA-1`, `sha_256`)
  *
- * Deliberately excludes whitespace: a dash is how NIST and Web Crypto spell
- * these algorithms, whereas a space is never part of an identifier and is
- * better reported than silently swallowed.
+ * A single dash is how NIST and Web Crypto spell these algorithms, so it is
+ * tolerated. Whitespace, stray or repeated separators (`'sha 1'`, `'-sha1'`,
+ * `'sha-2-5-6'`) are not spellings of any algorithm and are better reported
+ * than silently swallowed.
  *
  * @internal
  */
-const ALGORITHM_SEPARATORS = /[-_]/g;
+const ALGORITHM_SPELLING = /^sha[-_]?(1|256|512)$/;
 
 /**
  * Normalize and validate a hash algorithm
  *
- * Matching ignores case and `-`/`_` separators, so `'SHA1'`, `'Sha1'`,
- * `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is safe to be forgiving
- * about: every accepted spelling names the *same* algorithm, and no other
- * digest collapses onto a supported one (`'sha3-256'` strips to `'sha3256'`,
- * not `'sha256'`).
+ * Matching ignores case and tolerates one `-` or `_` separator, so `'SHA1'`,
+ * `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is safe to
+ * be forgiving about: every accepted spelling names the *same* algorithm, and
+ * no other digest's spelling collapses onto a supported one (`'sha3-256'` and
+ * `'sha-384'` are rejected outright).
  *
  * Anything that is not a spelling of a supported algorithm is rejected rather
  * than guessed at, because substituting a *different* algorithm produces
@@ -363,16 +365,14 @@ export function normalizeHashAlgorithm(
     throw new AlgorithmUnsupportedError(value, { supported, plugin });
   }
 
-  // Scanned with `includes` rather than looked up in a map, so a value such as
-  // `'__proto__'` cannot resolve to anything inherited.
-  const lowered = value.toLowerCase() as HashAlgorithm;
-  if (supported.includes(lowered)) {
-    return lowered;
-  }
-
-  const stripped = lowered.replace(ALGORITHM_SEPARATORS, "") as HashAlgorithm;
-  if (supported.includes(stripped)) {
-    return stripped;
+  const match = ALGORITHM_SPELLING.exec(value.toLowerCase());
+  if (match) {
+    // Checked with `includes` rather than looked up in a map, so nothing can
+    // resolve through inherited properties.
+    const canonical = `sha${match[1]}` as HashAlgorithm;
+    if (supported.includes(canonical)) {
+      return canonical;
+    }
   }
 
   throw new AlgorithmUnsupportedError(value, { supported, plugin });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -317,16 +317,29 @@ export function hasGuardrailOverrides(guardrails: OTPGuardrails): boolean {
 export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as const);
 
 /**
+ * Separator noise tolerated in an algorithm name (`SHA-1`, `sha_1`)
+ *
+ * Deliberately excludes whitespace: a dash is how NIST and Web Crypto spell
+ * these algorithms, whereas a space is never part of an identifier and is
+ * better reported than silently swallowed.
+ *
+ * @internal
+ */
+const ALGORITHM_SEPARATORS = /[-_]/g;
+
+/**
  * Normalize and validate a hash algorithm
  *
- * Matching is case-insensitive, so `'SHA1'` and `'Sha1'` both resolve to
- * `'sha1'`. Everything else is rejected - including separator variants such as
- * `'SHA-1'`, which are only tolerated when parsing third-party `otpauth://`
- * URIs (see `@otplib/uri`).
+ * Matching ignores case and `-`/`_` separators, so `'SHA1'`, `'Sha1'`,
+ * `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is safe to be forgiving
+ * about: every accepted spelling names the *same* algorithm, and no other
+ * digest collapses onto a supported one (`'sha3-256'` strips to `'sha3256'`,
+ * not `'sha256'`).
  *
- * Rejecting rather than guessing is deliberate: substituting a different
- * algorithm produces self-consistent tokens that never match any other
- * implementation, which fails silently at enrollment time.
+ * Anything that is not a spelling of a supported algorithm is rejected rather
+ * than guessed at, because substituting a *different* algorithm produces
+ * self-consistent tokens that never match any other implementation - a failure
+ * that only surfaces at enrollment time.
  *
  * @param value - The algorithm to normalize
  * @param supported - Accepted algorithms (defaults to all of {@link HASH_ALGORITHMS})
@@ -337,7 +350,8 @@ export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as con
  * @example
  * ```typescript
  * normalizeHashAlgorithm('SHA1');   // 'sha1'
- * normalizeHashAlgorithm('SHA-1');  // throws AlgorithmUnsupportedError
+ * normalizeHashAlgorithm('SHA-1');  // 'sha1'
+ * normalizeHashAlgorithm('sha384'); // throws AlgorithmUnsupportedError
  * ```
  */
 export function normalizeHashAlgorithm(
@@ -349,13 +363,19 @@ export function normalizeHashAlgorithm(
     throw new AlgorithmUnsupportedError(value, { supported, plugin });
   }
 
-  const normalized = value.toLowerCase() as HashAlgorithm;
-
-  if (!supported.includes(normalized)) {
-    throw new AlgorithmUnsupportedError(value, { supported, plugin });
+  // Scanned with `includes` rather than looked up in a map, so a value such as
+  // `'__proto__'` cannot resolve to anything inherited.
+  const lowered = value.toLowerCase() as HashAlgorithm;
+  if (supported.includes(lowered)) {
+    return lowered;
   }
 
-  return normalized;
+  const stripped = lowered.replace(ALGORITHM_SEPARATORS, "") as HashAlgorithm;
+  if (supported.includes(stripped)) {
+    return stripped;
+  }
+
+  throw new AlgorithmUnsupportedError(value, { supported, plugin });
 }
 
 /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -387,11 +387,11 @@ export type NormalizeHashAlgorithmOptions = {
 /**
  * Normalize and validate a hash algorithm
  *
- * Matching ignores case and accepts the `-`/`_` separated aliases, so `'SHA1'`,
- * `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is safe to be
- * forgiving about: every accepted alias names the *same* algorithm. No alias of
- * any other digest appears in the table, so `'sha3-256'` and `'sha-384'` are
- * rejected outright.
+ * Matching ignores case and accepts an optional `-` or `_` before the digest
+ * size, so `'SHA1'`, `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`.
+ * This is safe to be forgiving about: every accepted alias names the *same*
+ * algorithm. No alias of any other digest appears in the table, so `'sha3-256'`
+ * and `'sha-384'` are rejected outright.
  *
  * Anything that is not an alias of a supported algorithm is rejected rather
  * than guessed at, because substituting a *different* algorithm produces

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -307,18 +307,13 @@ export function hasGuardrailOverrides(guardrails: OTPGuardrails): boolean {
 }
 
 /**
- * The hash algorithms supported for HMAC operations
- *
- * Frozen because it is the runtime allowlist `normalizeHashAlgorithm` checks
- * against, not merely a type-level constant - `as const` is erased at compile
- * time and would leave the exported array mutable, letting any in-process code
- * re-enable a weak digest globally.
- */
-export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as const);
-
-/**
- * Every accepted spelling of each supported algorithm, grouped by the canonical
+ * Every accepted name for each supported algorithm, grouped by the canonical
  * name it resolves to
+ *
+ * Each list includes the canonical name itself, so the lookup built from this
+ * needs no separate case for it. (Strictly, a registry such as IANA's lists the
+ * canonical `Name` apart from its `Alias` entries; folding them together here
+ * keeps the lookup a single branch.)
  *
  * Enumerated rather than derived from a pattern. A pattern is a compressed
  * encoding of this list that can generalize past its intent - an earlier
@@ -328,18 +323,35 @@ export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as con
  *
  * The `satisfies` constraint is load-bearing. It requires an entry for every
  * member of {@link HashAlgorithm} and forbids keys outside it, so widening the
- * union fails to compile until spellings are supplied here.
+ * union fails to compile until aliases are supplied here.
  *
  * @internal
  */
-const HASH_ALGORITHM_SPELLINGS = {
+const HASH_ALGORITHM_ALIASES = {
   sha1: ["sha1", "sha-1", "sha_1"],
   sha256: ["sha256", "sha-256", "sha_256"],
   sha512: ["sha512", "sha-512", "sha_512"],
 } as const satisfies Record<HashAlgorithm, readonly string[]>;
 
 /**
- * Lowercased spelling to canonical algorithm
+ * The hash algorithms supported for HMAC operations
+ *
+ * Derived from {@link HASH_ALGORITHM_ALIASES} rather than written out again, so
+ * the runtime allowlist cannot disagree with the names that resolve to it. That
+ * matters because this array is both the default `supported` set and the
+ * intersection base in `normalizeHashAlgorithm`: an algorithm missing here is
+ * rejected at runtime no matter what the types say.
+ *
+ * Frozen because it is a runtime allowlist, not merely a type-level constant -
+ * types are erased at compile time and would leave the exported array mutable,
+ * letting any in-process code re-enable a weak digest globally.
+ */
+export const HASH_ALGORITHMS = Object.freeze(
+  Object.keys(HASH_ALGORITHM_ALIASES) as (keyof typeof HASH_ALGORITHM_ALIASES)[],
+);
+
+/**
+ * Lowercased name to canonical algorithm
  *
  * A `Map` rather than an object literal: `ALIAS_LOOKUP.get('__proto__')` is
  * `undefined`, whereas an object would resolve `'__proto__'`, `'constructor'`
@@ -349,8 +361,8 @@ const HASH_ALGORITHM_SPELLINGS = {
  * @internal
  */
 const ALIAS_LOOKUP: ReadonlyMap<string, HashAlgorithm> = new Map(
-  Object.entries(HASH_ALGORITHM_SPELLINGS).flatMap(([canonical, spellings]) =>
-    spellings.map((spelling) => [spelling, canonical as HashAlgorithm] as const),
+  Object.entries(HASH_ALGORITHM_ALIASES).flatMap(([canonical, aliases]) =>
+    aliases.map((alias) => [alias, canonical as HashAlgorithm] as const),
   ),
 );
 
@@ -375,13 +387,13 @@ export type NormalizeHashAlgorithmOptions = {
 /**
  * Normalize and validate a hash algorithm
  *
- * Matching ignores case and accepts the `-`/`_` separated spellings, so
- * `'SHA1'`, `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is
- * safe to be forgiving about: every accepted spelling names the *same*
- * algorithm. No spelling of any other digest appears in the table, so
- * `'sha3-256'` and `'sha-384'` are rejected outright.
+ * Matching ignores case and accepts the `-`/`_` separated aliases, so `'SHA1'`,
+ * `'Sha1'`, `'SHA-1'` and `'sha_1'` all resolve to `'sha1'`. This is safe to be
+ * forgiving about: every accepted alias names the *same* algorithm. No alias of
+ * any other digest appears in the table, so `'sha3-256'` and `'sha-384'` are
+ * rejected outright.
  *
- * Anything that is not a spelling of a supported algorithm is rejected rather
+ * Anything that is not an alias of a supported algorithm is rejected rather
  * than guessed at, because substituting a *different* algorithm produces
  * self-consistent tokens that never match any other implementation - a failure
  * that only surfaces at enrollment time.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -308,8 +308,13 @@ export function hasGuardrailOverrides(guardrails: OTPGuardrails): boolean {
 
 /**
  * The hash algorithms supported for HMAC operations
+ *
+ * Frozen because it is the runtime allowlist `normalizeHashAlgorithm` checks
+ * against, not merely a type-level constant - `as const` is erased at compile
+ * time and would leave the exported array mutable, letting any in-process code
+ * re-enable a weak digest globally.
  */
-export const HASH_ALGORITHMS = ["sha1", "sha256", "sha512"] as const;
+export const HASH_ALGORITHMS = Object.freeze(["sha1", "sha256", "sha512"] as const);
 
 /**
  * Normalize and validate a hash algorithm

--- a/packages/hotp/src/class.ts
+++ b/packages/hotp/src/class.ts
@@ -72,6 +72,8 @@ export class HOTP {
    * @param counter - The counter value
    * @param options - Optional overrides
    * @returns The HOTP code
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails in the crypto plugin
    */
   async generate(counter: number, options?: Partial<HOTPOptions>): Promise<string> {
     const mergedOptions = { ...this.options, ...options };
@@ -101,6 +103,8 @@ export class HOTP {
    * @param params - Verification parameters
    * @param options - Optional verification options
    * @returns Verification result with validity and optional delta
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails in the crypto plugin
    */
   async verify(
     params: { token: string; counter: number },
@@ -141,6 +145,7 @@ export class HOTP {
    *
    * @param counter - The counter value
    * @returns The otpauth:// URI
+   * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
    */
   toURI(counter: number = 0): string {
     const { issuer, label, secret, algorithm = "sha1", digits = 6 } = this.options;

--- a/packages/hotp/src/index-test.ts
+++ b/packages/hotp/src/index-test.ts
@@ -8,6 +8,7 @@
 import {
   stringToBytes,
   createGuardrails,
+  AlgorithmUnsupportedError,
   SecretTooLongError,
   CounterOverflowError,
   CounterToleranceTooLargeError,
@@ -1276,6 +1277,57 @@ export function createHOTPTests(ctx: TestContext<CryptoPlugin>): void {
             expect(result.delta).toBe(0);
           }
         });
+      });
+    });
+
+    // A plugin may support fewer algorithms than the library. Options
+    // resolution checks against that plugin's own set, so the error names what
+    // the configured plugin actually accepts instead of the full allowlist.
+    describe("narrowed crypto plugin", () => {
+      const sha1OnlyCrypto: CryptoPlugin = {
+        name: "sha1-only",
+        algorithms: ["sha1"],
+        hmac: (algorithm, key, data) => crypto.hmac(algorithm, key, data),
+        randomBytes: (length) => crypto.randomBytes(length),
+      };
+
+      it("should reject an algorithm the plugin does not support", async () => {
+        await expect(
+          generate({ secret, counter: 0, algorithm: "sha512", crypto: sha1OnlyCrypto }),
+        ).rejects.toThrow(AlgorithmUnsupportedError);
+      });
+
+      it("should report the plugin's own set rather than the full allowlist", async () => {
+        await expect(
+          generate({ secret, counter: 0, algorithm: "sha512", crypto: sha1OnlyCrypto }),
+        ).rejects.toThrow("[plugin: sha1-only]");
+
+        await expect(
+          generate({ secret, counter: 0, algorithm: "sha512", crypto: sha1OnlyCrypto }),
+        ).rejects.toThrow("Expected one of: sha1 ");
+      });
+
+      it("should still accept an algorithm the plugin supports", async () => {
+        const token = await generate({
+          secret,
+          counter: 0,
+          algorithm: "sha1",
+          crypto: sha1OnlyCrypto,
+        });
+
+        expect(token).toMatch(/^\d{6}$/);
+      });
+
+      it("should reject on verify as well", async () => {
+        await expect(
+          verify({
+            secret,
+            counter: 0,
+            token: "000000",
+            algorithm: "sha512",
+            crypto: sha1OnlyCrypto,
+          }),
+        ).rejects.toThrow(AlgorithmUnsupportedError);
       });
     });
   });

--- a/packages/hotp/src/index.ts
+++ b/packages/hotp/src/index.ts
@@ -18,6 +18,7 @@ import {
   validateCounterTolerance,
   normalizeSecret,
   normalizeCounterTolerance,
+  normalizeHashAlgorithm,
   requireSecret,
   requireCryptoPlugin,
 } from "@otplib/core";
@@ -53,7 +54,7 @@ function getHOTPGenerateOptions(options: HOTPGenerateOptions): HOTPGenerateOptio
   const {
     secret,
     counter,
-    algorithm = "sha1",
+    algorithm: rawAlgorithm = "sha1",
     digits = 6,
     crypto,
     base32,
@@ -67,6 +68,8 @@ function getHOTPGenerateOptions(options: HOTPGenerateOptions): HOTPGenerateOptio
   const secretBytes = normalizeSecret(secret, base32);
   validateSecret(secretBytes, guardrails);
   validateCounter(counter, guardrails);
+  // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
 
   const ctx = createCryptoContext(crypto);
   const counterBytes = counterToBytes(counter);
@@ -179,7 +182,7 @@ function getHOTPVerifyOptions(options: HOTPVerifyOptions): HOTPVerifyOptionsInte
     secret,
     counter,
     token,
-    algorithm = "sha1",
+    algorithm: rawAlgorithm = "sha1",
     digits = 6,
     crypto,
     base32,
@@ -194,6 +197,8 @@ function getHOTPVerifyOptions(options: HOTPVerifyOptions): HOTPVerifyOptionsInte
   const secretBytes = normalizeSecret(secret, base32);
   validateSecret(secretBytes, guardrails);
   validateCounter(counter, guardrails);
+  // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
 
   // Use custom validator if provided, otherwise default digit-only check
   if (hooks?.validateToken) {

--- a/packages/hotp/src/index.ts
+++ b/packages/hotp/src/index.ts
@@ -69,7 +69,12 @@ function getHOTPGenerateOptions(options: HOTPGenerateOptions): HOTPGenerateOptio
   validateSecret(secretBytes, guardrails);
   validateCounter(counter, guardrails);
   // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
-  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
+  // Checked against the configured plugin's own set, so a plugin supporting
+  // fewer algorithms reports what it actually accepts rather than the full set.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm, {
+    supported: crypto.algorithms,
+    plugin: crypto.name,
+  });
 
   const ctx = createCryptoContext(crypto);
   const counterBytes = counterToBytes(counter);
@@ -198,7 +203,12 @@ function getHOTPVerifyOptions(options: HOTPVerifyOptions): HOTPVerifyOptionsInte
   validateSecret(secretBytes, guardrails);
   validateCounter(counter, guardrails);
   // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
-  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
+  // Checked against the configured plugin's own set, so a plugin supporting
+  // fewer algorithms reports what it actually accepts rather than the full set.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm, {
+    supported: crypto.algorithms,
+    plugin: crypto.name,
+  });
 
   // Use custom validator if provided, otherwise default digit-only check
   if (hooks?.validateToken) {

--- a/packages/hotp/src/index.ts
+++ b/packages/hotp/src/index.ts
@@ -88,7 +88,8 @@ function getHOTPGenerateOptions(options: HOTPGenerateOptions): HOTPGenerateOptio
  * Implements the HOTP algorithm as specified in RFC 4226 Section 5.3:
  *
  * 1. Convert counter to 8-byte big-endian array (RFC 4226 Section 5.1)
- * 2. Compute HMAC-SHA-1 using the secret key and counter (RFC 4226 Section 5.2)
+ * 2. Compute HMAC using the selected algorithm. SHA-1 is the default specified
+ *    by RFC 4226; SHA-256 and SHA-512 are supported extensions.
  * 3. Apply dynamic truncation to extract 4-byte code (RFC 4226 Section 5.3)
  * 4. Reduce modulo 10^digits to get final OTP (RFC 4226 Section 5.3)
  *
@@ -96,6 +97,8 @@ function getHOTPGenerateOptions(options: HOTPGenerateOptions): HOTPGenerateOptio
  *
  * @param options - HOTP generation options
  * @returns The HOTP code as a string
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails in the crypto plugin
  *
  * @example
  * ```ts
@@ -132,7 +135,8 @@ export async function generate(options: HOTPGenerateOptions): Promise<string> {
  *
  * @param options - HOTP generation options
  * @returns The HOTP code as a string
- * @throws {HMACError} If the crypto plugin doesn't support sync operations
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
  *
  * @example
  * ```ts
@@ -265,6 +269,8 @@ function getHOTPVerifyOptions(options: HOTPVerifyOptions): HOTPVerifyOptionsInte
  *
  * @param options - HOTP verification options
  * @returns Verification result with validity and optional delta
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails in the crypto plugin
  *
  * @example Basic verification
  * ```ts
@@ -336,7 +342,8 @@ export async function verify(options: HOTPVerifyOptions): Promise<VerifyResult> 
  *
  * @param options - HOTP verification options
  * @returns Verification result with validity and optional delta
- * @throws {HMACError} If the crypto plugin doesn't support sync operations
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
  *
  * @example
  * ```ts

--- a/packages/otplib-cli/package.json
+++ b/packages/otplib-cli/package.json
@@ -36,6 +36,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@otplib/core": "workspace:*",
     "commander": "^15.0.0",
     "otplib": "workspace:*"
   },

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -155,6 +155,30 @@ describe("parseOtpauthUri", () => {
     expect(result.algorithm).toBe("SHA256");
   });
 
+  test("parses algorithm with hyphen (SHA-1)", () => {
+    const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&algorithm=SHA-1");
+
+    expect(result.algorithm).toBe("SHA1");
+  });
+
+  test("parses algorithm with hyphen (SHA-512)", () => {
+    const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&algorithm=SHA-512");
+
+    expect(result.algorithm).toBe("SHA512");
+  });
+
+  test("throws on unsupported algorithm (md5)", () => {
+    expect(() => parseOtpauthUri("otpauth://totp/Test?secret=ABC&algorithm=md5")).toThrow(
+      "Invalid algorithm: md5, expected SHA1, SHA256, or SHA512",
+    );
+  });
+
+  test("defaults to SHA1 when algorithm is absent", () => {
+    const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC");
+
+    expect(result.algorithm).toBe("SHA1");
+  });
+
   test("parses 7 digits", () => {
     const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&digits=7");
 
@@ -231,6 +255,33 @@ describe("parseJsonInput", () => {
       digits: 6,
       counter: 0,
     });
+  });
+
+  test("rejects dashed algorithm (SHA-1)", () => {
+    expect(() => parseJsonInput('{"secret":"ABC","algorithm":"SHA-1"}')).toThrow(
+      "Invalid algorithm: SHA-1, expected SHA1, SHA256, or SHA512",
+    );
+  });
+
+  test("rejects dashed algorithm (sha-256)", () => {
+    expect(() => parseJsonInput('{"secret":"ABC","algorithm":"sha-256"}')).toThrow(
+      "Invalid algorithm: sha-256, expected SHA1, SHA256, or SHA512",
+    );
+  });
+
+  test("accepts case variants of sha1", () => {
+    expect(parseJsonInput('{"secret":"ABC","algorithm":"sha1"}').algorithm).toBe("SHA1");
+    expect(parseJsonInput('{"secret":"ABC","algorithm":"SHA1"}').algorithm).toBe("SHA1");
+  });
+
+  test("defaults to SHA1 when algorithm is absent", () => {
+    expect(parseJsonInput('{"secret":"ABC"}').algorithm).toBe("SHA1");
+  });
+
+  test("throws on unsupported algorithm (md5)", () => {
+    expect(() => parseJsonInput('{"secret":"ABC","algorithm":"md5"}')).toThrow(
+      "Invalid algorithm: md5, expected SHA1, SHA256, or SHA512",
+    );
   });
 
   test("throws on invalid JSON", () => {

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -192,18 +192,40 @@ describe("parseOtpauthUri", () => {
   });
 
   test.each([
-    "algorithm=SHA1&algorithm=SHA512",
-    "algorithm=SHA512&algorithm=SHA512",
-    "algorithm=&algorithm=SHA512",
-    "algorithm=SHA512&algorithm=",
-    "algorithm=&algorithm=",
-    "algorithm&algorithm=SHA512",
-    "algorithm=SHA512&algorithm",
-    "algorithm&algorithm",
-  ])("rejects duplicate algorithm parameters: %s", (query) => {
-    expect(() => parseOtpauthUri(`otpauth://totp/Test?secret=ABC&${query}`)).toThrow(
-      "Duplicate parameter: algorithm",
+    ["secret", "otpauth://totp/Test?secret=FIRST&secret=SECOND", "secret", "FIRST"],
+    ["issuer", "otpauth://totp/Test?secret=ABC&issuer=First&issuer=Second", "issuer", "First"],
+    [
+      "algorithm",
+      "otpauth://totp/Test?secret=ABC&algorithm=SHA256&algorithm=SHA512",
+      "algorithm",
+      "SHA256",
+    ],
+    ["digits", "otpauth://totp/Test?secret=ABC&digits=6&digits=8", "digits", 6],
+    ["period", "otpauth://totp/Test?secret=ABC&period=30&period=60", "period", 30],
+  ])("uses only the first %s occurrence", (_name, uri, property, expected) => {
+    const result = parseOtpauthUri(uri);
+
+    expect(result[property as keyof typeof result]).toBe(expected);
+  });
+
+  test("uses only the first counter occurrence", () => {
+    const result = parseOtpauthUri("otpauth://hotp/Test?secret=ABC&counter=1&counter=2");
+
+    expect(result.counter).toBe(1);
+  });
+
+  test("does not validate a later algorithm value", () => {
+    const result = parseOtpauthUri(
+      "otpauth://totp/Test?secret=ABC&algorithm=SHA256&algorithm=INVALID",
     );
+
+    expect(result.algorithm).toBe("SHA256");
+  });
+
+  test("lets a bare first algorithm select the SHA1 default", () => {
+    const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&algorithm&algorithm=SHA512");
+
+    expect(result.algorithm).toBe("SHA1");
   });
 
   test("parses 7 digits", () => {

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -284,6 +284,21 @@ describe("parseJsonInput", () => {
     );
   });
 
+  // Valid JSON that String() cannot convert: the algorithm object has a
+  // non-callable toString, so building the error message used to throw a raw
+  // TypeError over the CLI's own message.
+  test("throws the CLI's message for an algorithm with no primitive conversion", () => {
+    expect(() => parseJsonInput('{"secret":"ABC","algorithm":{"toString":null}}')).toThrow(
+      "expected SHA1, SHA256, or SHA512",
+    );
+  });
+
+  test("throws the CLI's message for a non-string algorithm", () => {
+    expect(() => parseJsonInput('{"secret":"ABC","algorithm":123}')).toThrow(
+      "Invalid algorithm: 123, expected SHA1, SHA256, or SHA512",
+    );
+  });
+
   test("throws on invalid JSON", () => {
     expect(() => parseJsonInput("not json")).toThrow("Invalid JSON input");
   });

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -185,6 +185,27 @@ describe("parseOtpauthUri", () => {
     expect(result.algorithm).toBe("SHA1");
   });
 
+  test("defaults to SHA1 for a bare algorithm parameter", () => {
+    const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&algorithm");
+
+    expect(result.algorithm).toBe("SHA1");
+  });
+
+  test.each([
+    "algorithm=SHA1&algorithm=SHA512",
+    "algorithm=SHA512&algorithm=SHA512",
+    "algorithm=&algorithm=SHA512",
+    "algorithm=SHA512&algorithm=",
+    "algorithm=&algorithm=",
+    "algorithm&algorithm=SHA512",
+    "algorithm=SHA512&algorithm",
+    "algorithm&algorithm",
+  ])("rejects duplicate algorithm parameters: %s", (query) => {
+    expect(() => parseOtpauthUri(`otpauth://totp/Test?secret=ABC&${query}`)).toThrow(
+      "Duplicate parameter: algorithm",
+    );
+  });
+
   test("parses 7 digits", () => {
     const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&digits=7");
 

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -263,7 +263,7 @@ describe("parseJsonInput", () => {
     });
   });
 
-  // JSON input and otpauth:// URIs accept the same spellings, so a value
+  // JSON input and otpauth:// URIs accept the same aliases, so a value
   // copied out of one and pasted into the other keeps working.
   test("accepts dashed algorithm (SHA-1)", () => {
     expect(parseJsonInput('{"secret":"ABC","algorithm":"SHA-1"}').algorithm).toBe("SHA1");
@@ -279,7 +279,7 @@ describe("parseJsonInput", () => {
     );
   });
 
-  test("accepts case variants of sha1", () => {
+  test("accepts case aliases of sha1", () => {
     expect(parseJsonInput('{"secret":"ABC","algorithm":"sha1"}').algorithm).toBe("SHA1");
     expect(parseJsonInput('{"secret":"ABC","algorithm":"SHA1"}').algorithm).toBe("SHA1");
   });

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -257,15 +257,19 @@ describe("parseJsonInput", () => {
     });
   });
 
-  test("rejects dashed algorithm (SHA-1)", () => {
-    expect(() => parseJsonInput('{"secret":"ABC","algorithm":"SHA-1"}')).toThrow(
-      "Invalid algorithm: SHA-1, expected SHA1, SHA256, or SHA512",
-    );
+  // JSON input and otpauth:// URIs accept the same spellings, so a value
+  // copied out of one and pasted into the other keeps working.
+  test("accepts dashed algorithm (SHA-1)", () => {
+    expect(parseJsonInput('{"secret":"ABC","algorithm":"SHA-1"}').algorithm).toBe("SHA1");
   });
 
-  test("rejects dashed algorithm (sha-256)", () => {
-    expect(() => parseJsonInput('{"secret":"ABC","algorithm":"sha-256"}')).toThrow(
-      "Invalid algorithm: sha-256, expected SHA1, SHA256, or SHA512",
+  test("accepts dashed algorithm (sha-256)", () => {
+    expect(parseJsonInput('{"secret":"ABC","algorithm":"sha-256"}').algorithm).toBe("SHA256");
+  });
+
+  test("rejects an unsupported dashed digest (sha-384)", () => {
+    expect(() => parseJsonInput('{"secret":"ABC","algorithm":"sha-384"}')).toThrow(
+      "Invalid algorithm: sha-384, expected SHA1, SHA256, or SHA512",
     );
   });
 

--- a/packages/otplib-cli/src/shared/parse.test.ts
+++ b/packages/otplib-cli/src/shared/parse.test.ts
@@ -179,6 +179,12 @@ describe("parseOtpauthUri", () => {
     expect(result.algorithm).toBe("SHA1");
   });
 
+  test("defaults to SHA1 for an empty algorithm parameter", () => {
+    const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&algorithm=");
+
+    expect(result.algorithm).toBe("SHA1");
+  });
+
   test("parses 7 digits", () => {
     const result = parseOtpauthUri("otpauth://totp/Test?secret=ABC&digits=7");
 
@@ -280,6 +286,16 @@ describe("parseJsonInput", () => {
 
   test("defaults to SHA1 when algorithm is absent", () => {
     expect(parseJsonInput('{"secret":"ABC"}').algorithm).toBe("SHA1");
+  });
+
+  // JSON has no undefined: null is how its authors spell "absent", and both
+  // null and "" defaulted before validation moved to core.
+  test("defaults to SHA1 for a null algorithm", () => {
+    expect(parseJsonInput('{"secret":"ABC","algorithm":null}').algorithm).toBe("SHA1");
+  });
+
+  test("defaults to SHA1 for an empty-string algorithm", () => {
+    expect(parseJsonInput('{"secret":"ABC","algorithm":""}').algorithm).toBe("SHA1");
   });
 
   test("throws on unsupported algorithm (md5)", () => {

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -51,9 +51,10 @@ function describeAlgorithm(alg: unknown): string {
  * Parse an algorithm from either input format.
  *
  * Delegates to core's `normalizeHashAlgorithm` so `otpauth://` URIs and
- * user-authored JSON accept exactly the same aliases - case and separators
- * are ignored, so `SHA1`, `sha1` and `SHA-256` all resolve. The CLI's own
- * casing (`SHA1`) is applied on the way out.
+ * user-authored JSON accept exactly the same aliases. Case is ignored, and one
+ * optional `-` or `_` is accepted before the digest size, so `SHA1`, `sha1`
+ * and `SHA-256` all resolve. The CLI's own casing (`SHA1`) is applied on the
+ * way out.
  */
 function normalizeAlgorithm(alg?: unknown): OtpAlgorithm {
   // JSON spells "absent" as null, and an empty string carries no value either

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -1,3 +1,5 @@
+import { normalizeHashAlgorithm } from "@otplib/core";
+
 import { decodePayload } from "./types.js";
 
 import type { HotpData, OtpAlgorithm, OtpData, OtpDigits, ParsedEntry } from "./types.js";
@@ -19,13 +21,40 @@ export type ParsedEnv = {
   guardrails?: Partial<OTPGuardrailsConfig>;
 };
 
-function normalizeAlgorithm(alg?: string): OtpAlgorithm {
+function invalidAlgorithm(alg: unknown): Error {
+  return new Error(`Invalid algorithm: ${String(alg)}, expected SHA1, SHA256, or SHA512`);
+}
+
+/**
+ * Lenient algorithm parsing for third-party `otpauth://` URIs.
+ *
+ * Mirrors `parseAlgorithm` in `@otplib/uri` so the CLI accepts the same URIs
+ * the library does, including the dashed forms (`SHA-1`, `sha-256`).
+ */
+function normalizeUriAlgorithm(alg?: string): OtpAlgorithm {
   if (!alg) return "SHA1";
-  const upper = alg.toUpperCase().replace("-", "");
-  if (upper === "SHA1") return "SHA1";
-  if (upper === "SHA256") return "SHA256";
-  if (upper === "SHA512") return "SHA512";
-  throw new Error(`Invalid algorithm: ${alg}, expected SHA1, SHA256, or SHA512`);
+  const normalized = alg.toLowerCase();
+  if (normalized === "sha1" || normalized === "sha-1") return "SHA1";
+  if (normalized === "sha256" || normalized === "sha-256") return "SHA256";
+  if (normalized === "sha512" || normalized === "sha-512") return "SHA512";
+  throw invalidAlgorithm(alg);
+}
+
+/**
+ * Strict algorithm parsing for user-authored JSON input.
+ *
+ * Delegates to core's `normalizeHashAlgorithm`, which case-folds only:
+ * `sha1`/`SHA1` are accepted, dashed forms such as `SHA-1` are rejected.
+ */
+function normalizeInputAlgorithm(alg?: unknown): OtpAlgorithm {
+  if (alg === undefined) return "SHA1";
+  try {
+    return normalizeHashAlgorithm(alg).toUpperCase() as OtpAlgorithm;
+  } catch {
+    // normalizeHashAlgorithm only throws AlgorithmUnsupportedError, which is
+    // restated here in the CLI's own error style.
+    throw invalidAlgorithm(alg);
+  }
 }
 
 function normalizeDigits(digits?: number): OtpDigits {
@@ -71,7 +100,7 @@ export function parseOtpauthUri(uri: string): OtpData {
     account = label.slice(colonIndex + 1);
   }
 
-  const algorithm = normalizeAlgorithm(url.searchParams.get("algorithm") ?? undefined);
+  const algorithm = normalizeUriAlgorithm(url.searchParams.get("algorithm") ?? undefined);
   const digitsParam = url.searchParams.get("digits");
   const digits = normalizeDigits(digitsParam !== null ? parseInt(digitsParam, 10) : undefined);
 
@@ -111,7 +140,7 @@ export function parseJsonInput(raw: string): OtpData {
     throw new Error('Invalid type: expected "totp" or "hotp"');
   }
 
-  const algorithm = normalizeAlgorithm(input.algorithm);
+  const algorithm = normalizeInputAlgorithm(input.algorithm);
   const digits = normalizeDigits(input.digits);
 
   if (type === "totp") {

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -75,14 +75,6 @@ function normalizeDigits(digits?: number): OtpDigits {
   throw new Error(`Invalid digits: ${digits}, expected 6, 7, or 8`);
 }
 
-function getSingleUriParameter(searchParams: URLSearchParams, name: string): string | null {
-  const values = searchParams.getAll(name);
-  if (values.length > 1) {
-    throw new Error(`Duplicate parameter: ${name}`);
-  }
-  return values[0] ?? null;
-}
-
 export function parseOtpauthUri(uri: string): OtpData {
   let url: URL;
   try {
@@ -120,7 +112,7 @@ export function parseOtpauthUri(uri: string): OtpData {
     account = label.slice(colonIndex + 1);
   }
 
-  const algorithm = normalizeAlgorithm(getSingleUriParameter(url.searchParams, "algorithm"));
+  const algorithm = normalizeAlgorithm(url.searchParams.get("algorithm"));
   const digitsParam = url.searchParams.get("digits");
   const digits = normalizeDigits(digitsParam !== null ? parseInt(digitsParam, 10) : undefined);
 

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -75,6 +75,14 @@ function normalizeDigits(digits?: number): OtpDigits {
   throw new Error(`Invalid digits: ${digits}, expected 6, 7, or 8`);
 }
 
+function getSingleUriParameter(searchParams: URLSearchParams, name: string): string | null {
+  const values = searchParams.getAll(name);
+  if (values.length > 1) {
+    throw new Error(`Duplicate parameter: ${name}`);
+  }
+  return values[0] ?? null;
+}
+
 export function parseOtpauthUri(uri: string): OtpData {
   let url: URL;
   try {
@@ -112,7 +120,7 @@ export function parseOtpauthUri(uri: string): OtpData {
     account = label.slice(colonIndex + 1);
   }
 
-  const algorithm = normalizeAlgorithm(url.searchParams.get("algorithm"));
+  const algorithm = normalizeAlgorithm(getSingleUriParameter(url.searchParams, "algorithm"));
   const digitsParam = url.searchParams.get("digits");
   const digits = normalizeDigits(digitsParam !== null ? parseInt(digitsParam, 10) : undefined);
 

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -22,7 +22,29 @@ export type ParsedEnv = {
 };
 
 function invalidAlgorithm(alg: unknown): Error {
-  return new Error(`Invalid algorithm: ${String(alg)}, expected SHA1, SHA256, or SHA512`);
+  return new Error(
+    `Invalid algorithm: ${describeAlgorithm(alg)}, expected SHA1, SHA256, or SHA512`,
+  );
+}
+
+/**
+ * Render a rejected algorithm for the CLI's error message.
+ *
+ * JSON input reaches here as `unknown`, and `String()` throws on a value with
+ * no usable primitive conversion - `{"algorithm":{"toString":null}}` is valid
+ * JSON that produces exactly that. Building the error must not itself throw,
+ * or the user gets a raw TypeError instead of the CLI's message.
+ */
+function describeAlgorithm(alg: unknown): string {
+  if (typeof alg === "string") {
+    return alg;
+  }
+
+  try {
+    return String(alg);
+  } catch {
+    return typeof alg;
+  }
 }
 
 /**
@@ -51,8 +73,9 @@ function normalizeInputAlgorithm(alg?: unknown): OtpAlgorithm {
   try {
     return normalizeHashAlgorithm(alg).toUpperCase() as OtpAlgorithm;
   } catch {
-    // normalizeHashAlgorithm only throws AlgorithmUnsupportedError, which is
-    // restated here in the CLI's own error style.
+    // Caught broadly rather than narrowed to AlgorithmUnsupportedError: the
+    // value is arbitrary parsed JSON, and every rejection should surface in the
+    // CLI's own error style regardless of how core reported it.
     throw invalidAlgorithm(alg);
   }
 }

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -51,7 +51,7 @@ function describeAlgorithm(alg: unknown): string {
  * Parse an algorithm from either input format.
  *
  * Delegates to core's `normalizeHashAlgorithm` so `otpauth://` URIs and
- * user-authored JSON accept exactly the same spellings - case and separators
+ * user-authored JSON accept exactly the same aliases - case and separators
  * are ignored, so `SHA1`, `sha1` and `SHA-256` all resolve. The CLI's own
  * casing (`SHA1`) is applied on the way out.
  */

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -48,27 +48,14 @@ function describeAlgorithm(alg: unknown): string {
 }
 
 /**
- * Lenient algorithm parsing for third-party `otpauth://` URIs.
+ * Parse an algorithm from either input format.
  *
- * Mirrors `parseAlgorithm` in `@otplib/uri` so the CLI accepts the same URIs
- * the library does, including the dashed forms (`SHA-1`, `sha-256`).
+ * Delegates to core's `normalizeHashAlgorithm` so `otpauth://` URIs and
+ * user-authored JSON accept exactly the same spellings - case and separators
+ * are ignored, so `SHA1`, `sha1` and `SHA-256` all resolve. The CLI's own
+ * casing (`SHA1`) is applied on the way out.
  */
-function normalizeUriAlgorithm(alg?: string): OtpAlgorithm {
-  if (!alg) return "SHA1";
-  const normalized = alg.toLowerCase();
-  if (normalized === "sha1" || normalized === "sha-1") return "SHA1";
-  if (normalized === "sha256" || normalized === "sha-256") return "SHA256";
-  if (normalized === "sha512" || normalized === "sha-512") return "SHA512";
-  throw invalidAlgorithm(alg);
-}
-
-/**
- * Strict algorithm parsing for user-authored JSON input.
- *
- * Delegates to core's `normalizeHashAlgorithm`, which case-folds only:
- * `sha1`/`SHA1` are accepted, dashed forms such as `SHA-1` are rejected.
- */
-function normalizeInputAlgorithm(alg?: unknown): OtpAlgorithm {
+function normalizeAlgorithm(alg?: unknown): OtpAlgorithm {
   if (alg === undefined) return "SHA1";
   try {
     return normalizeHashAlgorithm(alg).toUpperCase() as OtpAlgorithm;
@@ -123,7 +110,9 @@ export function parseOtpauthUri(uri: string): OtpData {
     account = label.slice(colonIndex + 1);
   }
 
-  const algorithm = normalizeUriAlgorithm(url.searchParams.get("algorithm") ?? undefined);
+  // `|| undefined` not `??`: an empty `?algorithm=` falls back to the default
+  // rather than being reported as an invalid value.
+  const algorithm = normalizeAlgorithm(url.searchParams.get("algorithm") || undefined);
   const digitsParam = url.searchParams.get("digits");
   const digits = normalizeDigits(digitsParam !== null ? parseInt(digitsParam, 10) : undefined);
 
@@ -163,7 +152,7 @@ export function parseJsonInput(raw: string): OtpData {
     throw new Error('Invalid type: expected "totp" or "hotp"');
   }
 
-  const algorithm = normalizeInputAlgorithm(input.algorithm);
+  const algorithm = normalizeAlgorithm(input.algorithm);
   const digits = normalizeDigits(input.digits);
 
   if (type === "totp") {

--- a/packages/otplib-cli/src/shared/parse.ts
+++ b/packages/otplib-cli/src/shared/parse.ts
@@ -56,7 +56,9 @@ function describeAlgorithm(alg: unknown): string {
  * casing (`SHA1`) is applied on the way out.
  */
 function normalizeAlgorithm(alg?: unknown): OtpAlgorithm {
-  if (alg === undefined) return "SHA1";
+  // JSON spells "absent" as null, and an empty string carries no value either
+  // way - both take the default, as they did before validation moved to core.
+  if (alg === undefined || alg === null || alg === "") return "SHA1";
   try {
     return normalizeHashAlgorithm(alg).toUpperCase() as OtpAlgorithm;
   } catch {
@@ -110,9 +112,7 @@ export function parseOtpauthUri(uri: string): OtpData {
     account = label.slice(colonIndex + 1);
   }
 
-  // `|| undefined` not `??`: an empty `?algorithm=` falls back to the default
-  // rather than being reported as an invalid value.
-  const algorithm = normalizeAlgorithm(url.searchParams.get("algorithm") || undefined);
+  const algorithm = normalizeAlgorithm(url.searchParams.get("algorithm"));
   const digitsParam = url.searchParams.get("digits");
   const digits = normalizeDigits(digitsParam !== null ? parseInt(digitsParam, 10) : undefined);
 

--- a/packages/otplib-cli/tsconfig.json
+++ b/packages/otplib-cli/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],

--- a/packages/otplib/src/class.ts
+++ b/packages/otplib/src/class.ts
@@ -326,6 +326,8 @@ export class OTP {
    *
    * @param options - Generation options
    * @returns OTP code
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails in the crypto plugin
    */
   async generate(options: OTPGenerateOptions): Promise<string> {
     return functionalGenerate({
@@ -342,7 +344,8 @@ export class OTP {
    *
    * @param options - Generation options
    * @returns OTP code
-   * @throws {HMACError} If the crypto plugin doesn't support sync operations
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
    */
   generateSync(options: OTPGenerateOptions): string {
     return functionalGenerateSync({
@@ -359,6 +362,8 @@ export class OTP {
    *
    * @param options - Verification options
    * @returns Verification result with validity and optional delta
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails in the crypto plugin
    */
   async verify(options: OTPVerifyOptions): Promise<VerifyResult> {
     return functionalVerify({
@@ -375,7 +380,8 @@ export class OTP {
    *
    * @param options - Verification options
    * @returns Verification result with validity and optional delta
-   * @throws {HMACError} If the crypto plugin doesn't support sync operations
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
    */
   verifySync(options: OTPVerifyOptions): VerifyResult {
     return functionalVerifySync({
@@ -394,6 +400,7 @@ export class OTP {
    *
    * @param options - URI generation options
    * @returns otpauth:// URI string
+   * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
    */
   generateURI(options: OTPURIGenerateOptions): string {
     return functionalGenerateURI({

--- a/packages/otplib/src/defaults.ts
+++ b/packages/otplib/src/defaults.ts
@@ -21,13 +21,21 @@ export { defaultCrypto, defaultBase32 };
 export function normalizeGenerateOptions(
   options: OTPGenerateOptions,
 ): OTPGenerateOptionsWithDefaults {
+  // Hoisted so the algorithm can be checked against this plugin's own set.
+  const crypto = options.crypto ?? defaultCrypto;
+
   return {
     secret: options.secret,
     strategy: options.strategy ?? "totp",
-    crypto: options.crypto ?? defaultCrypto,
+    crypto,
     base32: options.base32 ?? defaultBase32,
     // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
-    algorithm: normalizeHashAlgorithm(options.algorithm ?? "sha1"),
+    // A plugin supporting fewer algorithms reports what it actually accepts
+    // rather than the full set.
+    algorithm: normalizeHashAlgorithm(options.algorithm ?? "sha1", {
+      supported: crypto.algorithms,
+      plugin: crypto.name,
+    }),
     digits: options.digits ?? 6,
     period: options.period ?? 30,
     epoch: options.epoch ?? Math.floor(Date.now() / 1000),

--- a/packages/otplib/src/defaults.ts
+++ b/packages/otplib/src/defaults.ts
@@ -5,7 +5,7 @@
  * and reduce memory overhead. Uses pre-instantiated frozen singletons
  * from the plugin packages.
  */
-import { createGuardrails } from "@otplib/core";
+import { createGuardrails, normalizeHashAlgorithm } from "@otplib/core";
 import { base32 as defaultBase32 } from "@otplib/plugin-base32-scure";
 import { crypto as defaultCrypto } from "@otplib/plugin-crypto-noble";
 
@@ -26,7 +26,8 @@ export function normalizeGenerateOptions(
     strategy: options.strategy ?? "totp",
     crypto: options.crypto ?? defaultCrypto,
     base32: options.base32 ?? defaultBase32,
-    algorithm: options.algorithm ?? "sha1",
+    // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
+    algorithm: normalizeHashAlgorithm(options.algorithm ?? "sha1"),
     digits: options.digits ?? 6,
     period: options.period ?? 30,
     epoch: options.epoch ?? Math.floor(Date.now() / 1000),

--- a/packages/otplib/src/defaults.ts
+++ b/packages/otplib/src/defaults.ts
@@ -5,7 +5,7 @@
  * and reduce memory overhead. Uses pre-instantiated frozen singletons
  * from the plugin packages.
  */
-import { createGuardrails, normalizeHashAlgorithm } from "@otplib/core";
+import { createGuardrails } from "@otplib/core";
 import { base32 as defaultBase32 } from "@otplib/plugin-base32-scure";
 import { crypto as defaultCrypto } from "@otplib/plugin-crypto-noble";
 
@@ -21,21 +21,15 @@ export { defaultCrypto, defaultBase32 };
 export function normalizeGenerateOptions(
   options: OTPGenerateOptions,
 ): OTPGenerateOptionsWithDefaults {
-  // Hoisted so the algorithm can be checked against this plugin's own set.
-  const crypto = options.crypto ?? defaultCrypto;
-
   return {
     secret: options.secret,
     strategy: options.strategy ?? "totp",
-    crypto,
+    crypto: options.crypto ?? defaultCrypto,
     base32: options.base32 ?? defaultBase32,
-    // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
-    // A plugin supporting fewer algorithms reports what it actually accepts
-    // rather than the full set.
-    algorithm: normalizeHashAlgorithm(options.algorithm ?? "sha1", {
-      supported: crypto.algorithms,
-      plugin: crypto.name,
-    }),
+    // Not normalized here. Every caller of this function delegates to HOTP or
+    // TOTP, which normalize against the same plugin and raise the same error -
+    // doing it twice only changes which frame reports it.
+    algorithm: options.algorithm ?? "sha1",
     digits: options.digits ?? 6,
     period: options.period ?? 30,
     epoch: options.epoch ?? Math.floor(Date.now() / 1000),

--- a/packages/otplib/src/functional.ts
+++ b/packages/otplib/src/functional.ts
@@ -111,6 +111,7 @@ export function generateSecret(options?: {
  *
  * @param options - URI generation options
  * @returns otpauth:// URI string
+ * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
  *
  * @example TOTP
  * ```ts
@@ -183,6 +184,8 @@ export function generateURI(options: {
  *
  * @param options - OTP generation options
  * @returns OTP code
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails in the crypto plugin
  *
  * @example TOTP
  * ```ts
@@ -246,7 +249,8 @@ export async function generate(options: OTPGenerateOptions): Promise<string> {
  *
  * @param options - OTP generation options
  * @returns OTP code
- * @throws {HMACError} If the crypto plugin doesn't support sync operations
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
  *
  * @example
  * ```ts
@@ -291,6 +295,8 @@ export function generateSync(options: OTPGenerateOptions): string {
  *
  * @param options - OTP verification options
  * @returns Verification result with validity and optional delta
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails in the crypto plugin
  *
  * @example TOTP
  * ```ts
@@ -361,7 +367,8 @@ export async function verify(options: OTPVerifyOptions): Promise<VerifyResult> {
  *
  * @param options - OTP verification options
  * @returns Verification result with validity and optional delta
- * @throws {HMACError} If the crypto plugin doesn't support sync operations
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
  *
  * @example
  * ```ts

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -593,9 +593,9 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         ).toThrow(AlgorithmUnsupportedError);
       });
 
-      // Option resolution checks against the configured plugin's own set, so
-      // the error names what that plugin accepts rather than the full
-      // allowlist. Also covers the `crypto` local hoisted in defaults.ts.
+      // The facade delegates to HOTP/TOTP, which check against the configured
+      // plugin's own set - so the error names what that plugin accepts rather
+      // than the full allowlist, without the facade normalizing again itself.
       describe("narrowed crypto plugin", () => {
         const sha1OnlyCrypto: CryptoPlugin = {
           name: "sha1-only",

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -18,7 +18,9 @@ import {
   verifySync,
 } from "./functional.ts";
 
-import type { CryptoPlugin, Base32Plugin } from "@otplib/core";
+import { AlgorithmUnsupportedError } from "@otplib/core";
+
+import type { CryptoPlugin, Base32Plugin, HashAlgorithm } from "@otplib/core";
 import type { TestContext } from "@repo/testing";
 import { TEST_SECRET_HOTP_BASE32, TEST_SECRET_BUG_REPORT } from "@repo/testing";
 
@@ -36,6 +38,9 @@ export type OtplibTestContext = TestContext<CryptoPlugin, Base32Plugin> & {
 };
 
 const TEST_SECRET = TEST_SECRET_HOTP_BASE32;
+
+/** RFC 6238 Appendix B test secret ("12345678901234567890") in Base32 */
+const RFC6238_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
 
 /**
  * Creates the otplib test suite with injected dependencies
@@ -544,6 +549,34 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(() => generateSync({ secret: TEST_SECRET, strategy: "invalid" as never })).toThrow(
           "Unknown OTP strategy: invalid",
         );
+      });
+
+      // Regression: an untyped JS caller passing 'SHA1' used to fall through to a
+      // non-sha1 code path and produce a wrong token ('69342147') instead of the
+      // RFC 6238 vector value.
+      it("should case-fold an uppercase 'SHA1' algorithm (RFC 6238 vector)", () => {
+        const token = generateSync({
+          secret: RFC6238_SECRET,
+          algorithm: "SHA1" as HashAlgorithm,
+          digits: 8,
+          period: 30,
+          epoch: 59,
+        });
+
+        expect(token).toBe("94287082");
+        expect(token).not.toBe("69342147");
+      });
+
+      it("should throw AlgorithmUnsupportedError for a dashed 'SHA-1' algorithm", () => {
+        expect(() =>
+          generateSync({
+            secret: RFC6238_SECRET,
+            algorithm: "SHA-1" as HashAlgorithm,
+            digits: 8,
+            period: 30,
+            epoch: 59,
+          }),
+        ).toThrow(AlgorithmUnsupportedError);
       });
     });
 

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -592,6 +592,59 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
           }),
         ).toThrow(AlgorithmUnsupportedError);
       });
+
+      // Option resolution checks against the configured plugin's own set, so
+      // the error names what that plugin accepts rather than the full
+      // allowlist. Also covers the `crypto` local hoisted in defaults.ts.
+      describe("narrowed crypto plugin", () => {
+        const sha1OnlyCrypto: CryptoPlugin = {
+          name: "sha1-only",
+          algorithms: ["sha1"],
+          hmac: (algorithm, key, data) => crypto.hmac(algorithm, key, data),
+          randomBytes: (length) => crypto.randomBytes(length),
+        };
+
+        it("should reject an algorithm the plugin does not support", () => {
+          expect(() =>
+            generateSync({
+              secret: RFC6238_SECRET,
+              algorithm: "sha512",
+              crypto: sha1OnlyCrypto,
+            }),
+          ).toThrow(AlgorithmUnsupportedError);
+        });
+
+        it("should report the plugin's own set rather than the full allowlist", () => {
+          expect(() =>
+            generateSync({
+              secret: RFC6238_SECRET,
+              algorithm: "sha512",
+              crypto: sha1OnlyCrypto,
+            }),
+          ).toThrow("Expected one of: sha1 ");
+
+          expect(() =>
+            generateSync({
+              secret: RFC6238_SECRET,
+              algorithm: "sha512",
+              crypto: sha1OnlyCrypto,
+            }),
+          ).toThrow("[plugin: sha1-only]");
+        });
+
+        it("should still produce the RFC 6238 vector for a supported algorithm", () => {
+          const token = generateSync({
+            secret: RFC6238_SECRET,
+            algorithm: "sha1",
+            digits: 8,
+            period: 30,
+            epoch: 59,
+            crypto: sha1OnlyCrypto,
+          });
+
+          expect(token).toBe("94287082");
+        });
+      });
     });
 
     describe("verifySync", () => {

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -22,7 +22,11 @@ import { AlgorithmUnsupportedError } from "@otplib/core";
 
 import type { CryptoPlugin, Base32Plugin, HashAlgorithm } from "@otplib/core";
 import type { TestContext } from "@repo/testing";
-import { TEST_SECRET_HOTP_BASE32, TEST_SECRET_BUG_REPORT } from "@repo/testing";
+import {
+  TEST_SECRET_HOTP_BASE32,
+  TEST_SECRET_BUG_REPORT,
+  RFC_TEST_SECRET_BASE32,
+} from "@repo/testing";
 
 export type OtplibTestContext = TestContext<CryptoPlugin, Base32Plugin> & {
   otplib: {
@@ -38,9 +42,6 @@ export type OtplibTestContext = TestContext<CryptoPlugin, Base32Plugin> & {
 };
 
 const TEST_SECRET = TEST_SECRET_HOTP_BASE32;
-
-/** RFC 6238 Appendix B test secret ("12345678901234567890") in Base32 */
-const RFC6238_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
 
 /**
  * Creates the otplib test suite with injected dependencies
@@ -556,7 +557,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
       // RFC 6238 vector value.
       it("should case-fold an uppercase 'SHA1' algorithm (RFC 6238 vector)", () => {
         const token = generateSync({
-          secret: RFC6238_SECRET,
+          secret: RFC_TEST_SECRET_BASE32,
           algorithm: "SHA1" as HashAlgorithm,
           digits: 8,
           period: 30,
@@ -571,7 +572,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
       // as 'SHA1' rather than being rejected or routed to a different digest.
       it("should accept a dashed 'SHA-1' algorithm (RFC 6238 vector)", () => {
         const token = generateSync({
-          secret: RFC6238_SECRET,
+          secret: RFC_TEST_SECRET_BASE32,
           algorithm: "SHA-1" as HashAlgorithm,
           digits: 8,
           period: 30,
@@ -584,7 +585,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
       it("should throw AlgorithmUnsupportedError for an unsupported digest", () => {
         expect(() =>
           generateSync({
-            secret: RFC6238_SECRET,
+            secret: RFC_TEST_SECRET_BASE32,
             algorithm: "sha-384" as HashAlgorithm,
             digits: 8,
             period: 30,
@@ -607,7 +608,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         it("should reject an algorithm the plugin does not support", () => {
           expect(() =>
             generateSync({
-              secret: RFC6238_SECRET,
+              secret: RFC_TEST_SECRET_BASE32,
               algorithm: "sha512",
               crypto: sha1OnlyCrypto,
             }),
@@ -617,7 +618,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         it("should report the plugin's own set rather than the full allowlist", () => {
           expect(() =>
             generateSync({
-              secret: RFC6238_SECRET,
+              secret: RFC_TEST_SECRET_BASE32,
               algorithm: "sha512",
               crypto: sha1OnlyCrypto,
             }),
@@ -625,7 +626,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
 
           expect(() =>
             generateSync({
-              secret: RFC6238_SECRET,
+              secret: RFC_TEST_SECRET_BASE32,
               algorithm: "sha512",
               crypto: sha1OnlyCrypto,
             }),
@@ -634,7 +635,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
 
         it("should still produce the RFC 6238 vector for a supported algorithm", () => {
           const token = generateSync({
-            secret: RFC6238_SECRET,
+            secret: RFC_TEST_SECRET_BASE32,
             algorithm: "sha1",
             digits: 8,
             period: 30,

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -567,11 +567,25 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(token).not.toBe("69342147");
       });
 
-      it("should throw AlgorithmUnsupportedError for a dashed 'SHA-1' algorithm", () => {
+      // Separators are stripped, so this must land on the same RFC 6238 vector
+      // as 'SHA1' rather than being rejected or routed to a different digest.
+      it("should accept a dashed 'SHA-1' algorithm (RFC 6238 vector)", () => {
+        const token = generateSync({
+          secret: RFC6238_SECRET,
+          algorithm: "SHA-1" as HashAlgorithm,
+          digits: 8,
+          period: 30,
+          epoch: 59,
+        });
+
+        expect(token).toBe("94287082");
+      });
+
+      it("should throw AlgorithmUnsupportedError for an unsupported digest", () => {
         expect(() =>
           generateSync({
             secret: RFC6238_SECRET,
-            algorithm: "SHA-1" as HashAlgorithm,
+            algorithm: "sha-384" as HashAlgorithm,
             digits: 8,
             period: 30,
             epoch: 59,

--- a/packages/otplib/src/index-test.ts
+++ b/packages/otplib/src/index-test.ts
@@ -568,7 +568,7 @@ export function createOtplibTests(ctx: OtplibTestContext): void {
         expect(token).not.toBe("69342147");
       });
 
-      // Separators are stripped, so this must land on the same RFC 6238 vector
+      // The explicit dashed SHA-1 alias must land on the same RFC 6238 vector
       // as 'SHA1' rather than being rejected or routed to a different digest.
       it("should accept a dashed 'SHA-1' algorithm (RFC 6238 vector)", () => {
         const token = generateSync({

--- a/packages/otplib/src/index.test.ts
+++ b/packages/otplib/src/index.test.ts
@@ -8,6 +8,14 @@ import { NobleCryptoPlugin } from "@otplib/plugin-crypto-noble";
 import { ScureBase32Plugin } from "@otplib/plugin-base32-scure";
 import { TOTP } from "@otplib/totp";
 import {
+  AlgorithmError as CoreAlgorithmError,
+  AlgorithmUnsupportedError as CoreAlgorithmUnsupportedError,
+  HMACError as CoreHMACError,
+} from "@otplib/core";
+import {
+  AlgorithmError,
+  AlgorithmUnsupportedError,
+  HMACError,
   generateSecret,
   generateURI,
   generate,
@@ -19,6 +27,14 @@ import {
 } from "./index.js";
 import { TEST_SECRET_GUARDRAILS } from "@repo/testing";
 import { createOtplibTests } from "./index-test.ts";
+
+describe("error exports", () => {
+  it("re-exports the relevant @otplib/core error constructors", () => {
+    expect(AlgorithmError).toBe(CoreAlgorithmError);
+    expect(AlgorithmUnsupportedError).toBe(CoreAlgorithmUnsupportedError);
+    expect(HMACError).toBe(CoreHMACError);
+  });
+});
 
 createOtplibTests({
   describe,

--- a/packages/otplib/src/index.ts
+++ b/packages/otplib/src/index.ts
@@ -36,7 +36,15 @@ export type { VerifyResult } from "@otplib/totp";
 export { HOTP } from "@otplib/hotp";
 export { TOTP } from "@otplib/totp";
 
-export { createGuardrails, stringToBytes, wrapResult, wrapResultAsync } from "@otplib/core";
+export {
+  AlgorithmError,
+  AlgorithmUnsupportedError,
+  HMACError,
+  createGuardrails,
+  stringToBytes,
+  wrapResult,
+  wrapResultAsync,
+} from "@otplib/core";
 
 // Default Plugins
 export { NobleCryptoPlugin } from "@otplib/plugin-crypto-noble";

--- a/packages/plugin-crypto-noble/package.json
+++ b/packages/plugin-crypto-noble/package.json
@@ -57,6 +57,7 @@
     "@otplib/core": "workspace:*"
   },
   "devDependencies": {
+    "@repo/testing": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"

--- a/packages/plugin-crypto-noble/src/index.test.ts
+++ b/packages/plugin-crypto-noble/src/index.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { NobleCryptoPlugin } from "./index.js";
-import { stringToBytes } from "@otplib/core";
-import { testRFC4226HMAC } from "@repo/testing";
+import { AlgorithmUnsupportedError, stringToBytes } from "@otplib/core";
+import { createCryptoAlgorithmTests, testRFC4226HMAC } from "@repo/testing";
+
+createCryptoAlgorithmTests({
+  describe,
+  it,
+  expect,
+  crypto: new NobleCryptoPlugin(),
+  errorClass: AlgorithmUnsupportedError,
+});
 
 describe("NobleCryptoPlugin", () => {
   describe("randomBytes", () => {
@@ -37,39 +45,6 @@ describe("NobleCryptoPlugin", () => {
   });
 
   describe("hmac", () => {
-    it("should compute HMAC-SHA1 correctly", async () => {
-      const plugin = new NobleCryptoPlugin();
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha1", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(20); // SHA1 outputs 20 bytes
-    });
-
-    it("should compute HMAC-SHA256 correctly", async () => {
-      const plugin = new NobleCryptoPlugin();
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha256", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(32); // SHA256 outputs 32 bytes
-    });
-
-    it("should compute HMAC-SHA512 correctly", async () => {
-      const plugin = new NobleCryptoPlugin();
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha512", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(64); // SHA512 outputs 64 bytes
-    });
-
     it("should produce consistent HMAC for same inputs", async () => {
       const plugin = new NobleCryptoPlugin();
       const secret = stringToBytes("abcde");

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -26,9 +26,11 @@ const HASH_FNS = {
  * Algorithms this plugin can compute
  *
  * Derived from the dispatch map rather than written out again, so the declared
- * set cannot disagree with what `hmac` actually handles.
+ * set cannot disagree with what `hmac` actually handles. Frozen because
+ * `readonly` is erased at compile time, so an unfrozen array exposed as
+ * `plugin.algorithms` could be mutated in-process to broaden it.
  */
-const SUPPORTED_ALGORITHMS = Object.keys(HASH_FNS) as readonly HashAlgorithm[];
+const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(HASH_FNS) as HashAlgorithm[]);
 
 /**
  * Pure JavaScript implementation of CryptoPlugin

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -64,9 +64,10 @@ export class NobleCryptoPlugin implements CryptoPlugin {
    *
    * Synchronous implementation using pure JS.
    *
-   * The algorithm is matched ignoring case and separators, so `'SHA1'`,
-   * `'Sha1'` and `'SHA-1'` all resolve to `'sha1'`. Any other digest throws
-   * `AlgorithmUnsupportedError` rather than falling back to a default.
+   * The algorithm is matched ignoring case, with an optional `-` or `_` before
+   * the digest size, so `'SHA1'`, `'Sha1'` and `'SHA-1'` all resolve to
+   * `'sha1'`. Any other digest throws `AlgorithmUnsupportedError` rather than
+   * falling back to a default.
    *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -76,7 +76,10 @@ export class NobleCryptoPlugin implements CryptoPlugin {
    * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
-    const alg = normalizeHashAlgorithm(algorithm, { plugin: this.name });
+    const alg = normalizeHashAlgorithm(algorithm, {
+      supported: this.algorithms,
+      plugin: this.name,
+    });
     return hmac(HASH_FNS[alg], key, data);
   }
 

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -2,9 +2,21 @@ import { hmac } from "@noble/hashes/hmac.js";
 import { sha1 } from "@noble/hashes/legacy.js";
 import { sha256, sha512 } from "@noble/hashes/sha2.js";
 import { randomBytes } from "@noble/hashes/utils.js";
-import { constantTimeEqual as constantTimeEqualUtil } from "@otplib/core";
+import { constantTimeEqual as constantTimeEqualUtil, normalizeHashAlgorithm } from "@otplib/core";
 
-import type { CryptoPlugin } from "@otplib/core";
+import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
+
+/**
+ * Hash function lookup keyed by canonical algorithm name
+ *
+ * Deliberately has no fallback branch: unsupported values are rejected by
+ * `normalizeHashAlgorithm` before they ever reach this map.
+ */
+const HASH_FNS = {
+  sha1,
+  sha256,
+  sha512,
+} as const;
 
 /**
  * Pure JavaScript implementation of CryptoPlugin
@@ -35,14 +47,19 @@ export class NobleCryptoPlugin implements CryptoPlugin {
    *
    * Synchronous implementation using pure JS.
    *
+   * The algorithm is matched case-insensitively (`'SHA1'` and `'Sha1'` both
+   * resolve to `'sha1'`). Anything else - including separator spellings such
+   * as `'SHA-1'` - throws `AlgorithmUnsupportedError`.
+   *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key
    * @param data - Data to authenticate
    * @returns HMAC digest
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
-  hmac(algorithm: "sha1" | "sha256" | "sha512", key: Uint8Array, data: Uint8Array): Uint8Array {
-    const hashFn = algorithm === "sha1" ? sha1 : algorithm === "sha256" ? sha256 : sha512;
-    return hmac(hashFn, key, data);
+  hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
+    const alg = normalizeHashAlgorithm(algorithm, undefined, this.name);
+    return hmac(HASH_FNS[alg], key, data);
   }
 
   /**

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -47,9 +47,9 @@ export class NobleCryptoPlugin implements CryptoPlugin {
    *
    * Synchronous implementation using pure JS.
    *
-   * The algorithm is matched case-insensitively (`'SHA1'` and `'Sha1'` both
-   * resolve to `'sha1'`). Anything else - including separator spellings such
-   * as `'SHA-1'` - throws `AlgorithmUnsupportedError`.
+   * The algorithm is matched ignoring case and separators, so `'SHA1'`,
+   * `'Sha1'` and `'SHA-1'` all resolve to `'sha1'`. Any other digest throws
+   * `AlgorithmUnsupportedError` rather than falling back to a default.
    *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -11,12 +11,24 @@ import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
  *
  * Deliberately has no fallback branch: unsupported values are rejected by
  * `normalizeHashAlgorithm` before they ever reach this map.
+ *
+ * The `satisfies` constraint forbids a key outside `HashAlgorithm`, so this
+ * plugin cannot widen the allowlist, and requires every member of it, so a
+ * newly supported algorithm fails to compile until it is dispatched here.
  */
 const HASH_FNS = {
   sha1,
   sha256,
   sha512,
-} as const;
+} as const satisfies Record<HashAlgorithm, unknown>;
+
+/**
+ * Algorithms this plugin can compute
+ *
+ * Derived from the dispatch map rather than written out again, so the declared
+ * set cannot disagree with what `hmac` actually handles.
+ */
+const SUPPORTED_ALGORITHMS = Object.keys(HASH_FNS) as readonly HashAlgorithm[];
 
 /**
  * Pure JavaScript implementation of CryptoPlugin
@@ -43,6 +55,11 @@ export class NobleCryptoPlugin implements CryptoPlugin {
   readonly name = "noble";
 
   /**
+   * Algorithms this plugin can compute
+   */
+  readonly algorithms = SUPPORTED_ALGORITHMS;
+
+  /**
    * Compute HMAC using @noble/hashes
    *
    * Synchronous implementation using pure JS.
@@ -58,7 +75,7 @@ export class NobleCryptoPlugin implements CryptoPlugin {
    * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
-    const alg = normalizeHashAlgorithm(algorithm, undefined, this.name);
+    const alg = normalizeHashAlgorithm(algorithm, { plugin: this.name });
     return hmac(HASH_FNS[alg], key, data);
   }
 

--- a/packages/plugin-crypto-noble/src/index.ts
+++ b/packages/plugin-crypto-noble/src/index.ts
@@ -28,7 +28,8 @@ const HASH_FNS = {
  * Derived from the dispatch map rather than written out again, so the declared
  * set cannot disagree with what `hmac` actually handles. Frozen because
  * `readonly` is erased at compile time, so an unfrozen array exposed as
- * `plugin.algorithms` could be mutated in-process to broaden it.
+ * `plugin.algorithms` could be mutated in-process and make the capability
+ * metadata unstable.
  */
 const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(HASH_FNS) as HashAlgorithm[]);
 

--- a/packages/plugin-crypto-node/package.json
+++ b/packages/plugin-crypto-node/package.json
@@ -55,6 +55,7 @@
     "@otplib/core": "workspace:*"
   },
   "devDependencies": {
+    "@repo/testing": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"

--- a/packages/plugin-crypto-node/src/index.test.ts
+++ b/packages/plugin-crypto-node/src/index.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { NodeCryptoPlugin } from "./index.js";
-import { stringToBytes } from "@otplib/core";
-import { testRFC4226HMAC } from "@repo/testing";
+import { AlgorithmUnsupportedError, stringToBytes } from "@otplib/core";
+import { createCryptoAlgorithmTests, testRFC4226HMAC } from "@repo/testing";
+
+createCryptoAlgorithmTests({
+  describe,
+  it,
+  expect,
+  crypto: new NodeCryptoPlugin(),
+  errorClass: AlgorithmUnsupportedError,
+});
 
 describe("NodeCryptoPlugin", () => {
   describe("randomBytes", () => {
@@ -37,39 +45,6 @@ describe("NodeCryptoPlugin", () => {
   });
 
   describe("hmac", () => {
-    it("should compute HMAC-SHA1 correctly", async () => {
-      const plugin = new NodeCryptoPlugin();
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha1", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(20); // SHA1 outputs 20 bytes
-    });
-
-    it("should compute HMAC-SHA256 correctly", async () => {
-      const plugin = new NodeCryptoPlugin();
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha256", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(32); // SHA256 outputs 32 bytes
-    });
-
-    it("should compute HMAC-SHA512 correctly", async () => {
-      const plugin = new NodeCryptoPlugin();
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha512", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(64); // SHA512 outputs 64 bytes
-    });
-
     it("should produce consistent HMAC for same inputs", async () => {
       const plugin = new NodeCryptoPlugin();
       const secret = stringToBytes("abcde");

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -1,6 +1,12 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
-import { stringToBytes, validateByteLengthEqual, type CryptoPlugin } from "@otplib/core";
+import {
+  normalizeHashAlgorithm,
+  stringToBytes,
+  validateByteLengthEqual,
+  type CryptoPlugin,
+  type HashAlgorithm,
+} from "@otplib/core";
 
 /**
  * Node.js crypto module implementation of CryptoPlugin
@@ -30,13 +36,20 @@ export class NodeCryptoPlugin implements CryptoPlugin {
    *
    * Synchronous implementation using createHmac.
    *
+   * The algorithm is matched case-insensitively (`'SHA1'` and `'Sha1'` both
+   * resolve to `'sha1'`). Anything else - including separator spellings such
+   * as `'SHA-1'` and other digests OpenSSL happens to support - throws
+   * `AlgorithmUnsupportedError`.
+   *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key
    * @param data - Data to authenticate
    * @returns HMAC digest
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
-  hmac(algorithm: "sha1" | "sha256" | "sha512", key: Uint8Array, data: Uint8Array): Uint8Array {
-    const hmac = createHmac(algorithm, key);
+  hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
+    const alg = normalizeHashAlgorithm(algorithm, undefined, this.name);
+    const hmac = createHmac(alg, key);
     hmac.update(data);
     return new Uint8Array(hmac.digest());
   }

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -9,6 +9,31 @@ import {
 } from "@otplib/core";
 
 /**
+ * OpenSSL digest name keyed by canonical algorithm name
+ *
+ * An explicit map rather than forwarding the caller's string: passing it
+ * straight through is how this plugin used to inherit OpenSSL's whole digest
+ * catalogue, accepting `md5`, `sha224` and `ripemd160`. Routing through a
+ * closed map makes that structural rather than a matter of validating first.
+ *
+ * The `satisfies` constraint forbids a key outside `HashAlgorithm` and
+ * requires every member of it.
+ */
+const OPENSSL_DIGESTS = {
+  sha1: "sha1",
+  sha256: "sha256",
+  sha512: "sha512",
+} as const satisfies Record<HashAlgorithm, string>;
+
+/**
+ * Algorithms this plugin can compute
+ *
+ * Derived from the digest map rather than written out again, so the declared
+ * set cannot disagree with what `hmac` actually handles.
+ */
+const SUPPORTED_ALGORITHMS = Object.keys(OPENSSL_DIGESTS) as readonly HashAlgorithm[];
+
+/**
  * Node.js crypto module implementation of CryptoPlugin
  *
  * This plugin uses Node.js's built-in crypto module which provides:
@@ -32,6 +57,11 @@ export class NodeCryptoPlugin implements CryptoPlugin {
   readonly name = "node";
 
   /**
+   * Algorithms this plugin can compute
+   */
+  readonly algorithms = SUPPORTED_ALGORITHMS;
+
+  /**
    * Compute HMAC using Node.js crypto module
    *
    * Synchronous implementation using createHmac.
@@ -48,8 +78,8 @@ export class NodeCryptoPlugin implements CryptoPlugin {
    * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
-    const alg = normalizeHashAlgorithm(algorithm, undefined, this.name);
-    const hmac = createHmac(alg, key);
+    const alg = normalizeHashAlgorithm(algorithm, { plugin: this.name });
+    const hmac = createHmac(OPENSSL_DIGESTS[alg], key);
     hmac.update(data);
     return new Uint8Array(hmac.digest());
   }

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -31,7 +31,8 @@ const OPENSSL_DIGESTS = {
  * Derived from the digest map rather than written out again, so the declared
  * set cannot disagree with what `hmac` actually handles. Frozen because
  * `readonly` is erased at compile time, so an unfrozen array exposed as
- * `plugin.algorithms` could be mutated in-process to broaden it.
+ * `plugin.algorithms` could be mutated in-process and make the capability
+ * metadata unstable.
  */
 const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(OPENSSL_DIGESTS) as HashAlgorithm[]);
 

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -29,9 +29,11 @@ const OPENSSL_DIGESTS = {
  * Algorithms this plugin can compute
  *
  * Derived from the digest map rather than written out again, so the declared
- * set cannot disagree with what `hmac` actually handles.
+ * set cannot disagree with what `hmac` actually handles. Frozen because
+ * `readonly` is erased at compile time, so an unfrozen array exposed as
+ * `plugin.algorithms` could be mutated in-process to broaden it.
  */
-const SUPPORTED_ALGORITHMS = Object.keys(OPENSSL_DIGESTS) as readonly HashAlgorithm[];
+const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(OPENSSL_DIGESTS) as HashAlgorithm[]);
 
 /**
  * Node.js crypto module implementation of CryptoPlugin

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -78,7 +78,10 @@ export class NodeCryptoPlugin implements CryptoPlugin {
    * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Uint8Array {
-    const alg = normalizeHashAlgorithm(algorithm, { plugin: this.name });
+    const alg = normalizeHashAlgorithm(algorithm, {
+      supported: this.algorithms,
+      plugin: this.name,
+    });
     const hmac = createHmac(OPENSSL_DIGESTS[alg], key);
     hmac.update(data);
     return new Uint8Array(hmac.digest());

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -66,10 +66,10 @@ export class NodeCryptoPlugin implements CryptoPlugin {
    *
    * Synchronous implementation using createHmac.
    *
-   * The algorithm is matched ignoring case and separators, so `'SHA1'`,
-   * `'Sha1'` and `'SHA-1'` all resolve to `'sha1'`. Any other digest OpenSSL
-   * happens to support - `'md5'`, `'sha224'`, `'ripemd160'` - throws
-   * `AlgorithmUnsupportedError`.
+   * The algorithm is matched ignoring case, with an optional `-` or `_` before
+   * the digest size, so `'SHA1'`, `'Sha1'` and `'SHA-1'` all resolve to
+   * `'sha1'`. Any other digest OpenSSL happens to support - `'md5'`,
+   * `'sha224'`, `'ripemd160'` - throws `AlgorithmUnsupportedError`.
    *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key

--- a/packages/plugin-crypto-node/src/index.ts
+++ b/packages/plugin-crypto-node/src/index.ts
@@ -36,9 +36,9 @@ export class NodeCryptoPlugin implements CryptoPlugin {
    *
    * Synchronous implementation using createHmac.
    *
-   * The algorithm is matched case-insensitively (`'SHA1'` and `'Sha1'` both
-   * resolve to `'sha1'`). Anything else - including separator spellings such
-   * as `'SHA-1'` and other digests OpenSSL happens to support - throws
+   * The algorithm is matched ignoring case and separators, so `'SHA1'`,
+   * `'Sha1'` and `'SHA-1'` all resolve to `'sha1'`. Any other digest OpenSSL
+   * happens to support - `'md5'`, `'sha224'`, `'ripemd160'` - throws
    * `AlgorithmUnsupportedError`.
    *
    * @param algorithm - Hash algorithm to use

--- a/packages/plugin-crypto-web/package.json
+++ b/packages/plugin-crypto-web/package.json
@@ -56,6 +56,7 @@
     "@otplib/core": "workspace:*"
   },
   "devDependencies": {
+    "@repo/testing": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"

--- a/packages/plugin-crypto-web/src/index.test.ts
+++ b/packages/plugin-crypto-web/src/index.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { WebCryptoPlugin } from "./index.js";
-import { stringToBytes } from "@otplib/core";
-import { testRFC4226HMAC } from "@repo/testing";
+import { AlgorithmUnsupportedError, stringToBytes } from "@otplib/core";
+import { createCryptoAlgorithmTests, testRFC4226HMAC } from "@repo/testing";
+
+createCryptoAlgorithmTests({
+  describe,
+  it,
+  expect,
+  crypto: new WebCryptoPlugin(),
+  errorClass: AlgorithmUnsupportedError,
+});
 
 describe("WebCryptoPlugin", () => {
   let plugin: WebCryptoPlugin;
@@ -51,36 +59,6 @@ describe("WebCryptoPlugin", () => {
   });
 
   describe("hmac", () => {
-    it("should compute HMAC-SHA1 correctly", async () => {
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha1", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(20); // SHA1 outputs 20 bytes
-    });
-
-    it("should compute HMAC-SHA256 correctly", async () => {
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha256", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(32); // SHA256 outputs 32 bytes
-    });
-
-    it("should compute HMAC-SHA512 correctly", async () => {
-      const secret = stringToBytes("abcde");
-      const message = stringToBytes("fghij");
-
-      const result = await plugin.hmac("sha512", secret, message);
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(64); // SHA512 outputs 64 bytes
-    });
-
     it("should produce consistent HMAC for same inputs", async () => {
       const secret = stringToBytes("abcde");
       const message = stringToBytes("fghij");

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -54,9 +54,10 @@ export class WebCryptoPlugin implements CryptoPlugin {
    *
    * Async implementation using SubtleCrypto.
    *
-   * The algorithm is matched case-insensitively (`'SHA1'` and `'Sha1'` both
-   * resolve to `'sha1'`). Anything else - including the Web Crypto spelling
-   * `'SHA-1'` - throws `AlgorithmUnsupportedError`.
+   * The algorithm is matched ignoring case and separators, so `'SHA1'`,
+   * `'Sha1'` and Web Crypto's own `'SHA-1'` all resolve to `'sha1'`. Any other
+   * digest - including ones SubtleCrypto supports, such as `'SHA-384'` -
+   * throws `AlgorithmUnsupportedError`.
    *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -1,4 +1,4 @@
-import { constantTimeEqual as constantTimeEqualUtil } from "@otplib/core";
+import { constantTimeEqual as constantTimeEqualUtil, normalizeHashAlgorithm } from "@otplib/core";
 
 import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
 
@@ -54,23 +54,25 @@ export class WebCryptoPlugin implements CryptoPlugin {
    *
    * Async implementation using SubtleCrypto.
    *
+   * The algorithm is matched case-insensitively (`'SHA1'` and `'Sha1'` both
+   * resolve to `'sha1'`). Anything else - including the Web Crypto spelling
+   * `'SHA-1'` - throws `AlgorithmUnsupportedError`.
+   *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key
    * @param data - Data to authenticate
    * @returns HMAC digest
+   * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
-  async hmac(
-    algorithm: "sha1" | "sha256" | "sha512",
-    key: Uint8Array,
-    data: Uint8Array,
-  ): Promise<Uint8Array> {
+  async hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
+    const alg = normalizeHashAlgorithm(algorithm, undefined, this.name);
     const webCrypto = globalThis.crypto;
 
     if (!webCrypto?.subtle) {
       throw new Error("Web Crypto API is not available in this environment");
     }
 
-    const hashAlgorithm = ALGORITHM_MAP[algorithm];
+    const hashAlgorithm = ALGORITHM_MAP[alg];
 
     const cryptoKey = await webCrypto.subtle.importKey(
       "raw",

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -22,9 +22,10 @@ const ALGORITHM_MAP = {
  * Derived from the algorithm map rather than written out again, so the
  * declared set cannot disagree with what `hmac` actually handles. Frozen
  * because `readonly` is erased at compile time, so an unfrozen array exposed as
- * `plugin.algorithms` could be mutated in-process to broaden it. Note that
+ * `plugin.algorithms` could be mutated in-process and make the capability
+ * metadata unstable. Note that
  * SubtleCrypto also implements SHA-384; it is deliberately absent, because
- * RFC 6238 does not include it and no authenticator would verify the result.
+ * RFC 6238 does not include it and using it would reduce interoperability.
  */
 const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(ALGORITHM_MAP) as HashAlgorithm[]);
 

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -5,13 +5,26 @@ import type { CryptoPlugin, HashAlgorithm } from "@otplib/core";
 /**
  * Web Crypto algorithm name mapping
  *
- * Maps our algorithm names to Web Crypto API algorithm identifiers.
+ * Maps our algorithm names to Web Crypto API algorithm identifiers. The
+ * `satisfies` constraint forbids a key outside `HashAlgorithm` and requires
+ * every member of it, so this plugin can neither widen the allowlist nor
+ * silently skip a newly supported algorithm.
  */
 const ALGORITHM_MAP = {
   sha1: "SHA-1",
   sha256: "SHA-256",
   sha512: "SHA-512",
 } as const satisfies Record<HashAlgorithm, string>;
+
+/**
+ * Algorithms this plugin can compute
+ *
+ * Derived from the algorithm map rather than written out again, so the
+ * declared set cannot disagree with what `hmac` actually handles. Note that
+ * SubtleCrypto also implements SHA-384; it is deliberately absent, because
+ * RFC 6238 does not include it and no authenticator would verify the result.
+ */
+const SUPPORTED_ALGORITHMS = Object.keys(ALGORITHM_MAP) as readonly HashAlgorithm[];
 
 /**
  * Get ArrayBuffer from Uint8Array, avoiding copy when possible
@@ -50,6 +63,11 @@ export class WebCryptoPlugin implements CryptoPlugin {
   readonly name = "web";
 
   /**
+   * Algorithms this plugin can compute
+   */
+  readonly algorithms = SUPPORTED_ALGORITHMS;
+
+  /**
    * Compute HMAC using Web Crypto API
    *
    * Async implementation using SubtleCrypto.
@@ -66,7 +84,7 @@ export class WebCryptoPlugin implements CryptoPlugin {
    * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   async hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
-    const alg = normalizeHashAlgorithm(algorithm, undefined, this.name);
+    const alg = normalizeHashAlgorithm(algorithm, { plugin: this.name });
     const webCrypto = globalThis.crypto;
 
     if (!webCrypto?.subtle) {

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -20,11 +20,13 @@ const ALGORITHM_MAP = {
  * Algorithms this plugin can compute
  *
  * Derived from the algorithm map rather than written out again, so the
- * declared set cannot disagree with what `hmac` actually handles. Note that
+ * declared set cannot disagree with what `hmac` actually handles. Frozen
+ * because `readonly` is erased at compile time, so an unfrozen array exposed as
+ * `plugin.algorithms` could be mutated in-process to broaden it. Note that
  * SubtleCrypto also implements SHA-384; it is deliberately absent, because
  * RFC 6238 does not include it and no authenticator would verify the result.
  */
-const SUPPORTED_ALGORITHMS = Object.keys(ALGORITHM_MAP) as readonly HashAlgorithm[];
+const SUPPORTED_ALGORITHMS = Object.freeze(Object.keys(ALGORITHM_MAP) as HashAlgorithm[]);
 
 /**
  * Get ArrayBuffer from Uint8Array, avoiding copy when possible

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -84,7 +84,10 @@ export class WebCryptoPlugin implements CryptoPlugin {
    * @throws {AlgorithmUnsupportedError} If the algorithm is not supported
    */
   async hmac(algorithm: HashAlgorithm, key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
-    const alg = normalizeHashAlgorithm(algorithm, { plugin: this.name });
+    const alg = normalizeHashAlgorithm(algorithm, {
+      supported: this.algorithms,
+      plugin: this.name,
+    });
     const webCrypto = globalThis.crypto;
 
     if (!webCrypto?.subtle) {

--- a/packages/plugin-crypto-web/src/index.ts
+++ b/packages/plugin-crypto-web/src/index.ts
@@ -72,10 +72,10 @@ export class WebCryptoPlugin implements CryptoPlugin {
    *
    * Async implementation using SubtleCrypto.
    *
-   * The algorithm is matched ignoring case and separators, so `'SHA1'`,
-   * `'Sha1'` and Web Crypto's own `'SHA-1'` all resolve to `'sha1'`. Any other
-   * digest - including ones SubtleCrypto supports, such as `'SHA-384'` -
-   * throws `AlgorithmUnsupportedError`.
+   * The algorithm is matched ignoring case, with an optional `-` or `_` before
+   * the digest size, so `'SHA1'`, `'Sha1'` and Web Crypto's own `'SHA-1'` all
+   * resolve to `'sha1'`. Any other digest - including ones SubtleCrypto
+   * supports, such as `'SHA-384'` - throws `AlgorithmUnsupportedError`.
    *
    * @param algorithm - Hash algorithm to use
    * @param key - Secret key

--- a/packages/totp/src/class.ts
+++ b/packages/totp/src/class.ts
@@ -70,6 +70,8 @@ export class TOTP {
    *
    * @param options - Optional overrides
    * @returns The TOTP code
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails in the crypto plugin
    */
   async generate(options?: Partial<TOTPOptions>): Promise<string> {
     const mergedOptions = { ...this.options, ...options };
@@ -110,6 +112,8 @@ export class TOTP {
    * @param token - The token to verify
    * @param options - Optional verification options
    * @returns Verification result with validity and optional delta
+   * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+   * @throws {HMACError} If HMAC computation fails in the crypto plugin
    */
   async verify(
     token: string,
@@ -161,6 +165,7 @@ export class TOTP {
    *
    * @param options - Optional overrides for label, issuer, and secret
    * @returns The otpauth:// URI
+   * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
    *
    * @example Without parameters (uses instance settings)
    * ```typescript

--- a/packages/totp/src/index-test.ts
+++ b/packages/totp/src/index-test.ts
@@ -8,6 +8,7 @@
 import {
   stringToBytes,
   createGuardrails,
+  AlgorithmUnsupportedError,
   SecretTooLongError,
   SecretTooShortError,
   PeriodTooLargeError,
@@ -2843,6 +2844,55 @@ export function createTOTPTests(ctx: TestContext<CryptoPlugin>): void {
             expect(STEAM_CHARS).toContain(ch);
           }
         });
+      });
+    });
+
+    // A plugin may support fewer algorithms than the library. Options
+    // resolution checks against that plugin's own set, so the error names what
+    // the configured plugin actually accepts instead of the full allowlist.
+    describe("narrowed crypto plugin", () => {
+      const sha1OnlyCrypto: CryptoPlugin = {
+        name: "sha1-only",
+        algorithms: ["sha1"],
+        hmac: (algorithm, key, data) => crypto.hmac(algorithm, key, data),
+        randomBytes: (length) => crypto.randomBytes(length),
+      };
+
+      it("should reject an algorithm the plugin does not support", async () => {
+        await expect(
+          generate({ secret, algorithm: "sha512", crypto: sha1OnlyCrypto }),
+        ).rejects.toThrow(AlgorithmUnsupportedError);
+      });
+
+      it("should report the plugin's own set rather than the full allowlist", async () => {
+        await expect(
+          generate({ secret, algorithm: "sha512", crypto: sha1OnlyCrypto }),
+        ).rejects.toThrow("[plugin: sha1-only]");
+
+        await expect(
+          generate({ secret, algorithm: "sha512", crypto: sha1OnlyCrypto }),
+        ).rejects.toThrow("Expected one of: sha1 ");
+      });
+
+      it("should still accept an algorithm the plugin supports", async () => {
+        const token = await generate({
+          secret,
+          algorithm: "sha1",
+          crypto: sha1OnlyCrypto,
+        });
+
+        expect(token).toMatch(/^\d{6}$/);
+      });
+
+      it("should reject on verify as well", async () => {
+        await expect(
+          verify({
+            secret,
+            token: "000000",
+            algorithm: "sha512",
+            crypto: sha1OnlyCrypto,
+          }),
+        ).rejects.toThrow(AlgorithmUnsupportedError);
       });
     });
   });

--- a/packages/totp/src/index.ts
+++ b/packages/totp/src/index.ts
@@ -77,7 +77,12 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
   validateTime(epoch);
   validatePeriod(period, guardrails);
   // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
-  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
+  // Checked against the configured plugin's own set, so a plugin supporting
+  // fewer algorithms reports what it actually accepts rather than the full set.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm, {
+    supported: crypto.algorithms,
+    plugin: crypto.name,
+  });
 
   const counter = Math.floor((epoch - t0) / period);
 
@@ -259,7 +264,12 @@ function getTOTPVerifyOptions(options: TOTPVerifyOptions): TOTPVerifyOptionsInte
   validateTime(epoch);
   validatePeriod(period, guardrails);
   // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
-  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
+  // Checked against the configured plugin's own set, so a plugin supporting
+  // fewer algorithms reports what it actually accepts rather than the full set.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm, {
+    supported: crypto.algorithms,
+    plugin: crypto.name,
+  });
 
   // Use custom validator if provided, otherwise default digit-only check
   if (hooks?.validateToken) {

--- a/packages/totp/src/index.ts
+++ b/packages/totp/src/index.ts
@@ -14,6 +14,7 @@ import {
   createGuardrails,
   normalizeSecret,
   normalizeEpochTolerance,
+  normalizeHashAlgorithm,
   validateEpochTolerance,
   validatePeriod,
   validateSecret,
@@ -60,7 +61,7 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
     epoch = Math.floor(Date.now() / 1000),
     t0 = 0,
     period = 30,
-    algorithm = "sha1",
+    algorithm: rawAlgorithm = "sha1",
     digits = 6,
     crypto,
     base32,
@@ -75,6 +76,8 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
   validateSecret(secretBytes, guardrails);
   validateTime(epoch);
   validatePeriod(period, guardrails);
+  // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
 
   const counter = Math.floor((epoch - t0) / period);
 
@@ -238,7 +241,7 @@ function getTOTPVerifyOptions(options: TOTPVerifyOptions): TOTPVerifyOptionsInte
     epoch = Math.floor(Date.now() / 1000),
     t0 = 0,
     period = 30,
-    algorithm = "sha1",
+    algorithm: rawAlgorithm = "sha1",
     digits = 6,
     crypto,
     base32,
@@ -255,6 +258,8 @@ function getTOTPVerifyOptions(options: TOTPVerifyOptions): TOTPVerifyOptionsInte
   validateSecret(secretBytes, guardrails);
   validateTime(epoch);
   validatePeriod(period, guardrails);
+  // Case-fold at the public API boundary: untyped JS callers may pass 'SHA1'.
+  const algorithm = normalizeHashAlgorithm(rawAlgorithm);
 
   // Use custom validator if provided, otherwise default digit-only check
   if (hooks?.validateToken) {

--- a/packages/totp/src/index.ts
+++ b/packages/totp/src/index.ts
@@ -117,6 +117,8 @@ function getTOTPGenerateOptions(options: TOTPGenerateOptions): TOTPGenerateOptio
  *
  * @param options - TOTP generation options
  * @returns The TOTP code as a string
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails in the crypto plugin
  *
  * @example
  * ```ts
@@ -150,7 +152,8 @@ export async function generate(options: TOTPGenerateOptions): Promise<string> {
  *
  * @param options - TOTP generation options
  * @returns The TOTP code as a string
- * @throws {HMACError} If the crypto plugin doesn't support sync operations
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
  *
  * @example
  * ```ts
@@ -329,6 +332,8 @@ function getTOTPVerifyOptions(options: TOTPVerifyOptions): TOTPVerifyOptionsInte
  *
  * @param options - TOTP verification options
  * @returns Verification result with validity and optional delta
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails in the crypto plugin
  *
  * @example Using epochTolerance
  * ```ts
@@ -392,7 +397,8 @@ export async function verify(options: TOTPVerifyOptions): Promise<VerifyResult> 
  *
  * @param options - TOTP verification options
  * @returns Verification result with validity and optional delta
- * @throws {HMACError} If the crypto plugin doesn't support sync operations
+ * @throws {AlgorithmUnsupportedError} If the algorithm is invalid or unsupported by the plugin
+ * @throws {HMACError} If HMAC computation fails or the plugin does not support sync operations
  *
  * @example
  * ```ts

--- a/packages/uri/README.md
+++ b/packages/uri/README.md
@@ -55,6 +55,12 @@ console.log(result);
 // }
 ```
 
+When a query parameter is repeated, otplib parses and validates only its first
+occurrence, matching `URLSearchParams.get()`. Later occurrences are ignored
+without decoding their values. A bare parameter such as `algorithm` counts as
+the first occurrence with an empty value. The OTPAuth URI format does not define
+duplicate-parameter behavior, so avoid duplicates when interoperability matters.
+
 ### Extracting Account Details
 
 ```typescript

--- a/packages/uri/README.md
+++ b/packages/uri/README.md
@@ -47,10 +47,7 @@ console.log(result);
 //   label: 'GitHub:user@example.com',
 //   params: {
 //     secret: 'GEZDGNBVGY3TQOJQGEZDGNBVGY',
-//     issuer: 'GitHub',
-//     algorithm: 'sha1',
-//     digits: 6,
-//     period: 30
+//     issuer: 'GitHub'
 //   }
 // }
 ```
@@ -60,6 +57,10 @@ occurrence, matching `URLSearchParams.get()`. Later occurrences are ignored
 without decoding their values. A bare parameter such as `algorithm` counts as
 the first occurrence with an empty value. The OTPAuth URI format does not define
 duplicate-parameter behavior, so avoid duplicates when interoperability matters.
+
+Parsing preserves optionality rather than materializing defaults: an absent,
+bare, or empty `algorithm` parameter leaves `params.algorithm` undefined. OTP
+consumers apply the SHA-1 default when they use the parsed result.
 
 ### Extracting Account Details
 
@@ -115,7 +116,7 @@ const uri = generateTOTP({
 });
 
 console.log(uri);
-// 'otpauth://totp/ACME%20Corp:john@example.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY&issuer=ACME%20Corp'
+// 'otpauth://totp/ACME%20Corp:john%40example.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY&issuer=ACME%20Corp'
 ```
 
 ### TOTP with Custom Options
@@ -172,19 +173,22 @@ const uri = generate({
 ## Google Authenticator Compatibility
 
 > [!WARNING]
-> Google Authenticator has specific requirements:
+> For the widest Google Authenticator interoperability, use the standard defaults:
 >
-> - Only supports `sha1` algorithm
-> - Only supports `6` or `8` digits
-> - Only supports `30` second period for TOTP
+> - `sha1` algorithm
+> - `6` digits
+> - `30` second period for TOTP
 > - Issuer should be included in both label and parameter
+>
+> Some authenticator versions ignore the algorithm, digits, or period parameter,
+> so non-default values may not be honored.
 
 ### Compatible URI
 
 ```typescript
 import { generateTOTP } from "@otplib/uri";
 
-// This URI is fully compatible with Google Authenticator
+// This URI uses the widely interoperable defaults
 const uri = generateTOTP({
   issuer: "MyService",
   label: "user@example.com",

--- a/packages/uri/src/generate.ts
+++ b/packages/uri/src/generate.ts
@@ -1,3 +1,5 @@
+import { normalizeHashAlgorithm } from "@otplib/core";
+
 import type { OTPAuthURI } from "./types.js";
 import type { HashAlgorithm, Digits } from "@otplib/core";
 
@@ -106,8 +108,15 @@ export function generate(uri: OTPAuthURI): string {
     queryParams.push(`issuer=${encodeURIComponent(params.issuer)}`);
   }
 
-  if (params.algorithm && params.algorithm !== "sha1") {
-    queryParams.push(`algorithm=${params.algorithm.toUpperCase()}`);
+  if (params.algorithm) {
+    // Normalize first so untyped JS callers passing e.g. 'SHA1' are case-folded
+    // (and invalid values rejected) before the "omit when sha1" rule is applied.
+    const algorithm = normalizeHashAlgorithm(params.algorithm);
+
+    if (algorithm !== "sha1") {
+      // Key Uri Format requires the uppercase, non-dashed spelling (SHA256/SHA512).
+      queryParams.push(`algorithm=${algorithm.toUpperCase()}`);
+    }
   }
 
   if (params.digits && params.digits !== 6) {

--- a/packages/uri/src/generate.ts
+++ b/packages/uri/src/generate.ts
@@ -24,7 +24,8 @@ export type URIOptions = {
 
   /**
    * Hash algorithm (default: 'sha1')
-   * Note: Google Authenticator only supports sha1
+   * Note: Some authenticator apps ignore this parameter; sha1 has the widest
+   * interoperability.
    */
   algorithm?: HashAlgorithm;
 
@@ -66,6 +67,7 @@ export type HOTPURIOptions = URIOptions & {
  *
  * @param uri - The URI components
  * @returns The otpauth:// URI string
+ * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
  *
  * @example
  * ```ts
@@ -142,6 +144,7 @@ export function generate(uri: OTPAuthURI): string {
  *
  * @param options - TOTP URI generation options
  * @returns The otpauth:// URI string
+ * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
  */
 export function generateTOTP(options: TOTPURIOptions & { issuer: string; label: string }): string {
   const { issuer, label: account, secret, algorithm = "sha1", digits = 6, period = 30 } = options;
@@ -166,6 +169,7 @@ export function generateTOTP(options: TOTPURIOptions & { issuer: string; label: 
  *
  * @param options - HOTP URI generation options
  * @returns The otpauth:// URI string
+ * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
  */
 export function generateHOTP(options: HOTPURIOptions & { issuer: string; label: string }): string {
   const { issuer, label: account, secret, counter = 0, algorithm = "sha1", digits = 6 } = options;

--- a/packages/uri/src/generate.ts
+++ b/packages/uri/src/generate.ts
@@ -114,7 +114,8 @@ export function generate(uri: OTPAuthURI): string {
     const algorithm = normalizeHashAlgorithm(params.algorithm);
 
     if (algorithm !== "sha1") {
-      // Key Uri Format requires the uppercase, non-dashed spelling (SHA256/SHA512).
+      // Mapped to the uppercase, non-dashed name the Key Uri Format requires
+      // (SHA256/SHA512).
       queryParams.push(`algorithm=${algorithm.toUpperCase()}`);
     }
   }

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -702,22 +702,116 @@ describe("URI", () => {
       }
     });
 
-    describe("duplicate algorithm parameters", () => {
-      const duplicateAlgorithms = [
-        "algorithm=SHA1&algorithm=SHA512",
-        "algorithm=SHA512&algorithm=SHA512",
-        "algorithm=&algorithm=SHA512",
-        "algorithm=SHA512&algorithm=",
-        "algorithm=&algorithm=",
-        "algorithm&algorithm=SHA512",
-        "algorithm=SHA512&algorithm",
-        "algorithm&algorithm",
+    describe("repeated query parameters", () => {
+      const firstWinsCases = [
+        {
+          name: "secret",
+          uri: `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&secret=SECONDSECRET`,
+          read: (parsed: OTPAuthURI) => parsed.params.secret,
+          expected: TEST_SECRET_PARSE_BASE32,
+        },
+        {
+          name: "issuer",
+          uri: `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&issuer=First&issuer=Second`,
+          read: (parsed: OTPAuthURI) => parsed.params.issuer,
+          expected: "First",
+        },
+        {
+          name: "algorithm",
+          uri: `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=SHA256&algorithm=SHA512`,
+          read: (parsed: OTPAuthURI) => parsed.params.algorithm,
+          expected: "sha256",
+        },
+        {
+          name: "digits",
+          uri: `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&digits=6&digits=8`,
+          read: (parsed: OTPAuthURI) => parsed.params.digits,
+          expected: 6,
+        },
+        {
+          name: "period",
+          uri: `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&period=30&period=60`,
+          read: (parsed: OTPAuthURI) => parsed.params.period,
+          expected: 30,
+        },
+        {
+          name: "counter",
+          uri: `otpauth://hotp/Test?secret=${TEST_SECRET_PARSE_BASE32}&counter=1&counter=2`,
+          read: (parsed: OTPAuthURI) => parsed.params.counter,
+          expected: 1,
+        },
       ];
 
-      for (const query of duplicateAlgorithms) {
-        it(`should reject ${query}`, () => {
+      for (const { name, uri, read, expected } of firstWinsCases) {
+        it(`should use only the first ${name} occurrence`, () => {
+          expect(read(parse(uri))).toBe(expected);
+        });
+      }
+
+      const ignoredMalformedValues = [
+        `secret=${TEST_SECRET_PARSE_BASE32}&secret=%`,
+        "issuer=First&issuer=%",
+        "algorithm=SHA256&algorithm=%",
+        "digits=6&digits=%",
+        "period=30&period=%",
+        "counter=1&counter=%",
+      ];
+
+      for (const query of ignoredMalformedValues) {
+        it(`should not decode the later value in "${query}"`, () => {
+          const type = query.startsWith("counter=") ? "hotp" : "totp";
+          const secret = query.startsWith("secret=") ? "" : `secret=${TEST_SECRET_PARSE_BASE32}&`;
+
+          expect(() => parse(`otpauth://${type}/Test?${secret}${query}`)).not.toThrow();
+        });
+      }
+
+      it("should identify repeated keys after decoding them", () => {
+        const parsed = parse(
+          `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=SHA256&%61lgorithm=%`,
+        );
+
+        expect(parsed.params.algorithm).toBe("sha256");
+      });
+
+      it("should validate the first value even when a later value is valid", () => {
+        expect(() =>
+          parse(
+            `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=INVALID&algorithm=SHA256`,
+          ),
+        ).toThrow(InvalidParameterError);
+      });
+
+      it("should let a bare first algorithm select the SHA-1 default", () => {
+        const parsed = parse(
+          `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm&algorithm=SHA512`,
+        );
+
+        expect(parsed.params.algorithm).toBeUndefined();
+      });
+
+      it("should let a bare first issuer select the empty value", () => {
+        const parsed = parse(
+          `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&issuer&issuer=Second`,
+        );
+
+        expect(parsed.params.issuer).toBe("");
+      });
+
+      it("should let a bare first secret block a later secret", () => {
+        expect(() =>
+          parse(`otpauth://totp/Test?secret&secret=${TEST_SECRET_PARSE_BASE32}`),
+        ).toThrow("Missing required parameter: secret");
+      });
+
+      for (const parameter of ["digits", "period", "counter"]) {
+        it(`should validate a bare first ${parameter} as an empty value`, () => {
+          const type = parameter === "counter" ? "hotp" : "totp";
+
           expect(() =>
-            parse(`otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&${query}`),
+            parse(
+              `otpauth://${type}/Test?secret=${TEST_SECRET_PARSE_BASE32}&${parameter}&${parameter}=1`,
+            ),
           ).toThrow(InvalidParameterError);
         });
       }

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -647,6 +647,18 @@ describe("URI", () => {
       expect(parsed.params.algorithm).toBeUndefined();
     });
 
+    // This package is a string layer with no crypto plugin, so it validates
+    // against the full allowlist. A narrowed plugin elsewhere in the app must
+    // not make a URI unparseable or ungeneratable.
+    it("should accept every supported algorithm regardless of any plugin", () => {
+      for (const algorithm of ["sha1", "sha256", "sha512"] as const) {
+        const uri = `otpauth://totp/Service:user?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${algorithm.toUpperCase()}`;
+
+        expect(parse(uri).params.algorithm).toBe(algorithm);
+        expect(() => generate(baseURI(algorithm))).not.toThrow();
+      }
+    });
+
     // parse() wraps the rejection in this package's InvalidParameterError while
     // generate() throws the core error directly; the cause is the bridge that
     // keeps the underlying rejection reachable from the parse side.

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -620,9 +620,9 @@ describe("URI", () => {
       expect(() => generate(baseURI("md5" as HashAlgorithm))).toThrow(AlgorithmUnsupportedError);
     });
 
-    // generate() and parse() accept the same spellings, so a URI that parses
+    // generate() and parse() accept the same aliases, so a URI that parses
     // can be regenerated without the caller having to canonicalize first.
-    it("should emit the canonical spelling for a dashed algorithm", () => {
+    it("should emit the canonical name for a dashed alias", () => {
       expect(generate(baseURI("SHA-256" as HashAlgorithm))).toContain("algorithm=SHA256");
     });
 

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -620,10 +620,21 @@ describe("URI", () => {
       expect(() => generate(baseURI("md5" as HashAlgorithm))).toThrow(AlgorithmUnsupportedError);
     });
 
-    it("should throw on a dashed algorithm at the generate boundary", () => {
-      expect(() => generate(baseURI("SHA-256" as HashAlgorithm))).toThrow(
-        AlgorithmUnsupportedError,
-      );
+    // generate() and parse() accept the same spellings, so a URI that parses
+    // can be regenerated without the caller having to canonicalize first.
+    it("should emit the canonical spelling for a dashed algorithm", () => {
+      expect(generate(baseURI("SHA-256" as HashAlgorithm))).toContain("algorithm=SHA256");
+    });
+
+    it("should round-trip a dashed algorithm through parse and generate", () => {
+      const uri = `otpauth://totp/Service:user?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=SHA-512`;
+      const regenerated = generate({
+        type: "totp",
+        label: "Service:user",
+        params: parse(uri).params,
+      });
+
+      expect(regenerated).toContain("algorithm=SHA512");
     });
 
     it("should round-trip to a canonical lowercase algorithm", () => {

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -4,6 +4,8 @@ import { formatErrorMessage } from "./parse.js";
 import { AlgorithmUnsupportedError } from "@otplib/core";
 import { TEST_SECRET_PARSE_BASE32 } from "@repo/testing";
 
+import { InvalidParameterError } from "./types.js";
+
 import type { OTPAuthURI } from "./types.js";
 import type { HashAlgorithm } from "@otplib/core";
 
@@ -656,6 +658,33 @@ describe("URI", () => {
 
         expect(parse(uri).params.algorithm).toBe(algorithm);
         expect(() => generate(baseURI(algorithm))).not.toThrow();
+      }
+    });
+
+    // The Key Uri Format makes `algorithm` optional with a SHA-1 default, so
+    // `?algorithm=` carries no value and is treated as omitted - the same URI
+    // the CLI parser already accepts.
+    describe("empty algorithm parameter", () => {
+      const emptyParam = `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=`;
+      const noParam = `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}`;
+
+      it("should parse successfully", () => {
+        expect(() => parse(emptyParam)).not.toThrow();
+      });
+
+      it("should leave the algorithm undefined, matching an absent parameter", () => {
+        expect(parse(emptyParam).params.algorithm).toBeUndefined();
+        expect(parse(emptyParam).params.algorithm).toBe(parse(noParam).params.algorithm);
+      });
+
+      // Only the empty case is forgiving. Anything actually present is still
+      // held to the alias table.
+      for (const value of ["md5", "sha-384", "sha3-256", "%20", "sha%201", "not-an-algorithm"]) {
+        it(`should still throw InvalidParameterError for "?algorithm=${value}"`, () => {
+          expect(() =>
+            parse(`otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${value}`),
+          ).toThrow(InvalidParameterError);
+        });
       }
     });
 

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -666,6 +666,7 @@ describe("URI", () => {
     // the CLI parser already accepts.
     describe("empty algorithm parameter", () => {
       const emptyParam = `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=`;
+      const bareParam = `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm`;
       const noParam = `otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}`;
 
       it("should parse successfully", () => {
@@ -677,12 +678,38 @@ describe("URI", () => {
         expect(parse(emptyParam).params.algorithm).toBe(parse(noParam).params.algorithm);
       });
 
+      it("should treat one bare algorithm parameter as omitted", () => {
+        expect(parse(bareParam).params.algorithm).toBeUndefined();
+        expect(parse(bareParam).params.algorithm).toBe(parse(noParam).params.algorithm);
+      });
+
       // Only the empty case is forgiving. Anything actually present is still
       // held to the alias table.
       for (const value of ["md5", "sha-384", "sha3-256", "%20", "sha%201", "not-an-algorithm"]) {
         it(`should still throw InvalidParameterError for "?algorithm=${value}"`, () => {
           expect(() =>
             parse(`otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=${value}`),
+          ).toThrow(InvalidParameterError);
+        });
+      }
+    });
+
+    describe("duplicate algorithm parameters", () => {
+      const duplicateAlgorithms = [
+        "algorithm=SHA1&algorithm=SHA512",
+        "algorithm=SHA512&algorithm=SHA512",
+        "algorithm=&algorithm=SHA512",
+        "algorithm=SHA512&algorithm=",
+        "algorithm=&algorithm=",
+        "algorithm&algorithm=SHA512",
+        "algorithm=SHA512&algorithm",
+        "algorithm&algorithm",
+      ];
+
+      for (const query of duplicateAlgorithms) {
+        it(`should reject ${query}`, () => {
+          expect(() =>
+            parse(`otpauth://totp/Test?secret=${TEST_SECRET_PARSE_BASE32}&${query}`),
           ).toThrow(InvalidParameterError);
         });
       }

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -646,6 +646,24 @@ describe("URI", () => {
       const parsed = parse(generate(baseURI("SHA1" as HashAlgorithm)));
       expect(parsed.params.algorithm).toBeUndefined();
     });
+
+    // parse() wraps the rejection in this package's InvalidParameterError while
+    // generate() throws the core error directly; the cause is the bridge that
+    // keeps the underlying rejection reachable from the parse side.
+    it("should carry the core error as cause when parse rejects an algorithm", () => {
+      const uri = `otpauth://totp/Service:user?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=md5`;
+
+      let caught: unknown;
+      try {
+        parse(uri);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).name).toBe("InvalidParameterError");
+      expect((caught as Error).cause).toBeInstanceOf(AlgorithmUnsupportedError);
+    });
   });
 
   describe("error classes", () => {

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { generateTOTP, generateHOTP, parse, generate } from "./index.js";
 import { formatErrorMessage } from "./parse.js";
+import { AlgorithmUnsupportedError } from "@otplib/core";
 import { TEST_SECRET_PARSE_BASE32 } from "@repo/testing";
+
+import type { OTPAuthURI } from "./types.js";
+import type { HashAlgorithm } from "@otplib/core";
 
 describe("URI", () => {
   describe("generateTOTP", () => {
@@ -582,6 +586,54 @@ describe("URI", () => {
       expect(parsed.params.algorithm).toBe(original.algorithm);
       expect(parsed.params.digits).toBe(original.digits);
       expect(parsed.params.counter).toBe(original.counter);
+    });
+  });
+
+  describe("algorithm normalization", () => {
+    const baseURI = (algorithm: HashAlgorithm): OTPAuthURI => ({
+      type: "totp",
+      label: "Service:user",
+      params: { secret: TEST_SECRET_PARSE_BASE32, algorithm },
+    });
+
+    it("should emit uppercase non-dashed SHA256 token", () => {
+      expect(generate(baseURI("sha256"))).toContain("algorithm=SHA256");
+    });
+
+    it("should emit uppercase non-dashed SHA512 token", () => {
+      expect(generate(baseURI("sha512"))).toContain("algorithm=SHA512");
+    });
+
+    it("should omit algorithm param for sha1", () => {
+      expect(generate(baseURI("sha1"))).not.toContain("algorithm=");
+    });
+
+    it("should omit algorithm param for uppercase 'SHA1' from untyped callers", () => {
+      expect(generate(baseURI("SHA1" as HashAlgorithm))).not.toContain("algorithm=");
+    });
+
+    it("should case-fold uppercase 'SHA256' from untyped callers", () => {
+      expect(generate(baseURI("SHA256" as HashAlgorithm))).toContain("algorithm=SHA256");
+    });
+
+    it("should throw on an invalid algorithm", () => {
+      expect(() => generate(baseURI("md5" as HashAlgorithm))).toThrow(AlgorithmUnsupportedError);
+    });
+
+    it("should throw on a dashed algorithm at the generate boundary", () => {
+      expect(() => generate(baseURI("SHA-256" as HashAlgorithm))).toThrow(
+        AlgorithmUnsupportedError,
+      );
+    });
+
+    it("should round-trip to a canonical lowercase algorithm", () => {
+      const parsed = parse(generate(baseURI("SHA256" as HashAlgorithm)));
+      expect(parsed.params.algorithm).toBe("sha256");
+    });
+
+    it("should round-trip sha1 to an absent algorithm param", () => {
+      const parsed = parse(generate(baseURI("SHA1" as HashAlgorithm)));
+      expect(parsed.params.algorithm).toBeUndefined();
     });
   });
 

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -403,6 +403,14 @@ describe("URI", () => {
       expect(parsed.params.issuer).toBe("Service");
     });
 
+    it("should skip malformed percent-encoding in a bare unknown parameter", () => {
+      const uri = `otpauth://totp/Service:user?secret=${TEST_SECRET_PARSE_BASE32}&malformed%ZZ&issuer=Service`;
+      const parsed = parse(uri);
+
+      expect(parsed.params.secret).toBe(TEST_SECRET_PARSE_BASE32);
+      expect(parsed.params.issuer).toBe("Service");
+    });
+
     it("should parse non-hyphenated algorithm names", () => {
       const sha1Uri = `otpauth://totp/Service:user?secret=${TEST_SECRET_PARSE_BASE32}&algorithm=sha1`;
       expect(parse(sha1Uri).params.algorithm).toBe("sha1");

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -126,7 +126,7 @@ export function parse(uri: string): OTPAuthURI {
  */
 function parseQueryString(queryString: string): MutableOTPAuthParams {
   const params: MutableOTPAuthParams = {};
-  let algorithmSeen = false;
+  const seenParameters = new Set<string>();
 
   if (!queryString) {
     return params;
@@ -135,8 +135,10 @@ function parseQueryString(queryString: string): MutableOTPAuthParams {
   const pairs = queryString.split("&");
   for (const pair of pairs) {
     const equalIndex = pair.indexOf("=");
-    if (equalIndex === -1) {
-      let key: string;
+    const isBare = equalIndex === -1;
+
+    let key: string;
+    if (isBare) {
       try {
         key = decodeURIComponent(pair);
       } catch {
@@ -144,22 +146,24 @@ function parseQueryString(queryString: string): MutableOTPAuthParams {
         // key/value pairs participate in strict URI decoding.
         continue;
       }
-
-      if (key === "algorithm") {
-        if (algorithmSeen) {
-          throw new InvalidParameterError("algorithm", "duplicate parameter");
-        }
-        algorithmSeen = true;
-      }
-      continue;
+    } else {
+      key = safeDecodeURIComponent(pair.slice(0, equalIndex), 64, "parameter key");
     }
 
-    const key = safeDecodeURIComponent(pair.slice(0, equalIndex), 64, "parameter key");
-    const value = safeDecodeURIComponent(
-      pair.slice(equalIndex + 1),
-      MAX_PARAM_VALUE_LENGTH,
-      `parameter '${key}'`,
-    );
+    // Match URLSearchParams.get(): the first decoded occurrence determines the
+    // parameter. Later values are ignored without decoding or validating them.
+    if (seenParameters.has(key)) {
+      continue;
+    }
+    seenParameters.add(key);
+
+    const value = isBare
+      ? ""
+      : safeDecodeURIComponent(
+          pair.slice(equalIndex + 1),
+          MAX_PARAM_VALUE_LENGTH,
+          `parameter '${key}'`,
+        );
 
     switch (key) {
       case "secret":
@@ -169,10 +173,6 @@ function parseQueryString(queryString: string): MutableOTPAuthParams {
         params.issuer = value;
         break;
       case "algorithm":
-        if (algorithmSeen) {
-          throw new InvalidParameterError("algorithm", "duplicate parameter");
-        }
-        algorithmSeen = true;
         // `?algorithm=` carries no value. The Key Uri Format makes this
         // parameter optional with a SHA-1 default, so an empty one is treated
         // as omitted rather than as an invalid value - which is also what the

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -1,3 +1,5 @@
+import { normalizeHashAlgorithm } from "@otplib/core";
+
 import { InvalidURIError, InvalidParameterError, MissingParameterError } from "./types.js";
 
 import type { OTPAuthURI, OTPAuthParams } from "./types.js";
@@ -191,30 +193,17 @@ function parseIntegerParameter(name: string, value: string, min: number): number
 /**
  * Parse algorithm string
  *
- * NOTE: this is deliberately MORE permissive than the core API. Core's
- * `normalizeHashAlgorithm` only case-folds and accepts the canonical
- * non-dashed spellings (sha1/sha256/sha512); here we also accept the dashed
- * forms (sha-1/sha-256/sha-512) because otpauth:// URIs are produced by
- * third-party issuers we do not control, and some of them emit dashed names.
- *
- * Its job is to hand core a canonical lowercase value, so the leniency stops
- * at the parse boundary and never leaks into the OTP API surface.
- *
- * Do not "tighten" this to reuse normalizeHashAlgorithm - that would break
- * parsing of real-world URIs.
+ * `otpauth://` URIs come from third-party issuers, several of which emit the
+ * dashed spellings (`SHA-1`, `SHA-256`). Core's `normalizeHashAlgorithm`
+ * accepts those and returns the canonical lowercase name, so this only has to
+ * restate the rejection in this package's error type.
  */
 function parseAlgorithm(value: string): HashAlgorithm {
-  const normalized = value.toLowerCase();
-  if (normalized === "sha1" || normalized === "sha-1") {
-    return "sha1";
+  try {
+    return normalizeHashAlgorithm(value);
+  } catch {
+    throw new InvalidParameterError("algorithm", value);
   }
-  if (normalized === "sha256" || normalized === "sha-256") {
-    return "sha256";
-  }
-  if (normalized === "sha512" || normalized === "sha-512") {
-    return "sha512";
-  }
-  throw new InvalidParameterError("algorithm", value);
 }
 
 /**

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -153,7 +153,13 @@ function parseQueryString(queryString: string): MutableOTPAuthParams {
         params.issuer = value;
         break;
       case "algorithm":
-        params.algorithm = parseAlgorithm(value);
+        // `?algorithm=` carries no value. The Key Uri Format makes this
+        // parameter optional with a SHA-1 default, so an empty one is treated
+        // as omitted rather than as an invalid value - which is also what the
+        // CLI parser does with the same URI. Any non-empty value stays strict.
+        if (value !== "") {
+          params.algorithm = parseAlgorithm(value);
+        }
         break;
       case "digits":
         params.digits = parseDigits(value);

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -190,6 +190,18 @@ function parseIntegerParameter(name: string, value: string, min: number): number
 
 /**
  * Parse algorithm string
+ *
+ * NOTE: this is deliberately MORE permissive than the core API. Core's
+ * `normalizeHashAlgorithm` only case-folds and accepts the canonical
+ * non-dashed spellings (sha1/sha256/sha512); here we also accept the dashed
+ * forms (sha-1/sha-256/sha-512) because otpauth:// URIs are produced by
+ * third-party issuers we do not control, and some of them emit dashed names.
+ *
+ * Its job is to hand core a canonical lowercase value, so the leniency stops
+ * at the parse boundary and never leaks into the OTP API surface.
+ *
+ * Do not "tighten" this to reuse normalizeHashAlgorithm - that would break
+ * parsing of real-world URIs.
  */
 function parseAlgorithm(value: string): HashAlgorithm {
   const normalized = value.toLowerCase();

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -201,8 +201,11 @@ function parseIntegerParameter(name: string, value: string, min: number): number
 function parseAlgorithm(value: string): HashAlgorithm {
   try {
     return normalizeHashAlgorithm(value);
-  } catch {
-    throw new InvalidParameterError("algorithm", value);
+  } catch (error) {
+    // Carried as cause so the AlgorithmUnsupportedError stays reachable -
+    // generate() throws the core error directly, and without this bridge the
+    // two directions would be programmatically unrelatable.
+    throw new InvalidParameterError("algorithm", value, { cause: error });
   }
 }
 

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -126,6 +126,7 @@ export function parse(uri: string): OTPAuthURI {
  */
 function parseQueryString(queryString: string): MutableOTPAuthParams {
   const params: MutableOTPAuthParams = {};
+  let algorithmSeen = false;
 
   if (!queryString) {
     return params;
@@ -135,6 +136,21 @@ function parseQueryString(queryString: string): MutableOTPAuthParams {
   for (const pair of pairs) {
     const equalIndex = pair.indexOf("=");
     if (equalIndex === -1) {
+      let key: string;
+      try {
+        key = decodeURIComponent(pair);
+      } catch {
+        // Preserve the existing behavior for malformed bare parameters: only
+        // key/value pairs participate in strict URI decoding.
+        continue;
+      }
+
+      if (key === "algorithm") {
+        if (algorithmSeen) {
+          throw new InvalidParameterError("algorithm", "duplicate parameter");
+        }
+        algorithmSeen = true;
+      }
       continue;
     }
 
@@ -153,6 +169,10 @@ function parseQueryString(queryString: string): MutableOTPAuthParams {
         params.issuer = value;
         break;
       case "algorithm":
+        if (algorithmSeen) {
+          throw new InvalidParameterError("algorithm", "duplicate parameter");
+        }
+        algorithmSeen = true;
         // `?algorithm=` carries no value. The Key Uri Format makes this
         // parameter optional with a SHA-1 default, so an empty one is treated
         // as omitted rather than as an invalid value - which is also what the

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -194,7 +194,7 @@ function parseIntegerParameter(name: string, value: string, min: number): number
  * Parse algorithm string
  *
  * `otpauth://` URIs come from third-party issuers, several of which emit the
- * dashed spellings (`SHA-1`, `SHA-256`). Core's `normalizeHashAlgorithm`
+ * dashed aliases (`SHA-1`, `SHA-256`). Core's `normalizeHashAlgorithm`
  * accepts those and returns the canonical lowercase name, so this only has to
  * restate the rejection in this package's error type.
  */

--- a/packages/uri/src/types.ts
+++ b/packages/uri/src/types.ts
@@ -20,24 +20,30 @@ export type OTPAuthParams = {
   readonly issuer?: string;
 
   /**
-   * Hash algorithm (default: sha1)
-   * Note: Google Authenticator only supports sha1
+   * Hash algorithm. Parsing preserves absence; OTP consumers default to sha1.
+   * Some authenticator apps ignore this parameter; sha1 has the widest
+   * interoperability.
    */
   readonly algorithm?: HashAlgorithm;
 
   /**
-   * Number of digits (default: 6)
-   * Google Authenticator supports 6 or 8
+   * Number of digits. Parsing preserves absence; OTP consumers default to 6.
+   * The Key URI format defines 6 or 8; some authenticator apps ignore this
+   * parameter.
    */
   readonly digits?: Digits;
 
   /**
-   * Initial counter value for HOTP (default: 0)
+   * Initial counter value for HOTP. Required by the Key URI format; parsing
+   * preserves absence, while HOTP generation helpers default to 0.
    */
   readonly counter?: number;
 
   /**
-   * Time step in seconds for TOTP (default: 30)
+   * Time step in seconds for TOTP. Parsing preserves absence; OTP consumers
+   * default to 30.
+   * Some authenticator apps ignore this parameter, so 30 has the widest
+   * interoperability.
    */
   readonly period?: number;
 };

--- a/packages/uri/src/types.ts
+++ b/packages/uri/src/types.ts
@@ -66,8 +66,8 @@ export type OTPAuthURI = {
  * Error thrown when URI parsing fails
  */
 export class URIParseError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "URIParseError";
   }
 }
@@ -96,8 +96,8 @@ export class MissingParameterError extends URIParseError {
  * Error thrown when URI has invalid parameter value
  */
 export class InvalidParameterError extends URIParseError {
-  constructor(param: string, value: string) {
-    super(`Invalid value for parameter '${param}': ${value}`);
+  constructor(param: string, value: string, options?: ErrorOptions) {
+    super(`Invalid value for parameter '${param}': ${value}`, options);
     this.name = "InvalidParameterError";
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       '@otplib/plugin-crypto-node':
         specifier: workspace:*
         version: link:../../packages/plugin-crypto-node
+      '@otplib/plugin-crypto-web':
+        specifier: workspace:*
+        version: link:../../packages/plugin-crypto-web
       '@otplib/totp':
         specifier: workspace:*
         version: link:../../packages/totp
@@ -308,6 +311,9 @@ importers:
 
   packages/otplib-cli:
     dependencies:
+      '@otplib/core':
+        specifier: workspace:*
+        version: link:../core
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -378,6 +384,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@repo/testing':
+        specifier: workspace:*
+        version: link:../../internal/testing
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.8.4)
@@ -394,6 +403,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@repo/testing':
+        specifier: workspace:*
+        version: link:../../internal/testing
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.8.4)
@@ -410,6 +422,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@repo/testing':
+        specifier: workspace:*
+        version: link:../../internal/testing
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.8.4)


### PR DESCRIPTION
Refs #869

## Summary

Unifies hash-algorithm handling across core, HOTP/TOTP, URI/CLI inputs, and the Noble, Node, and Web Crypto plugins. Unsupported algorithms can no longer be silently substituted or delegated to backend-specific digest handling.

### Algorithm validation

- The canonical algorithms remain `sha1`, `sha256`, and `sha512`.
- Matching is case-insensitive and accepts one optional `-` or `_` before the digest size, including `SHA1`, `SHA-1`, and `sha_256`.
- Other spellings and algorithms are rejected; whitespace and degenerate separators remain invalid.
- `AlgorithmUnsupportedError` is the public core error for values that are unknown or outside a plugin's declared capability.
- Error rendering is bounded and cannot itself be broken by hostile or unstringifiable runtime values.
- The exported algorithm policy and plugin capability declarations are frozen against runtime mutation.

### Plugin capabilities and error boundaries

- Crypto plugins may declare a restricted, readonly `algorithms` capability set. Omitting it means the full supported set; an explicit empty set means no algorithms.
- `createCryptoPlugin()` enforces declared capabilities for direct factory-plugin calls, and `CryptoContext` retains a capability precheck for every plugin shape.
- Algorithm validation performed before plugin delegation surfaces as `AlgorithmUnsupportedError`.
- Once plugin execution begins, synchronous throws and asynchronous rejections are wrapped in a fresh `HMACError` with the original error as `cause`, preserving the existing abstraction boundary. Direct plugin calls still expose the plugin's own error.
- Async HMAC results are awaited inside that boundary, including cross-realm promises and thenables. `hmacSync()` rejects promise-like results safely without allowing an unhandled rejection.

### URI and CLI behavior

- URI generation and parsing, CLI URI input, and CLI JSON input share core algorithm normalization.
- The Key URI `algorithm` parameter remains optional. An absent, bare, or empty value leaves `params.algorithm` undefined; OTP consumers then use the SHA-1 default.
- `@otplib/uri` now follows `URLSearchParams.get()` semantics for repeated query parameters: the first decoded occurrence wins for every parameter, and later occurrences are ignored without decoding or validating their values.
- URI parsing preserves its package contract by throwing `InvalidParameterError` for an invalid algorithm while retaining `AlgorithmUnsupportedError` as its `cause`.
- CLI JSON retains its existing defaults for `undefined`, `null`, and an empty algorithm string, and reports invalid dynamic values in the CLI's own error style.

### Public API, documentation, and coverage

- `AlgorithmError`, `AlgorithmUnsupportedError`, and `HMACError` are exported through the top-level `otplib` package with consistent constructor identity across module formats.
- Public API `@throws` documentation, plugin-author guidance, URI examples, interoperability notes, and migration troubleshooting now describe the final behavior.
- Shared conformance tests cover all first-party crypto plugins, aliases, restricted capabilities, hostile values, direct versus contextual error behavior, and sync/async promise boundaries.
- Fuzz coverage checks cross-plugin agreement and URI algorithm handling.

## Compatibility

This is a bug fix with observable changes for untyped JavaScript callers, appropriate for a minor release because runtime behavior now matches the supported algorithm domain and documented contract.

Typed TypeScript callers using the canonical `HashAlgorithm` union are unaffected. Dynamic callers may be affected when algorithm values come from JavaScript, configuration, external URIs, or code that bypasses type checking.

Before vNext, Noble could silently compute SHA-512 for an unrecognized algorithm name, while Node could accept backend-supported digests such as `md5`. Those inputs now either normalize to one of the three supported algorithms or fail at the appropriate public boundary.

If an enrollment was created through Noble's fallback in v13.0.0–13.4.1, it was actually SHA-512. Continue verifying with `algorithm: "sha512"` or re-enroll with the intended algorithm. Existing callers using canonical algorithm names are unaffected.

For repeated URI query parameters, `@otplib/uri` now consistently uses the first value, matching the CLI's `URLSearchParams.get()` behavior. Subsequent values do not override the first and are not parsed.

## Validation

- Repository CI is green, including lint, type checking, security audit, build/tests, distribution tests, CodeQL, Socket, and coverage reporting.
- Local verification passed: 35 test files / 1,513 tests with 100% statement, branch, function, and line coverage.
- Fuzz verification passed: 6 files / 89 tests.
- Formatting, package build, and API documentation generation passed.
- The full VitePress site bundle still has a pre-existing generated-code/esbuild target-transform failure and is intentionally left for a follow-up PR.

## Follow-ups and exclusions

- #876 should be refreshed after this PR merges to retain the symmetric tuple property and add dedicated scalar HOTP look-ahead coverage.
- Running the internal fuzz suite in CI is a separate follow-up.
- Consolidating the CLI and URI parsers, including evaluating broader use of `URLSearchParams`, is a separate behavioral refactor.
- The VitePress/esbuild build issue is a separate follow-up.
- `deno.lock` resynchronization is intentionally excluded.
