### PR TITLE
test(fuzz): cover scalar HOTP counter tolerance semantics

### DIFF
--- a/internal/fuzz-tests/src/hotp.test.ts
+++ b/internal/fuzz-tests/src/hotp.test.ts
@@ -118,6 +118,46 @@ describe("HOTP fuzz tests", () => {
         ),
       );
     });
+
+    it("should treat scalar counter tolerance as look-ahead only", async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.uint8Array({ minLength: 16, maxLength: 64 }),
+          fc.integer({ min: 10, max: 1000000 }),
+          fc.integer({ min: 1, max: 10 }),
+          async (secret, counter, tolerance) => {
+            const token = await generate({ secret, counter, crypto, base32, digits: 10 });
+            const futureTokens = await Promise.all(
+              Array.from({ length: tolerance * 2 }, (_, index) =>
+                generate({
+                  secret,
+                  counter: counter + index + 1,
+                  crypto,
+                  base32,
+                  digits: 10,
+                }),
+              ),
+            );
+
+            fc.pre(futureTokens.every((futureToken) => futureToken !== token));
+
+            for (let offset = -tolerance; offset <= tolerance; offset++) {
+              const result = await verify({
+                secret,
+                counter: counter + offset,
+                token,
+                crypto,
+                base32,
+                counterTolerance: tolerance,
+                digits: 10,
+              });
+
+              expect(result.valid).toBe(offset <= 0);
+            }
+          },
+        ),
+      );
+    });
   });
 
   describe("algorithm variations", () => {


### PR DESCRIPTION
## Summary

- add an independent property-based test for scalar HOTP `counterTolerance`
- prove that a scalar tolerance is look-ahead only: tokens at or ahead of the verifier within the window validate, while tokens behind it do not
- preserve the symmetric tuple property introduced by #874 unchanged

## Context

After #874, the existing fuzz property correctly covers an explicit symmetric `[past, future]` tuple. The runtime already normalizes a scalar tolerance to `[0, future]`, and focused HOTP tests confirm that behavior, but the fuzz suite did not independently pin the scalar contract.

The new property uses a collision precondition over the complete union of counters searched by the behind-token cases. This avoids treating legitimate HOTP token collisions as counter-window behavior.

## Scope

Test-only. There is no runtime behavior change.

## Verification

- `pnpm --filter @repo/fuzz-tests test --run` — 6 files, 90 tests passed
- tracked repository files pass Prettier
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` — 35 files, 1,513 tests passed

An independent final review confirmed the collision handling, scalar-window semantics, preservation of #874's tuple coverage, and one-file test-only scope.
