### PR TITLE
docs: collapse API section by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ internal/typedoc/api/
 
 # Git worktrees
 .worktrees/
+.*/worktrees/
 
 # Testing
 coverage/

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -90,7 +90,7 @@ export default defineConfig({
       },
       {
         text: "API Reference",
-        collapsed: false,
+        collapsed: true,
         items: typedocSidebar,
       },
     ],


### PR DESCRIPTION
Collapses the API reference section by default in the documentation.