### PR TITLE
fix(ci): poll npm registry instead of fixed sleep in smoke tests

### DIFF
--- a/.github/workflows/smoke-test-packages.yml
+++ b/.github/workflows/smoke-test-packages.yml
@@ -43,7 +43,30 @@ jobs:
           cache-dependency-path: package.json
 
       - name: Wait for npm to propagate
-        run: sleep 60
+        run: |
+          set -euo pipefail
+          packages=(
+            otplib
+            @otplib/core
+            @otplib/totp
+            @otplib/hotp
+            @otplib/uri
+            @otplib/plugin-base32-scure
+            @otplib/plugin-crypto-noble
+            @otplib/plugin-crypto-node
+          )
+          deadline=$((SECONDS + 900))
+          for pkg in "${packages[@]}"; do
+            until npm view "${pkg}@${OTPLIB_VERSION}" version > /dev/null 2>&1; do
+              if (( SECONDS >= deadline )); then
+                echo "::error::Timed out waiting for ${pkg}@${OTPLIB_VERSION} to appear on npm"
+                exit 1
+              fi
+              echo "Waiting for ${pkg}@${OTPLIB_VERSION}..."
+              sleep 30
+            done
+            echo "Found ${pkg}@${OTPLIB_VERSION}"
+          done
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The v13.5.0 smoke test run ([run 32493853348](https://github.com/yeojz/otplib/actions/runs/32493853348)) failed all 17 tests. Nothing was wrong with the release — it was a propagation race.

## What happened

`publish-packages.yml` dispatches the smoke test immediately after `Publish to npm` finishes. The workflow then waited a fixed `sleep 60` before installing.

For v13.5.0 that was not enough:

- install ran at **14:46:37Z** → `npm error code ETARGET` / `No matching version found for @otplib/hotp@13.5.0`
- npm reports `@otplib/hotp@13.5.0` published at **14:48:07Z** — 88s *after* the install attempt

Every test then failed with `ERR_MODULE_NOT_FOUND`. A manual re-run at 14:52 ([run 32494513625](https://github.com/yeojz/otplib/actions/runs/32494513625)) passed with no changes.

## Change

Replace the fixed sleep with a poll that waits for each of the 8 published packages to actually resolve at the target version, failing with an `::error::` annotation on timeout instead of proceeding to a guaranteed-broken install.

## Sizing the interval and ceiling

These are set against the registry CDN rather than guessed. `registry.npmjs.org` serves the packument as:

```
cache-control: public, max-age=300
cf-cache-status: HIT
```

A **300s TTL behind Cloudflare**. If an edge caches the packument just before a publish lands, it serves a stale "version not found" for up to 5 minutes — and polling faster cannot see past it, because every request re-reads the same cached negative.

So:

- **30s interval** — avoids re-requesting a cache entry that cannot have changed. A shorter interval buys no earlier detection; the TTL dominates.
- **900s ceiling** — 3x the TTL rather than 2x, so a worst-case stale edge cannot consume the whole budget.

Rate limiting is not the constraint at either value: 30s is 2 req/min, where a single `npm install` fires hundreds in seconds.

## Verification

Run against the live registry:

| input | result |
|---|---|
| `13.5.0` | all 8 found, exit 0 |
| `latest` | all 8 found, exit 0 |
| `99.0.0` | retries, `::error::`, exit 1 |

Workflow YAML parses; the embedded script passes `bash -n`. Pre-commit hooks (format, lint, typecheck) all green.

## Known limits

- The deadline is checked *after* each sleep, so the real ceiling is up to one interval beyond it — worst case ~930s, not 900s.
- The deadline is global across all 8 packages, not per-package. In practice `pnpm publish -r` lands them within seconds of each other, so once the slowest appears the rest follow immediately.
- The poll uses `npm view`, which can hit a different CDN edge than `npm install` — same 300s TTL, independent cache key. A successful poll therefore does not *guarantee* the install sees the version. Much narrower than the fixed sleep, but not zero. A retry around the install step would close it; worth adding only if this recurs.

Pairs with #883 on the `smoke-tests` branch, which makes a failed install fail its own step rather than going green.