### PR TITLE
fix(smoke-test): fail install step when npm install fails

### DIFF
--- a/install-packages.sh
+++ b/install-packages.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Install otplib packages for smoke testing
 # Version can be configured via OTPLIB_VERSION environment variable


### PR DESCRIPTION
Companion to #882, which fixes the underlying propagation race. This one fixes the bug that made that race so hard to read.

## Problem

`install-packages.sh` had no `set -e`. When `npm install` failed, the script carried on, printed `Installed packages@<version>`, and exited **0**. The GitHub step went green and the real failure only surfaced later as `ERR_MODULE_NOT_FOUND` across all 17 tests.

In the v13.5.0 run, npm returned `ETARGET` for `@otplib/hotp@13.5.0` — and the install step still reported success.

## Change

Add `set -euo pipefail` so the install fails where it actually breaks.

## Verification

Same input (`OTPLIB_VERSION=99.0.0`), before and after:

| | exit code |
|---|---|
| before | `0` ← swallowed |
| after | `1` |

`bash -n` passes. `${OTPLIB_VERSION:-latest}` is already `set -u` safe.

## Notes

- Base is `smoke-tests`, not `main` — this is an orphan branch (no common ancestor with `main`) and `install-packages.sh` exists only here. The workflow checks it out via `ref: smoke-tests`.
- lefthook reported no config on this branch, so pre-commit hooks were a no-op. Expected: no `lefthook.yml`, no turbo, no TS packages here. `--no-verify` was not used.