### PR TITLE
ci: tag releases on merge and publish from the tag

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -2,6 +2,11 @@ name: Publish Packages
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v13.5.0)"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -15,7 +20,6 @@ env:
 
 jobs:
   dry-run:
-    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}"
     environment: general
     name: Dry Run (Packages)
     runs-on: ubuntu-latest
@@ -25,7 +29,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.tag }}
           persist-credentials: false
+
+      - name: Verify tag matches package version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          PKG_VERSION="v$(jq -r '.version' packages/otplib/package.json)"
+          if [ "$PKG_VERSION" != "$INPUT_TAG" ]; then
+            echo "::error::Tag $INPUT_TAG does not match packages/otplib/package.json ($PKG_VERSION)"
+            exit 1
+          fi
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -58,7 +73,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.tag }}
           persist-credentials: false
+
+      - name: Verify tag matches package version
+        id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          VERSION=$(jq -r '.version' packages/otplib/package.json)
+          if [ "v$VERSION" != "$INPUT_TAG" ]; then
+            echo "::error::Tag $INPUT_TAG does not match packages/otplib/package.json (v$VERSION)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -81,10 +109,6 @@ jobs:
         run: pnpm run release:packages
         env:
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Get published version
-        id: version
-        run: echo "version=$(jq -r '.version' packages/otplib/package.json)" >> $GITHUB_OUTPUT
 
       - name: Trigger smoke tests
         if: success()
@@ -124,26 +148,26 @@ jobs:
           # Find the previous latest tag:
           # 1. List all tags matching vX.X.X
           # 2. Sort by version descending (v14 > v13 > v2)
-          # 3. Filter out the current version (if tag already exists)
+          # 3. Filter out the current version (tagged when the release PR merged)
           # 4. Take the first result
           PREV_TAG=$(git tag -l "v*.*.*" --sort=-v:refname | grep -v "^${VERSION}$" | head -n 1)
 
           echo "Current Version: $VERSION"
           echo "Previous Version: $PREV_TAG"
 
+          # The tag already exists (created by tag-release.yml), so gh attaches
+          # the release to it rather than creating it at main's current HEAD.
           if [ -n "$PREV_TAG" ]; then
             echo "Creating release with notes from $PREV_TAG..."
             gh release create "$VERSION" \
               --title "v${{ steps.version.outputs.version }}" \
               --generate-notes \
               --notes-start-tag "$PREV_TAG" \
-              --target main \
               release-artifacts/*.tgz
           else
             echo "No previous tag found. Creating initial release..."
             gh release create "$VERSION" \
               --title "v${{ steps.version.outputs.version }}" \
               --generate-notes \
-              --target main \
               release-artifacts/*.tgz
           fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,12 +1,9 @@
 name: Publish Packages
 
 on:
+  # Dispatch against the release tag, not a branch. The ref selects both
+  # the source that gets published and the workflow that publishes it.
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Release tag to publish (e.g. v13.5.0)"
-        required: true
-        type: string
 
 permissions: {}
 
@@ -29,16 +26,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
           persist-credentials: false
 
-      - name: Verify tag matches package version
+      - name: Verify dispatched from a release tag
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
+          # The dispatch dropdown pre-selects the default branch, so reject
+          # anything that is not a vX.Y.Z tag rather than publishing main.
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "::error::Publish must be dispatched against a release tag, got $REF_TYPE '$REF_NAME'"
+            exit 1
+          fi
+
+          if [[ ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Not a release tag: $REF_NAME"
+            exit 1
+          fi
+
           PKG_VERSION="v$(jq -r '.version' packages/otplib/package.json)"
-          if [ "$PKG_VERSION" != "$INPUT_TAG" ]; then
-            echo "::error::Tag $INPUT_TAG does not match packages/otplib/package.json ($PKG_VERSION)"
+          if [ "$PKG_VERSION" != "$REF_NAME" ]; then
+            echo "::error::Tag $REF_NAME does not match packages/otplib/package.json ($PKG_VERSION)"
             exit 1
           fi
 
@@ -73,20 +82,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
           persist-credentials: false
 
-      - name: Verify tag matches package version
+      - name: Verify dispatched from a release tag
         id: version
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          VERSION=$(jq -r '.version' packages/otplib/package.json)
-          if [ "v$VERSION" != "$INPUT_TAG" ]; then
-            echo "::error::Tag $INPUT_TAG does not match packages/otplib/package.json (v$VERSION)"
+          # The dispatch dropdown pre-selects the default branch, so reject
+          # anything that is not a vX.Y.Z tag rather than publishing main.
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "::error::Publish must be dispatched against a release tag, got $REF_TYPE '$REF_NAME'"
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          if [[ ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Not a release tag: $REF_NAME"
+            exit 1
+          fi
+
+          PKG_VERSION="v$(jq -r '.version' packages/otplib/package.json)"
+          if [ "$PKG_VERSION" != "$REF_NAME" ]; then
+            echo "::error::Tag $REF_NAME does not match packages/otplib/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+          echo "version=${REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,9 +12,13 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # prepare-release opens the PR with the default GITHUB_TOKEN, which
-  # authors it as github-actions[bot]. Change this if that token changes.
-  RELEASE_PR_AUTHOR: "github-actions[bot]"
+  # Numeric account id of github-actions[bot], the identity the default
+  # GITHUB_TOKEN acts as. Ids are immutable across renames, unlike logins.
+  RELEASE_BOT_ID: "41898282"
+  # Commit identity hardcoded by .github/actions/version-release-pr.
+  # Not an identity proof (commit metadata is unsigned and forgeable) --
+  # a canary for that constant drifting out of sync with this workflow.
+  RELEASE_BOT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
 
 jobs:
   tag-release:
@@ -32,12 +36,15 @@ jobs:
     steps:
       - name: Verify PR author
         env:
+          PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           # The ci-release label alone is not enough: anyone with triage
-          # access can apply it to a hand-written PR.
-          if [ "$PR_AUTHOR" != "$RELEASE_PR_AUTHOR" ]; then
-            echo "::error::Release PR must be opened by $RELEASE_PR_AUTHOR (got $PR_AUTHOR)"
+          # access can apply it to a hand-written PR. The account id comes
+          # from the event payload, so it reflects the token that opened the
+          # PR and cannot be set by the PR itself.
+          if [ "$PR_AUTHOR_ID" != "$RELEASE_BOT_ID" ]; then
+            echo "::error::Release PR must be opened by account $RELEASE_BOT_ID (got $PR_AUTHOR_ID, $PR_AUTHOR)"
             exit 1
           fi
 
@@ -46,6 +53,18 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           persist-credentials: false
+
+      - name: Verify release commit identity
+        run: |
+          # Weaker than the id check above: git author metadata is unsigned
+          # and anyone who can push may set it. This exists to catch the
+          # release action's hardcoded identity drifting, not to prove who
+          # ran it.
+          COMMIT_EMAIL=$(git log -1 --format='%ae' HEAD)
+          if [ "$COMMIT_EMAIL" != "$RELEASE_BOT_EMAIL" ]; then
+            echo "::error::Release commit authored by $COMMIT_EMAIL, expected $RELEASE_BOT_EMAIL"
+            exit 1
+          fi
 
       - name: Resolve version
         id: version

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -141,4 +141,4 @@ jobs:
           echo "**Tag:** v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** ${{ github.event.pull_request.merge_commit_sha }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Run **Publish Packages** with tag \`v${{ steps.version.outputs.version }}\` to release." >> $GITHUB_STEP_SUMMARY
+          echo "To release, run **Publish Packages** against the \`v${{ steps.version.outputs.version }}\` tag (select it in the ref dropdown, not a branch)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,107 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions: {}
+
+concurrency:
+  group: "tag-release"
+  cancel-in-progress: false
+
+jobs:
+  tag-release:
+    # Only merged release PRs, identified by the label applied by prepare-release.
+    if: >-
+      ${{ github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'ci-release') }}
+    environment: general
+    name: Tag Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push the release tag
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
+      - name: Resolve version
+        id: version
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # prepare-release names the branch release/<group>-v<version>
+          if [[ ! "$HEAD_REF" =~ ^release/(.+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            echo "::error::Unexpected release branch name: $HEAD_REF"
+            exit 1
+          fi
+
+          GROUP="${BASH_REMATCH[1]}"
+          VERSION="${BASH_REMATCH[2]}"
+
+          # The v<version> tag format is only unambiguous while "packages" is the
+          # sole release group. A second group needs its own tag namespace first.
+          if [ "$GROUP" != "packages" ]; then
+            echo "::error::No tag format defined for release group '$GROUP'"
+            exit 1
+          fi
+
+          PKG_VERSION=$(jq -r '.version' packages/otplib/package.json)
+          if [ "$PKG_VERSION" != "$VERSION" ]; then
+            echo "::error::Branch says v$VERSION but packages/otplib/package.json says v$PKG_VERSION"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release tag
+        id: tag
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tag = `v${process.env.VERSION}`;
+            const sha = process.env.SHA;
+
+            try {
+              const { data } = await github.rest.git.getRef({
+                ...context.repo,
+                ref: `tags/${tag}`,
+              });
+
+              if (data.object.sha === sha) {
+                core.info(`Tag ${tag} already points at ${sha}`);
+                return;
+              }
+
+              core.setFailed(
+                `Tag ${tag} already exists at ${data.object.sha}, refusing to move it to ${sha}`
+              );
+              return;
+            } catch (err) {
+              if (err.status !== 404) throw err;
+            }
+
+            await github.rest.git.createRef({
+              ...context.repo,
+              ref: `refs/tags/${tag}`,
+              sha,
+            });
+
+            core.info(`Created tag ${tag} at ${sha}`);
+
+      - name: Summary
+        run: |
+          echo "## Release Tagged" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.event.pull_request.merge_commit_sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Run **Publish Packages** with tag \`v${{ steps.version.outputs.version }}\` to release." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -48,6 +48,23 @@ jobs:
             exit 1
           fi
 
+      - name: Verify PR base branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # A PR can be retargeted after creation, and retargeting preserves the
+          # label, author, head branch and version bump -- so every other guard
+          # here still passes. Without this, merging a retargeted release PR
+          # would tag that branch's tree under a release version.
+          #
+          # Only the default branch is a release line today. A maintenance branch
+          # flow (hotfix backports) has to widen this deliberately.
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::Release PR must target $DEFAULT_BRANCH (got $BASE_REF)"
+            exit 1
+          fi
+
       - name: Checkout merge commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,6 +11,11 @@ concurrency:
   group: "tag-release"
   cancel-in-progress: false
 
+env:
+  # prepare-release opens the PR with the default GITHUB_TOKEN, which
+  # authors it as github-actions[bot]. Change this if that token changes.
+  RELEASE_PR_AUTHOR: "github-actions[bot]"
+
 jobs:
   tag-release:
     # Only merged release PRs, identified by the label applied by prepare-release.
@@ -23,6 +28,17 @@ jobs:
     permissions:
       contents: write # Required to push the release tag
     steps:
+      - name: Verify PR author
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # The ci-release label alone is not enough: anyone with triage
+          # access can apply it to a hand-written PR.
+          if [ "$PR_AUTHOR" != "$RELEASE_PR_AUTHOR" ]; then
+            echo "::error::Release PR must be opened by $RELEASE_PR_AUTHOR (got $PR_AUTHOR)"
+            exit 1
+          fi
+
       - name: Checkout merge commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -22,7 +22,9 @@ jobs:
     if: >-
       ${{ github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'ci-release') }}
-    environment: general
+    # No environment: this runs on a pull_request ref (refs/pull/N/merge),
+    # which no deployment branch policy would match. It needs no secrets
+    # beyond GITHUB_TOKEN.
     name: Tag Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

Publishing created the tag as a side effect of `gh release create --target main`. `--target main` resolves to main's HEAD **at publish time**, not the release commit. The publish job's checkout had no `ref:` either, so it built from main's HEAD too.

That left two windows open between merging the release PR and dispatching publish:

1. **Tag drift** — anything landing on main in between silently moves where the tag points.
2. **Content drift** — npm gets a tarball containing those commits, under a version number that never corresponded to any reviewed tree. Unlike a tag, a published version can't be corrected.

History has stayed clean (`v13.5.0` → `97069d8`, `v13.4.1` → `1d997b0`) but that's release discipline, not construction.

## Changes

**New: `.github/workflows/tag-release.yml`**

Fires on `pull_request: [closed]`, gated on `merged == true` plus the `ci-release` label. Tags `merge_commit_sha` directly, so the tag is a deterministic function of the merge rather than of when someone gets around to publishing.

Guards, all failing loudly rather than skipping:

- **PR author account id is `41898282`** (github-actions[bot]). From the event payload, so it reflects the token that opened the PR and can't be set by the PR itself. Ids are immutable across renames; logins are not. The `ci-release` label alone is not an identity signal — anyone with triage access can apply it.
- **Release commit author email** matches the constant in `version-release-pr`. Explicitly *not* an identity proof: git author metadata is unsigned (head commit reports `verified: false`) and anyone who can push may set it. It's a canary for that hardcoded identity drifting out of sync.
- Branch matches `release/<group>-v<version>`, group is `packages`, and the version matches `packages/otplib/package.json` at the merge commit.

Tag creation is idempotent (same sha → no-op) and refuses to move an existing tag.

**Changed: `.github/workflows/publish-packages.yml`**

- Dispatched **against the release tag** rather than taking a tag input. The ref selects both the source published and the workflow that publishes it.
- Both jobs reject anything that isn't a `vX.Y.Z` tag matching the committed version. The dispatch dropdown pre-selects the default branch, so without that guard an accepted default would publish main's HEAD — the exact drift this removes. Rejecting on `ref_type` also closes a gap the input design had: a branch named like a tag.
- `--target main` dropped from both `gh release create` calls — the tag pre-exists, so `gh` attaches to it.
- Removed the dead `startsWith(github.ref, 'refs/tags/v')` clause (the workflow was `workflow_dispatch`-only, so its first clause was always true).

Publish stays manual. The human gate before npm is worth keeping, and it sidesteps the fact that tags pushed with `GITHUB_TOKEN` don't trigger other workflows.

## Environment policies (done)

Deployment policies were updated alongside this, since a tag dispatch is refused by default:

| Environment | Policies | Serves |
|---|---|---|
| `general` | `branch: main` + `tag: v*.*.*` | prepare-release, smoke-test, publish-docs (main); publish dry-run (tag) |
| `production` | `tag: v*.*.*` + required reviewers | publish only — no branch path exists |

`production` is deliberately tag-only. It is used by exactly one job, and under dispatch-from-tag an old tag runs its own copy of the workflow, predating the `ref_type` guard. The environment policy is enforced by GitHub before the job starts, so it is the one check that applies regardless of which workflow version runs.

`tag: v*.*.*` rather than `v*` because these are glob patterns, not regex — requiring the three-part shape is as precise as the policy layer gets. Exact validation stays in the workflow.

Related: `tag-release` deliberately carries **no** `environment:`. It runs on a `pull_request` ref (`refs/pull/N/merge`), which no branch policy matches, and it needs nothing beyond `GITHUB_TOKEN`.

## Design decisions

**Dispatch-from-tag over a `tag` input.** Trade-off is real: workflow fixes stop applying retroactively, since publishing an old tag runs that tag's copy of the file, pinned action SHAs included. That only bites when republishing something old, and self-heals from the next release. In exchange, recipe and source come from one ref, and there's nothing to type.

**No "is this tag an ancestor of main" check.** It would guard against publishing an off-branch tag, but closes the door on hotfixes — and if we branch from a tag to backport, checking against main is actively wrong. Tag-matches-version is the invariant worth enforcing; reachability from main is not.

## When tagging fires

On merge of the release PR, and only then. `prepare-release` is `workflow_dispatch` and touches no tags. A release PR closed without merging skips the job.

For `pull_request` events the workflow file comes from the merge ref — head merged into base — and the base is main. So once this lands, main's copy runs regardless of whether the release branch contains it, including for a PR cut from main beforehand.

`pull_request` has no label-based event filter, so the workflow is evaluated on every closed PR and skips via `if:`, leaving a skipped run in the Actions tab each time.

## Verification

- Both files parse; the folded `if:` collapses to a single valid expression.
- Branch-name resolver exercised against real and adversarial inputs: correct version accepted; wrong version, wrong group, non-release branch, and a `; rm -rf /` injection attempt all rejected. Untrusted values go through `env:`, never interpolated into script bodies.
- Dispatch guard: `tag v13.6.0` accepted; `branch main`, `branch v13.6.0`, `tag v13.4.1`, `tag latest` all rejected.
- Identity checks validated against real data — account id `41898282` on #819/#854/#881, bot email on the `v13.5.0`/`v13.4.1`/`v13.4.0` squash commits, and a human-authored commit correctly rejected.
- `PREV_TAG` still resolves to `v13.4.1` with `v13.5.0` present.
- No backfill needed — `v13.5.0` already exists on the remote at the release commit.

