### PR TITLE
fix(packages): resolve attw node10 failures on subpath exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,19 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "errors": [
+        "./dist/errors.d.ts"
+      ],
+      "utils": [
+        "./dist/utils.d.ts"
+      ],
+      "types": [
+        "./dist/types.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/otplib-cli/package.json
+++ b/packages/otplib-cli/package.json
@@ -9,6 +9,7 @@
     "otplib": "./dist/index.cjs",
     "otplibx": "./dist/otplibx.cjs"
   },
+  "main": "./dist/index.cjs",
   "files": [
     "dist"
   ],

--- a/packages/otplib-cli/package.json
+++ b/packages/otplib-cli/package.json
@@ -9,7 +9,6 @@
     "otplib": "./dist/index.cjs",
     "otplibx": "./dist/otplibx.cjs"
   },
-  "main": "./dist/index.cjs",
   "files": [
     "dist"
   ],

--- a/packages/otplib/package.json
+++ b/packages/otplib/package.json
@@ -34,6 +34,16 @@
   "browser": "./dist/index.global.js",
   "unpkg": "./dist/index.global.js",
   "jsdelivr": "./dist/index.global.js",
+  "typesVersions": {
+    "*": {
+      "functional": [
+        "./dist/functional.d.ts"
+      ],
+      "class": [
+        "./dist/class.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
Flagged as pre-existing during the tsdown migration work (#858). Verified against packed tarballs with `@arethetypeswrong/cli`.

## The bug

`otplib` and `@otplib/core` declare their subpaths only under `exports`. node10 module resolution predates `exports`, so `otplib/functional` is looked up as `node_modules/otplib/functional.d.ts` — but the files live in `dist/`. No package in the repo set `typesVersions`.

Affects consumers on `moduleResolution: "node"` / `"node10"` (legacy TS setups, `ts-node` defaults). Modern resolution was always fine.

The original report named only `otplib`; `@otplib/core` has the same failure on `./errors`, `./utils` and `./types`. These are the only two packages with subpath exports — the other 11 are single-entry and were already clean.

## Fix

Added `typesVersions` maps pointing each subpath at its `dist/*.d.ts`. That is the entire diff.

| package | before | after |
| --- | --- | --- |
| `otplib` | 3 x `Resolution failed` on node10, exit 1 | No problems found, exit 0 |
| `@otplib/core` | 3 x `Resolution failed` on node10, exit 1 | No problems found, exit 0 |

## Scope note: `otplib-cli` left alone

An earlier revision of this PR also dropped `main` from `otplib-cli`, which points at a shebang'd bin that runs `parseAsync(process.argv)` at module scope. **That has been reverted** — this PR no longer touches `otplib-cli`.

Review raised that removing `main` breaks package-root resolution. Verified against the published `otplib-cli@13.5.0`:

- `require.resolve("otplib-cli")` resolves today and returns `dist/index.cjs`. With `main` removed it throws `MODULE_NOT_FOUND`. It does **not** execute the CLI, so locating the binary this way is a real working pattern — this part of the review is correct.
- `require("otplib-cli")`, by contrast, has no working consumers to break: it prints CLI help to the host's stdout and calls `process.exit(1)`, so the require never returns. With host flags present it exits 1 with `error: unknown option`.

Either way the removal is orthogonal to the node10 fix — attw exits 0 for `otplib-cli` regardless, since `does not contain types` is informational and has no corresponding `--ignore-rules` value. It is semver-major-shaped, so it is deferred rather than carried here.

Worth noting for whoever picks that up: `main` and `bin` pointed at separate files until v2.0.0 (v1.0.1 had `main: src/index.js`, `bin: bin/otplib.js`), and `src/otplib/index.ts` already exports a non-executing `createCli`. But pointing `main` at a library module would make `require.resolve("otplib-cli")` silently return something that is not the executable, which is worse than a loud failure for the one real use case — so that option needs its own thought, not a drive-by.

## Verification

Rebased onto `main` after #886. Build, size (13/13 PASS), typecheck (22 tasks), lint (13 tasks), unit tests (1513 passed / 35 files), distribution tests (119 passed), prettier — all green.

No CI wiring for attw exists yet; happy to add a regression guard in a follow-up if wanted.