### PR TITLE
fix(turbo): include CI and NODE_ENV in the cache key

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["CI", "NODE_ENV"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Found while investigating why `pnpm size` reported bundle-size failures locally that CI never saw.

## The bug

Every package's `tsup.config.ts` gates minification on:

```ts
const isProduction = process.env.NODE_ENV === "production" || process.env.CI === "true";
```

and `vitest.config.ts` switches reporters and coverage output on `process.env.CI`.

Neither variable was declared in `turbo.json`, so neither was part of the task cache key — making minified and unminified builds interchangeable in the cache, in both directions.

Reproduced on `main`: after a `CI=true` build, a plain `turbo run build` reported `13 cached, 13 total >>> FULL TURBO` and left the minified 645-byte artifact in place instead of rebuilding the 2450-byte one.

The visible symptom is that `pnpm size` measures whichever build happens to be cached rather than the one requested. `@otplib/plugin-crypto-node` reads 1.1 KB unminified vs a 1.0 KB limit, and 0.4 KB minified — so a stale cache entry flips the result either way. Worse, it silently hands a developer the wrong artifact even when they explicitly ask for the other build.

## Fix

One line — `"globalEnv": ["CI", "NODE_ENV"]`.

Scoped globally rather than to `build` because `CI` also changes `test:ci` coverage output, and `docs:build` builds too. This is also robust to another env-dependent config being added later.

## Verification

| step | expected | result |
| --- | --- | --- |
| `CI=true` build (populate) | minified | 645 bytes |
| plain build | must **not** reuse CI cache | `0 cached, 13 total`, 2450 bytes |
| `CI=true` build again | hits its own entry | `13 cached, 13 total >>> FULL TURBO`, 645 bytes |

So cross-contamination is gone while same-env cache hits are fully preserved — no cache-efficiency loss in CI or locally.

Full CI-equivalent run green: build, size (13/13 PASS), typecheck (22 tasks), lint (13 tasks), tests (1513 passed), distribution tests (119 passed), prettier.

## Why separate from #885

Branched off `main` and kept standalone so the other in-flight branches can pick it up independently.

Related follow-ups, not included here:
- `pnpm size` is misleading on a default local build — could set `NODE_ENV=production` in the script itself.
- The size step writes `ERROR: One or more bundle size checks failed.` to stdout, which `ci.yml` redirects into `$GITHUB_STEP_SUMMARY` — so on a real failure the job log shows a bare non-zero exit with the reason only in the summary tab.