### PR TITLE
feat(otplib-cli)!: split library entry point from executables

### DIFF
--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -307,6 +307,39 @@ aws secretsmanager get-secret-value --secret-id otp-secrets \
   --query SecretString --output text | otplib token A1B2C3D4
 ```
 
+## Programmatic Usage
+
+`otplib-cli` also ships an importable entry point, for wrapping either program in your own
+tool. The package root is a library and has no side effects on import - the executables live
+behind the `otplib` and `otplibx` bins and are never loaded by `import` or `require`.
+
+```ts
+import { createCli, createOtplibxCli } from "otplib-cli";
+
+// Build the program without running it.
+const program = createCli();
+
+// Add your own command alongside the built-in ones.
+program.command("whoami").action(() => console.log("custom command"));
+
+await program.parseAsync(process.argv);
+```
+
+`createCli()` and `createOtplibxCli()` each return a configured [commander](https://github.com/tj/commander.js)
+`Command`. Nothing is parsed until you call `parseAsync` yourself, so you stay in control of
+argument handling and process exit.
+
+Both accept an optional stdin reader, which is useful for testing or for feeding input from
+somewhere other than the process stdin:
+
+```ts
+import { createCli, type ReadStdinFn } from "otplib-cli";
+
+const readStdin: ReadStdinFn = async () => JSON.stringify({/* entries */});
+
+const program = createCli(readStdin);
+```
+
 ## Security Notes
 
 - **Encryption**: `otplibx` uses AES-256-GCM authenticated encryption. The key is stored in `.env.keys` Never commit this file!

--- a/packages/otplib-cli/package.json
+++ b/packages/otplib-cli/package.json
@@ -5,11 +5,27 @@
   "license": "MIT",
   "author": "Gerald Yeo <support@yeojz.dev>",
   "type": "module",
+  "sideEffects": false,
   "bin": {
-    "otplib": "./dist/index.cjs",
-    "otplibx": "./dist/otplibx.cjs"
+    "otplib": "./dist/bin/otplib.cjs",
+    "otplibx": "./dist/bin/otplibx.cjs"
   },
   "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/packages/otplib-cli/src/index.test.ts
+++ b/packages/otplib-cli/src/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createCli, createOtplibxCli, readStdin } from "./index.js";
+
+describe("public entry point", () => {
+  test("exposes the documented API", () => {
+    expect(typeof createCli).toBe("function");
+    expect(typeof createOtplibxCli).toBe("function");
+    expect(typeof readStdin).toBe("function");
+  });
+
+  test("createCli returns a configured program without parsing argv", () => {
+    const program = createCli();
+
+    expect(program.name()).toBe("otplib");
+    expect(program.commands.length).toBeGreaterThan(0);
+  });
+
+  test("createOtplibxCli returns a configured program without parsing argv", () => {
+    const program = createOtplibxCli();
+
+    expect(program.name()).toBe("otplibx");
+  });
+
+  // Guards the packaging split: `main` must resolve to this module, never to the
+  // bin wrappers, which call parseAsync(process.argv) at import time.
+  test("importing the entry point does not run a CLI", async () => {
+    const originalArgv = process.argv;
+    const originalExitCode = process.exitCode;
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    process.argv = ["node", "host-app", "--a-flag-otplib-does-not-know"];
+
+    try {
+      vi.resetModules();
+      await import("./index.js");
+
+      expect(exit).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(originalExitCode);
+    } finally {
+      process.argv = originalArgv;
+      process.exitCode = originalExitCode;
+      exit.mockRestore();
+    }
+  });
+});

--- a/packages/otplib-cli/src/index.ts
+++ b/packages/otplib-cli/src/index.ts
@@ -1,0 +1,4 @@
+export { createCli, readStdin } from "./otplib/index.js";
+export { createOtplibxCli } from "./otplibx/index.js";
+
+export type { ReadStdinFn } from "./shared/stdin.js";

--- a/packages/otplib-cli/tsup.config.ts
+++ b/packages/otplib-cli/tsup.config.ts
@@ -1,16 +1,25 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: {
-    index: "src/otplib/cli.ts",
-    otplibx: "src/otplibx/cli.ts",
+export default defineConfig([
+  {
+    entry: { index: "src/index.ts" },
+    format: ["cjs", "esm"],
+    dts: true,
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    target: "node20",
   },
-  format: ["cjs"],
-  clean: true,
-  sourcemap: true,
-  target: "node20",
-  shims: true,
-  banner: {
-    js: "#!/usr/bin/env node",
+  {
+    entry: {
+      "bin/otplib": "src/otplib/cli.ts",
+      "bin/otplibx": "src/otplibx/cli.ts",
+    },
+    format: ["cjs"],
+    splitting: false,
+    sourcemap: true,
+    target: "node20",
+    shims: true,
+    banner: { js: "#!/usr/bin/env node" },
   },
-});
+]);


### PR DESCRIPTION
> [!WARNING]
> **Breaking change — needs a major release.** CLI usage is unaffected; the published `dist/` layout and the package-root import behaviour change.

Follow-up to #885. Closes the `otplib-cli has no types` half of that report properly, rather than dismissing it.

## The problem

`main` and `bin.otplib` pointed at the same file:

```
main:       ./dist/index.cjs
bin.otplib: ./dist/index.cjs   ← identical
```

`tsup.config.ts` built that file from `src/otplib/cli.ts`, an 8-line wrapper that calls `parseAsync(process.argv)` at module scope. So the package root was an executable, not a library. Verified against the published `otplib-cli@13.5.0`:

```
BEFORE require
Usage: otplib [options] [command]
...
EXIT=1                      ← "AFTER require" never printed
```

With host flags present it is worse — `error: unknown option '--my-flag'`, exit 1. Importing the package printed CLI help to the host's stdout and killed the host process. `createCli` was bundled inside `dist/index.cjs` but never exported.

## The fix

The source was **already** separated — [`src/otplib/index.ts`](packages/otplib-cli/src/otplib/index.ts) exports `createCli()` with no side effects and `cli.ts` is just a wrapper around it. Only the build wiring was wrong, and the library modules were never emitted as entry points.

- new `src/index.ts` barrel exporting `createCli`, `createOtplibxCli`, `readStdin`, `ReadStdinFn`
- `tsup.config.ts` split into two configs: library (`dist/index.*`, CJS + ESM + dts) and executables (`dist/bin/*.cjs`, shebang, CJS)
- `package.json`: `main`/`module`/`types`/`exports` point at the library; `bin` points into `dist/bin/`

Deliberately **not** included: minification for this package. It has never been minified, and turning it on would change published artifacts and hurt CLI stack traces for reasons unrelated to this split.

## Verified from an installed tarball

| check | result |
| --- | --- |
| `otplib --version` / `otplibx --version` | `13.5.0` / `13.5.0` |
| bin symlinks | `otplib -> ../otplib-cli/dist/bin/otplib.cjs` |
| `require("otplib-cli")` | `exports: createCli, createOtplibxCli, readStdin` — process survives, exit 0 |
| `import` (ESM) | `otplib / otplibx` |
| `require.resolve("otplib-cli")` | resolves (no `MODULE_NOT_FOUND`) |
| `tsc` `moduleResolution: nodenext` | OK |
| `tsc` `moduleResolution: node10` | OK |
| attw | **No problems found** on all 4 entrypoints |

Repo suite: build (13 tasks), size (`otplib-cli` 8.9 KB vs 13 KB limit, 13/13 PASS), typecheck (22 tasks), lint (13 tasks), tests **1517 passed / 36 files** (+4 new), distribution tests (119 passed), prettier.

## Regression guard

[`src/index.test.ts`](packages/otplib-cli/src/index.test.ts) asserts the public API is exported, that `createCli()`/`createOtplibxCli()` return configured but **unparsed** programs, and — with `process.argv` set to flags the CLI does not recognise — that importing the entry point neither calls `process.exit` nor sets `process.exitCode`. That is the exact regression that would return if `main` were ever re-pointed at a bin wrapper.

## Migration

| | before | after |
| --- | --- | --- |
| `otplib` / `otplibx` on the command line | works | **unchanged** |
| `npx -p otplib-cli otplib` | works | **unchanged** |
| `require("otplib-cli")` | prints help, exits 1 | returns `{ createCli, createOtplibxCli, readStdin }` |
| `require.resolve("otplib-cli")` | `dist/index.cjs` (the executable) | `dist/index.cjs` (the library) |
| bin files on disk | `dist/index.cjs`, `dist/otplibx.cjs` | `dist/bin/otplib.cjs`, `dist/bin/otplibx.cjs` |
| deep imports into `dist/` | allowed | blocked by the new `exports` map |

Anyone locating the executable by path should read the package's `bin` field rather than assuming `require.resolve` returns it. For context on scale: `otplib-cli` currently sees ~54 downloads/month.

## Docs

Added a **Programmatic Usage** section to [the CLI guide](apps/docs/guide/cli.md) covering `createCli()`, `createOtplibxCli()`, the injectable stdin reader, and the no-side-effects-on-import guarantee.