### PR TITLE
chore(ci): drop stale CVE suppression, dead publish token env, and input interpolation

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -115,8 +115,6 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           node-version: ${{ env.NODE_VERSION_TARGET }}
           cache: "pnpm"
@@ -127,6 +125,9 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
+      # Auth is via npm trusted publishing (OIDC): id-token: write above plus
+      # NPM_CONFIG_PROVENANCE lets npm exchange the workflow's OIDC token for
+      # a short-lived publish token, so no NPM_TOKEN secret is required.
       - name: Publish to npm
         run: pnpm run release:packages
         env:

--- a/.github/workflows/smoke-test-packages.yml
+++ b/.github/workflows/smoke-test-packages.yml
@@ -27,7 +27,9 @@ jobs:
       checks: write # Required for uploading test results
     steps:
       - name: Set version
-        run: echo "OTPLIB_VERSION=${{ github.event.inputs.version || 'latest' }}" >> $GITHUB_ENV
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: echo "OTPLIB_VERSION=${INPUT_VERSION:-latest}" >> $GITHUB_ENV
 
       - name: Checkout smoke tests
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/package.json
+++ b/package.json
@@ -63,11 +63,6 @@
     "vitest-tsconfig-paths": "^3.4.1"
   },
   "pnpm": {
-    "auditConfig": {
-      "ignoreCves": [
-        "CVE-2026-39365"
-      ]
-    },
     "overrides": {
       "ajv@>=6.0.0 <6.14.0": "6.14.0",
       "esbuild@<=0.24.2": ">=0.25.0 <0.28.0",


### PR DESCRIPTION
## Summary

Three small supply-chain housekeeping items surfaced by a repo audit.

- **Remove stale CVE suppression.** `pnpm.auditConfig.ignoreCves` muted CVE-2026-39365 (GHSA-4w7w-66w2-5vf9, Vite path traversal in optimized-deps `.map` handling, patched in 8.0.5). The lockfile resolves only `vite@8.2.2`, so the suppression no longer does anything. Both `pnpm audit --prod --audit-level=moderate` and `pnpm audit` report no known vulnerabilities with it removed.
- **Remove dead `NODE_AUTH_TOKEN` env from publish workflow.** It was set only on the `setup-node` step, which had no `registry-url`, so setup-node never wrote npm auth config and the env was step-scoped anyway. v13.5.0 was published with the identical wiring, so publishing is already going through npm trusted publishing (OIDC via `id-token: write`). Added a comment saying so. The `NPM_TOKEN` repository secret can be deleted separately.
- **Pass `workflow_dispatch` input via `env:`** in `smoke-test-packages.yml` instead of interpolating `github.event.inputs.version` straight into `run:`.

## Semver

No published package code changes.

## Test plan

- [x] `pnpm audit --prod --audit-level=moderate` and `pnpm audit` clean without the suppression
- [x] `pnpm format:check`
- [x] Both workflow YAML files parse