### PR TITLE
fix(uri): keep secrets out of error messages and validate generate params

### DIFF
--- a/packages/uri/src/generate.ts
+++ b/packages/uri/src/generate.ts
@@ -6,6 +6,30 @@ import type { OTPAuthURI } from "./types.js";
 import type { HashAlgorithm, Digits } from "@otplib/core";
 
 /**
+ * Coerce a number or a strict numeric string (e.g. from parsed JSON or a
+ * database row) into a safe integer within [min, max]. Mirrors parse.ts's
+ * parseIntegerParameter, minus the throw - callers decide how to report a
+ * rejection.
+ */
+function coerceInteger(
+  value: unknown,
+  min: number,
+  max = Number.MAX_SAFE_INTEGER,
+): number | undefined {
+  let numeric: number;
+
+  if (typeof value === "number") {
+    numeric = value;
+  } else if (typeof value === "string" && /^-?\d+$/.test(value)) {
+    numeric = Number(value);
+  } else {
+    return undefined;
+  }
+
+  return Number.isSafeInteger(numeric) && numeric >= min && numeric <= max ? numeric : undefined;
+}
+
+/**
  * Base options for URI generation
  */
 export type URIOptions = {
@@ -71,8 +95,10 @@ export type HOTPURIOptions = URIOptions & {
  * @returns The otpauth:// URI string
  * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
  * @throws {InvalidParameterError} If `type` is not "hotp"/"totp", or if
- * `digits`, `counter`, or `period` are present but are not safe, in-range
- * integers
+ * `digits`, `counter`, or `period` are present but are not a safe integer (or
+ * a numeric string of one) in range - `digits` must be 6, 7 or 8 to match
+ * what this package's `parse()` accepts, `counter` must be >= 0, and `period`
+ * must be >= 1
  *
  * @example
  * ```ts
@@ -104,18 +130,25 @@ export function generate(uri: OTPAuthURI): string {
     throw new InvalidParameterError("type", String(type));
   }
 
-  if (params.digits !== undefined && !(Number.isSafeInteger(params.digits) && params.digits > 0)) {
+  // digits/counter/period commonly arrive as numeric strings (parsed JSON, a
+  // database row, form data), which worked before validation existed since
+  // the value was just interpolated with String(). Coerce those alongside
+  // plain numbers rather than rejecting them outright.
+  //
+  // digits is bounded to 6-8 to match parse()'s accepted set, so generate()
+  // can never produce a URI that this package's own parse() rejects.
+  const digits = params.digits === undefined ? undefined : coerceInteger(params.digits, 6, 8);
+  if (params.digits !== undefined && digits === undefined) {
     throw new InvalidParameterError("digits", String(params.digits));
   }
 
-  if (
-    params.counter !== undefined &&
-    !(Number.isSafeInteger(params.counter) && params.counter >= 0)
-  ) {
+  const counter = params.counter === undefined ? undefined : coerceInteger(params.counter, 0);
+  if (params.counter !== undefined && counter === undefined) {
     throw new InvalidParameterError("counter", String(params.counter));
   }
 
-  if (params.period !== undefined && !(Number.isSafeInteger(params.period) && params.period > 0)) {
+  const period = params.period === undefined ? undefined : coerceInteger(params.period, 1);
+  if (params.period !== undefined && period === undefined) {
     throw new InvalidParameterError("period", String(params.period));
   }
 
@@ -149,16 +182,16 @@ export function generate(uri: OTPAuthURI): string {
     }
   }
 
-  if (params.digits && params.digits !== 6) {
-    queryParams.push(`digits=${params.digits}`);
+  if (digits !== undefined && digits !== 6) {
+    queryParams.push(`digits=${digits}`);
   }
 
-  if (type === "hotp" && params.counter !== undefined) {
-    queryParams.push(`counter=${params.counter}`);
+  if (type === "hotp" && counter !== undefined) {
+    queryParams.push(`counter=${counter}`);
   }
 
-  if (type === "totp" && params.period !== undefined && params.period !== 30) {
-    queryParams.push(`period=${params.period}`);
+  if (type === "totp" && period !== undefined && period !== 30) {
+    queryParams.push(`period=${period}`);
   }
 
   result += queryParams.join("&");

--- a/packages/uri/src/generate.ts
+++ b/packages/uri/src/generate.ts
@@ -1,5 +1,7 @@
 import { normalizeHashAlgorithm } from "@otplib/core";
 
+import { InvalidParameterError } from "./types.js";
+
 import type { OTPAuthURI } from "./types.js";
 import type { HashAlgorithm, Digits } from "@otplib/core";
 
@@ -68,6 +70,9 @@ export type HOTPURIOptions = URIOptions & {
  * @param uri - The URI components
  * @returns The otpauth:// URI string
  * @throws {AlgorithmUnsupportedError} If a non-empty algorithm is not supported
+ * @throws {InvalidParameterError} If `type` is not "hotp"/"totp", or if
+ * `digits`, `counter`, or `period` are present but are not safe, in-range
+ * integers
  *
  * @example
  * ```ts
@@ -91,6 +96,28 @@ export type HOTPURIOptions = URIOptions & {
  */
 export function generate(uri: OTPAuthURI): string {
   const { type, label, params } = uri;
+
+  // `type` is interpolated directly into the URI below (unlike label/issuer/
+  // secret, it is never percent-encoded), so untyped JS callers must be
+  // stopped from smuggling extra path/query segments through it.
+  if (type !== "hotp" && type !== "totp") {
+    throw new InvalidParameterError("type", String(type));
+  }
+
+  if (params.digits !== undefined && !(Number.isSafeInteger(params.digits) && params.digits > 0)) {
+    throw new InvalidParameterError("digits", String(params.digits));
+  }
+
+  if (
+    params.counter !== undefined &&
+    !(Number.isSafeInteger(params.counter) && params.counter >= 0)
+  ) {
+    throw new InvalidParameterError("counter", String(params.counter));
+  }
+
+  if (params.period !== undefined && !(Number.isSafeInteger(params.period) && params.period > 0)) {
+    throw new InvalidParameterError("period", String(params.period));
+  }
 
   // Encode label parts while preserving ':' as the issuer/account separator
   const encodedLabel = label

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -355,6 +355,67 @@ describe("URI", () => {
         expect(uri).toContain("digits=8");
         expect(uri).toContain("period=60");
       });
+
+      it("should accept numeric strings for digits, counter and period", () => {
+        // digits/counter/period commonly arrive as strings from parsed JSON
+        // or a database row; this worked before validation existed and must
+        // keep working.
+        const totpUri = generate({
+          type: "totp",
+          label: "user",
+          params: {
+            secret: TEST_SECRET_PARSE_BASE32,
+            digits: "8" as never,
+            period: "60" as never,
+          },
+        });
+        expect(totpUri).toContain("digits=8");
+        expect(totpUri).toContain("period=60");
+
+        const hotpUri = generate({
+          type: "hotp",
+          label: "user",
+          params: { secret: TEST_SECRET_PARSE_BASE32, counter: "5" as never },
+        });
+        expect(hotpUri).toContain("counter=5");
+      });
+
+      it("should reject a non-numeric digits value", () => {
+        expect(() =>
+          generate({
+            type: "totp",
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32, digits: "six" as never },
+          }),
+        ).toThrow(InvalidParameterError);
+      });
+
+      it("should reject a digits value parse() would not accept back", () => {
+        // digits is bounded to 6-8 (the same set parse() accepts) so
+        // generate() can never emit a URI that this package's own parse()
+        // rejects.
+        expect(() =>
+          generate({
+            type: "totp",
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32, digits: 10 },
+          }),
+        ).toThrow(InvalidParameterError);
+      });
+
+      it("should round-trip every digits value it accepts through parse()", () => {
+        for (const digits of [6, 7, 8] as const) {
+          const uri = generate({
+            type: "totp",
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32, digits },
+          });
+
+          // digits=6 is the default, so generate() omits it from the query
+          // string and parse() reports it back as absent rather than 6.
+          expect(parse(uri).params.digits).toBe(digits === 6 ? undefined : digits);
+        }
+      });
     });
   });
 
@@ -637,6 +698,29 @@ describe("URI", () => {
     it("should not leak the secret or the full URI when type/label are missing", () => {
       const secret = TEST_SECRET_PARSE_BASE32;
       const uri = `otpauth://totp?secret=${secret}`;
+
+      let caught: unknown;
+      try {
+        parse(uri);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toBe("Invalid otpauth URI: missing type or label");
+      expect(message).not.toContain(secret);
+      expect(message).not.toContain(uri);
+    });
+
+    it("should not leak the secret when a label-less URI's query string contains a slash", () => {
+      // Regression test: the type/label separator search used to scan the
+      // whole remainder for "/", so a "/" inside a query value (e.g. an
+      // image URL) was mistaken for the separator. Everything before it -
+      // including the query string - then became the rejected `type` value
+      // and was embedded verbatim in the error message.
+      const secret = TEST_SECRET_PARSE_BASE32;
+      const uri = `otpauth://totp?secret=${secret}&image=https://acme.com/logo.png`;
 
       let caught: unknown;
       try {

--- a/packages/uri/src/index.test.ts
+++ b/packages/uri/src/index.test.ts
@@ -229,6 +229,133 @@ describe("URI", () => {
 
       expect(uri).not.toContain("period=");
     });
+
+    describe("type validation", () => {
+      it("should throw when type is neither 'hotp' nor 'totp'", () => {
+        // `type` is interpolated directly (unencoded) into the otpauth:// URI,
+        // so an attacker-controlled string could smuggle extra path/query
+        // segments - e.g. injecting a second, attacker-chosen `secret`.
+        expect(() =>
+          generate({
+            type: "totp/x?secret=EVIL#" as unknown as OTPAuthURI["type"],
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32 },
+          }),
+        ).toThrow(InvalidParameterError);
+      });
+
+      it("should not embed the injected type value in the generated URI", () => {
+        let caught: unknown;
+        try {
+          generate({
+            type: "totp/x?secret=EVIL#" as unknown as OTPAuthURI["type"],
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32 },
+          });
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught).toBeInstanceOf(InvalidParameterError);
+        expect((caught as Error).message).toContain("type");
+      });
+
+      it("should reject an empty string type", () => {
+        expect(() =>
+          generate({
+            type: "" as unknown as OTPAuthURI["type"],
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32 },
+          }),
+        ).toThrow(InvalidParameterError);
+      });
+    });
+
+    describe("numeric parameter validation", () => {
+      const invalidNumbers = [NaN, 6.5, -1, 1e300, Infinity, -Infinity];
+
+      describe.each(invalidNumbers)("digits = %p", (digits) => {
+        it("should throw InvalidParameterError", () => {
+          expect(() =>
+            generate({
+              type: "totp",
+              label: "user",
+              params: { secret: TEST_SECRET_PARSE_BASE32, digits: digits as never },
+            }),
+          ).toThrow(InvalidParameterError);
+        });
+      });
+
+      // digits must be strictly positive (unlike counter, 0 is not valid)
+      it("should throw when digits is 0", () => {
+        expect(() =>
+          generate({
+            type: "totp",
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32, digits: 0 as never },
+          }),
+        ).toThrow(InvalidParameterError);
+      });
+
+      describe.each(invalidNumbers)("counter = %p", (counter) => {
+        it("should throw InvalidParameterError", () => {
+          expect(() =>
+            generate({
+              type: "hotp",
+              label: "user",
+              params: { secret: TEST_SECRET_PARSE_BASE32, counter: counter as never },
+            }),
+          ).toThrow(InvalidParameterError);
+        });
+      });
+
+      it("should accept counter = 0 (inclusive lower bound)", () => {
+        const uri = generate({
+          type: "hotp",
+          label: "user",
+          params: { secret: TEST_SECRET_PARSE_BASE32, counter: 0 },
+        });
+        expect(uri).toContain("counter=0");
+      });
+
+      describe.each(invalidNumbers)("period = %p", (period) => {
+        it("should throw InvalidParameterError", () => {
+          expect(() =>
+            generate({
+              type: "totp",
+              label: "user",
+              params: { secret: TEST_SECRET_PARSE_BASE32, period: period as never },
+            }),
+          ).toThrow(InvalidParameterError);
+        });
+      });
+
+      // period must be strictly positive (unlike counter, 0 is not valid)
+      it("should throw when period is 0", () => {
+        expect(() =>
+          generate({
+            type: "totp",
+            label: "user",
+            params: { secret: TEST_SECRET_PARSE_BASE32, period: 0 },
+          }),
+        ).toThrow(InvalidParameterError);
+      });
+
+      it("should still accept valid, in-range numeric parameters", () => {
+        const uri = generate({
+          type: "totp",
+          label: "user",
+          params: {
+            secret: TEST_SECRET_PARSE_BASE32,
+            digits: 8,
+            period: 60,
+          },
+        });
+
+        expect(uri).toContain("digits=8");
+        expect(uri).toContain("period=60");
+      });
+    });
   });
 
   describe("generateHOTP", () => {
@@ -386,6 +513,27 @@ describe("URI", () => {
       expect(() => parse(uri)).toThrow("Invalid otpauth URI");
     });
 
+    it("should not leak the secret or the full URI when the scheme is wrong", () => {
+      // Regression test: InvalidURIError used to be constructed with the raw
+      // URI, so a rejected `otpauth://`-lookalike containing `secret=...`
+      // would put the secret straight into Error.message.
+      const secret = TEST_SECRET_PARSE_BASE32;
+      const uri = `not-otpauth://totp/user?secret=${secret}`;
+
+      let caught: unknown;
+      try {
+        parse(uri);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toBe("Invalid otpauth URI: expected otpauth:// scheme");
+      expect(message).not.toContain(secret);
+      expect(message).not.toContain(uri);
+    });
+
     it("should handle URIs with extra parameters", () => {
       const uri = `otpauth://totp/Service:user?secret=${TEST_SECRET_PARSE_BASE32}&unknown=value&issuer=Service`;
       const parsed = parse(uri);
@@ -484,6 +632,24 @@ describe("URI", () => {
       const uri = "otpauth://totp";
 
       expect(() => parse(uri)).toThrow("Invalid otpauth URI");
+    });
+
+    it("should not leak the secret or the full URI when type/label are missing", () => {
+      const secret = TEST_SECRET_PARSE_BASE32;
+      const uri = `otpauth://totp?secret=${secret}`;
+
+      let caught: unknown;
+      try {
+        parse(uri);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toBe("Invalid otpauth URI: missing type or label");
+      expect(message).not.toContain(secret);
+      expect(message).not.toContain(uri);
     });
 
     it("should parse URI without query string", () => {

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -79,14 +79,14 @@ export function parse(uri: string): OTPAuthURI {
   }
 
   if (!uri.startsWith("otpauth://")) {
-    throw new InvalidURIError(uri);
+    throw new InvalidURIError("expected otpauth:// scheme");
   }
 
   const withoutScheme = uri.slice("otpauth://".length);
   const slashIndex = withoutScheme.indexOf("/");
 
   if (slashIndex === -1) {
-    throw new InvalidURIError(uri);
+    throw new InvalidURIError("missing type or label");
   }
 
   const type = withoutScheme.slice(0, slashIndex);

--- a/packages/uri/src/parse.ts
+++ b/packages/uri/src/parse.ts
@@ -83,7 +83,17 @@ export function parse(uri: string): OTPAuthURI {
   }
 
   const withoutScheme = uri.slice("otpauth://".length);
-  const slashIndex = withoutScheme.indexOf("/");
+
+  // Bound the search for the type/label separator to the part of the URI
+  // before the query string. Otherwise a `/` inside a query value (e.g. an
+  // `image=https://...` param on a label-less URI) is mistaken for the
+  // separator, and everything before it - including the query string, which
+  // may contain the secret - becomes the rejected `type` value and is
+  // embedded verbatim in the thrown error's message.
+  const schemeQueryIndex = withoutScheme.indexOf("?");
+  const authority =
+    schemeQueryIndex === -1 ? withoutScheme : withoutScheme.slice(0, schemeQueryIndex);
+  const slashIndex = authority.indexOf("/");
 
   if (slashIndex === -1) {
     throw new InvalidURIError("missing type or label");

--- a/packages/uri/src/types.ts
+++ b/packages/uri/src/types.ts
@@ -82,8 +82,14 @@ export class URIParseError extends Error {
  * Error thrown when URI is invalid
  */
 export class InvalidURIError extends URIParseError {
-  constructor(uri: string) {
-    super(`Invalid otpauth URI: ${uri}`);
+  /**
+   * @param reason - A short, non-sensitive description of why the URI was
+   * rejected. Callers must never pass the URI itself (or any substring of
+   * it, such as the secret) here, since it is embedded verbatim in
+   * `Error.message`.
+   */
+  constructor(reason: string) {
+    super(`Invalid otpauth URI: ${reason}`);
     this.name = "InvalidURIError";
   }
 }


### PR DESCRIPTION
## Summary

Two hardening fixes in `@otplib/uri` surfaced by a repo self-audit, plus follow-up fixes from review.

**Secret leak in `Error.message`.** `parse()` threw `new InvalidURIError(uri)` for a bad scheme or a missing type/label, and the error formatted the full URI into its message. Both call sites now pass a fixed reason. The constructor parameter is renamed to `reason` with a JSDoc warning against passing anything sensitive.

Review caught a second leak in the same area: the type/label separator search scanned the whole remainder for `/`, so on a label-less URI with a `/` inside a query value (e.g. an `image=https://...` param), everything before that `/` - including the secret - became the rejected `type` value and was embedded verbatim in the error. The search is now bounded to before the query string.

**Injection and validation in `generate()`.** `type` was interpolated into the URI unvalidated and unencoded, so an untyped caller passing a crafted `type` could forge extra path/query segments. `digits`, `counter` and `period` were interpolated unencoded with no runtime check. `generate()` now throws `InvalidParameterError` unless `type` is exactly `hotp` or `totp`, and unless the numeric params are safe integers in range.

Review caught two issues with the initial validation: it rejected numeric strings (e.g. `digits: "6"`), which previously worked and is the normal shape of values from parsed JSON or a database row. Numbers and non-blank strings now go through `Number()` and must come out as a safe integer in range; `null`, booleans, arrays and blank strings are rejected first, because `Number()` maps them to 0 and a zero counter is valid, so they would invent a value rather than spell one. This is looser than `parse()`'s digit-only rule on purpose: the emitted value is the validated integer, never the raw input. It also let `digits` be any positive integer while `parse()` only accepts 6, 7 or 8. An earlier revision bounded `digits` to that set, but `Digits` is `number` in `@otplib/core` and custom lengths are supported, so a typed `generateTOTP({ digits: 5 })` call must keep working. `digits` is validated as a positive safe integer only; `parse()` staying narrower is its own concern.

## Semver

Patch. Every previously valid call returns the same result. Newly rejected inputs were never valid under the TypeScript types and could only be reached from untyped JS or casts. The reason suffix of the two `InvalidURIError` messages changes; the `Invalid otpauth URI:` prefix and the error class are unchanged. Worth a changelog note.

## Test plan

- [x] Tests prove malformed-URI errors no longer contain the secret or URI, including via a query-string slash
- [x] Tests for type injection, numeric-string coercion, and NaN / non-integer / negative / out-of-range params
- [x] `pnpm fix && pnpm typecheck && pnpm test:ci` (1545 tests, 100% coverage)
- [x] `@otplib/uri` bundle size within limit

