### PR TITLE
fix(cli): enforce 0600 on vault and key files and gitignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ internal/typedoc/api/
 .env
 .env.local
 .env.*.local
+# otplibx vault + key files — never commit encrypted secrets or the master key
+.env.keys
+.env.otplibx
 
 # IDE
 .vscode/

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -84,7 +84,9 @@ otplibx init
 otplibx init .env.otp
 ```
 
-This creates `.env.otplibx` (or your custom filename) to store encrypted secrets, along with a `.env.keys` file containing the 256-bit symmetric encryption key. Both files are written (and re-chmod'd on every update) with `0600` permissions — readable and writable only by the current user — and `otplibx` refuses to load a `.env.keys` file that isn't `0600`.
+This creates `.env.otplibx` (or your custom filename) to store encrypted secrets, along with a `.env.keys` file containing the 256-bit symmetric encryption key. Both files are written (and re-chmod'd on every update) with `0600` permissions — readable and writable only by the current user — and `otplibx` refuses to load a `.env.keys` file that isn't `0600` or that has been replaced with a symlink. If you'd rather not have the key touch disk at all (e.g. in CI), skip `.env.keys` entirely and set `OTPLIBX_ENCRYPTION_KEY` instead — every command checks the environment variable first.
+
+This only covers `.env.keys` itself: it does not check the permissions or ownership of the directory containing it, so a key file that's `0600` inside a directory other users can write to is still not private. Keep that directory locked down too (e.g. your home directory's default permissions, not a shared or world-writable one).
 
 ::: warning
 **Never commit `.env.keys` or `.env.otplibx` to version control.** `.env.keys` contains your encryption key and `.env.otplibx` contains the ciphertext it unlocks — keep both out of your repo. Add them to `.gitignore`:

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -84,13 +84,14 @@ otplibx init
 otplibx init .env.otp
 ```
 
-This creates `.env.otplibx` (or your custom filename) to store encrypted secrets, along with a `.env.keys` file containing the 256-bit symmetric encryption key.
+This creates `.env.otplibx` (or your custom filename) to store encrypted secrets, along with a `.env.keys` file containing the 256-bit symmetric encryption key. Both files are written (and re-chmod'd on every update) with `0600` permissions — readable and writable only by the current user — and `otplibx` refuses to load a `.env.keys` file that isn't `0600`.
 
 ::: warning
-**Never commit `.env.keys` to version control.** This file contains your encryption key. Add it to `.gitignore`:
+**Never commit `.env.keys` or `.env.otplibx` to version control.** `.env.keys` contains your encryption key and `.env.otplibx` contains the ciphertext it unlocks — keep both out of your repo. Add them to `.gitignore`:
 
 ```bash
 echo ".env.keys" >> .gitignore
+echo ".env.otplibx" >> .gitignore
 ```
 
 :::

--- a/packages/otplib-cli/README.md
+++ b/packages/otplib-cli/README.md
@@ -22,6 +22,10 @@ Two commands are available:
 # Initialize secrets file
 otplibx init
 
+# `otplibx init` creates .env.otplibx (encrypted secrets) and .env.keys
+# (the 256-bit key), both written with 0600 permissions. Never commit
+# either file to version control — add both to .gitignore.
+
 # Add entry from file or clipboard
 cat otp-uri.txt | otplibx add
 pbpaste | otplibx add

--- a/packages/otplib-cli/src/otplib/commands/encode.ts
+++ b/packages/otplib-cli/src/otplib/commands/encode.ts
@@ -1,6 +1,5 @@
-import fs from "node:fs";
-
 import { parseAddInput } from "../../shared/parse.js";
+import { writeSecretFile } from "../../shared/secure-file.js";
 import { encodePayload, generateUid } from "../../shared/types.js";
 
 import type { ReadStdinFn } from "../../shared/stdin.js";
@@ -60,9 +59,7 @@ export function registerEncodeCommand(program: Command, readStdinFn: ReadStdinFn
 
         if (options.saveUid) {
           try {
-            const fd = fs.openSync(options.saveUid, "a", 0o600);
-            fs.writeSync(fd, id + "\n");
-            fs.closeSync(fd);
+            writeSecretFile(options.saveUid, id + "\n", "a");
           } catch (err) {
             console.error(
               `\nWarning: Could not save UID to ${options.saveUid}: ${(err as Error).message}`,

--- a/packages/otplib-cli/src/otplib/index.test.ts
+++ b/packages/otplib-cli/src/otplib/index.test.ts
@@ -2,14 +2,18 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Readable } from "node:stream";
 
 // Mock all dependencies before importing
-vi.mock("node:fs", () => ({
-  default: {
-    openSync: vi.fn(),
-    fchmodSync: vi.fn(),
-    writeSync: vi.fn(),
-    closeSync: vi.fn(),
-  },
-}));
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    default: {
+      constants: actual.constants,
+      openSync: vi.fn(),
+      fchmodSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      closeSync: vi.fn(),
+    },
+  };
+});
 
 vi.mock("../shared/otp.js", () => ({
   generateOtp: vi.fn(),
@@ -42,6 +46,8 @@ import { encodePayload, formatOutput, generateUid, getLabel } from "../shared/ty
 
 const mockFs = vi.mocked(fs);
 const FD = 42;
+const APPEND_FLAGS =
+  fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW;
 const mockGenerateOtp = vi.mocked(generateOtp);
 const mockVerifyOtp = vi.mocked(verifyOtp);
 const mockParseAddInput = vi.mocked(parseAddInput);
@@ -134,9 +140,9 @@ describe("CLI", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(mockFs.openSync).toHaveBeenCalledWith("/tmp/uids.txt", "a", 0o600);
+      expect(mockFs.openSync).toHaveBeenCalledWith("/tmp/uids.txt", APPEND_FLAGS, 0o600);
       expect(mockFs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
-      expect(mockFs.writeSync).toHaveBeenCalledWith(FD, "test-uid\n");
+      expect(mockFs.writeFileSync).toHaveBeenCalledWith(FD, "test-uid\n");
       expect(mockFs.closeSync).toHaveBeenCalledWith(FD);
     });
 

--- a/packages/otplib-cli/src/otplib/index.test.ts
+++ b/packages/otplib-cli/src/otplib/index.test.ts
@@ -4,9 +4,8 @@ import { Readable } from "node:stream";
 // Mock all dependencies before importing
 vi.mock("node:fs", () => ({
   default: {
-    openSync: vi.fn(),
-    writeSync: vi.fn(),
-    closeSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    chmodSync: vi.fn(),
   },
 }));
 
@@ -124,7 +123,6 @@ describe("CLI", () => {
       mockParseAddInput.mockReturnValue(mockData as ReturnType<typeof parseAddInput>);
       mockGenerateUid.mockReturnValue("test-uid");
       mockEncodePayload.mockReturnValue("payload");
-      mockFs.openSync.mockReturnValue(3);
 
       const { exitCode } = await runCli(
         ["encode", "--save-uid", "/tmp/uids.txt"],
@@ -132,9 +130,11 @@ describe("CLI", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(mockFs.openSync).toHaveBeenCalledWith("/tmp/uids.txt", "a", 0o600);
-      expect(mockFs.writeSync).toHaveBeenCalledWith(3, "test-uid\n");
-      expect(mockFs.closeSync).toHaveBeenCalledWith(3);
+      expect(mockFs.writeFileSync).toHaveBeenCalledWith("/tmp/uids.txt", "test-uid\n", {
+        mode: 0o600,
+        flag: "a",
+      });
+      expect(mockFs.chmodSync).toHaveBeenCalledWith("/tmp/uids.txt", 0o600);
     });
 
     test("handles file save error gracefully", async () => {
@@ -142,7 +142,7 @@ describe("CLI", () => {
       mockParseAddInput.mockReturnValue(mockData as ReturnType<typeof parseAddInput>);
       mockGenerateUid.mockReturnValue("test-uid");
       mockEncodePayload.mockReturnValue("payload");
-      mockFs.openSync.mockImplementation(() => {
+      mockFs.writeFileSync.mockImplementation(() => {
         throw new Error("Permission denied");
       });
 

--- a/packages/otplib-cli/src/otplib/index.test.ts
+++ b/packages/otplib-cli/src/otplib/index.test.ts
@@ -4,8 +4,10 @@ import { Readable } from "node:stream";
 // Mock all dependencies before importing
 vi.mock("node:fs", () => ({
   default: {
-    writeFileSync: vi.fn(),
-    chmodSync: vi.fn(),
+    openSync: vi.fn(),
+    fchmodSync: vi.fn(),
+    writeSync: vi.fn(),
+    closeSync: vi.fn(),
   },
 }));
 
@@ -39,6 +41,7 @@ import { createCli } from "./index.js";
 import { encodePayload, formatOutput, generateUid, getLabel } from "../shared/types.js";
 
 const mockFs = vi.mocked(fs);
+const FD = 42;
 const mockGenerateOtp = vi.mocked(generateOtp);
 const mockVerifyOtp = vi.mocked(verifyOtp);
 const mockParseAddInput = vi.mocked(parseAddInput);
@@ -81,6 +84,7 @@ describe("CLI", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockFs.openSync.mockReturnValue(FD);
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -130,11 +134,10 @@ describe("CLI", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(mockFs.writeFileSync).toHaveBeenCalledWith("/tmp/uids.txt", "test-uid\n", {
-        mode: 0o600,
-        flag: "a",
-      });
-      expect(mockFs.chmodSync).toHaveBeenCalledWith("/tmp/uids.txt", 0o600);
+      expect(mockFs.openSync).toHaveBeenCalledWith("/tmp/uids.txt", "a", 0o600);
+      expect(mockFs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
+      expect(mockFs.writeSync).toHaveBeenCalledWith(FD, "test-uid\n");
+      expect(mockFs.closeSync).toHaveBeenCalledWith(FD);
     });
 
     test("handles file save error gracefully", async () => {
@@ -142,7 +145,7 @@ describe("CLI", () => {
       mockParseAddInput.mockReturnValue(mockData as ReturnType<typeof parseAddInput>);
       mockGenerateUid.mockReturnValue("test-uid");
       mockEncodePayload.mockReturnValue("payload");
-      mockFs.writeFileSync.mockImplementation(() => {
+      mockFs.openSync.mockImplementation(() => {
         throw new Error("Permission denied");
       });
 

--- a/packages/otplib-cli/src/otplibx/storage/errors.ts
+++ b/packages/otplib-cli/src/otplibx/storage/errors.ts
@@ -4,6 +4,7 @@ export const ErrorCodes = {
   DECRYPT_FAILED: "DECRYPT_FAILED",
   FILE_NOT_FOUND: "FILE_NOT_FOUND",
   ALREADY_INITIALIZED: "ALREADY_INITIALIZED",
+  INSECURE_PERMISSIONS: "INSECURE_PERMISSIONS",
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/packages/otplib-cli/src/otplibx/storage/native-aes.test.ts
+++ b/packages/otplib-cli/src/otplibx/storage/native-aes.test.ts
@@ -14,13 +14,19 @@ describe("native-aes storage", () => {
   const testIv = Buffer.alloc(12, 0x01);
   const testAuthTag = Buffer.alloc(16, 0x02);
 
+  const originalPlatform = process.platform;
+
   beforeEach(() => {
     vi.resetAllMocks();
     delete process.env.OTPLIBX_ENCRYPTION_KEY;
+    // Default to secure (owner-only) permissions on all statted files unless
+    // a test overrides this to simulate a group/world-readable file.
+    vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
   });
 
   afterEach(() => {
     delete process.env.OTPLIBX_ENCRYPTION_KEY;
+    Object.defineProperty(process, "platform", { value: originalPlatform });
   });
 
   describe("status", () => {
@@ -97,13 +103,45 @@ describe("native-aes storage", () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         ".env.keys",
         expect.stringContaining("OTPLIBX_ENCRYPTION_KEY="),
-        { mode: 0o600 },
+        { mode: 0o600, flag: "w" },
       );
 
       // Should write env file
       expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "", {
         mode: 0o600,
+        flag: "w",
       });
+
+      // Both files should be chmod'd to 0600 after writing, even though the
+      // mode option on writeFileSync only takes effect on file creation.
+      expect(fs.chmodSync).toHaveBeenCalledWith(".env.keys", 0o600);
+      expect(fs.chmodSync).toHaveBeenCalledWith(".env.otplibx", 0o600);
+    });
+
+    test("chmods pre-existing files to 0600 even if they were 0644", async () => {
+      // Simulate: keys file already exists (e.g. checked out from git with a
+      // permissive umask), env file does not exist yet.
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        return p.toString() === ".env.keys";
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue("");
+      vi.mocked(crypto.randomBytes).mockReturnValue(Buffer.alloc(32, 0xab) as unknown as void);
+
+      await nativeAesStorage.init(".env.otplibx");
+
+      expect(fs.chmodSync).toHaveBeenCalledWith(".env.keys", 0o600);
+      expect(fs.chmodSync).toHaveBeenCalledWith(".env.otplibx", 0o600);
+    });
+
+    test("does not chmod on Windows", async () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(crypto.randomBytes).mockReturnValue(Buffer.alloc(32, 0xab) as unknown as void);
+
+      await nativeAesStorage.init(".env.otplibx");
+
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      expect(fs.chmodSync).not.toHaveBeenCalled();
     });
   });
 
@@ -200,8 +238,9 @@ describe("native-aes storage", () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         ".env.otplibx",
         expect.stringMatching(/KEY=.*encrypted:/),
-        { mode: 0o600 },
+        { mode: 0o600, flag: "w" },
       );
+      expect(fs.chmodSync).toHaveBeenCalledWith(".env.otplibx", 0o600);
     });
 
     test("removes key when value is empty", async () => {
@@ -211,7 +250,10 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.set(".env.otplibx", "KEY", "");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "", { mode: 0o600 });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "", {
+        mode: 0o600,
+        flag: "w",
+      });
     });
   });
 
@@ -230,7 +272,10 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.remove(".env.otplibx", "KEY1");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "KEY2=value2", { mode: 0o600 });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "KEY2=value2", {
+        mode: 0o600,
+        flag: "w",
+      });
     });
   });
 
@@ -420,12 +465,12 @@ describe("native-aes storage", () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         ".env.keys",
         expect.stringContaining("OTHER_KEY=somevalue"),
-        { mode: 0o600 },
+        { mode: 0o600, flag: "w" },
       );
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         ".env.keys",
         expect.stringContaining("OTPLIBX_ENCRYPTION_KEY="),
-        { mode: 0o600 },
+        { mode: 0o600, flag: "w" },
       );
     });
   });
@@ -443,6 +488,105 @@ describe("native-aes storage", () => {
         expect(err).toBeInstanceOf(OtplibxStorageError);
         expect((err as OtplibxStorageError).code).toBe(ErrorCodes.NOT_INITIALIZED);
       }
+    });
+  });
+
+  describe("key file permission enforcement", () => {
+    function mockExistingKeyFile() {
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        const pathStr = p.toString();
+        return pathStr === ".env.otplibx" || pathStr === ".env.keys";
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((p: fs.PathOrFileDescriptor) => {
+        const pathStr = p.toString();
+        if (pathStr === ".env.keys") {
+          return `OTPLIBX_ENCRYPTION_KEY=${testKey}`;
+        }
+        return "KEY=plaintext";
+      });
+    }
+
+    test("throws when the .env.keys file is group/world readable (0644)", async () => {
+      mockExistingKeyFile();
+      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+
+      try {
+        await nativeAesStorage.load(".env.otplibx");
+        expect.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(OtplibxStorageError);
+        expect((err as OtplibxStorageError).code).toBe(ErrorCodes.INSECURE_PERMISSIONS);
+        expect((err as OtplibxStorageError).message).toContain("chmod 600 .env.keys");
+      }
+    });
+
+    test("succeeds when the .env.keys file is 0600", async () => {
+      mockExistingKeyFile();
+      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
+
+      const result = await nativeAesStorage.load(".env.otplibx");
+
+      expect(result.KEY).toBe("plaintext");
+    });
+
+    test("does not check permissions on Windows", async () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      mockExistingKeyFile();
+      // If the permission check ran, this insecure mode would throw.
+      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+
+      const result = await nativeAesStorage.load(".env.otplibx");
+
+      expect(result.KEY).toBe("plaintext");
+      expect(fs.statSync).not.toHaveBeenCalledWith(".env.keys");
+    });
+  });
+
+  describe("vault file permission warning", () => {
+    test("warns to stderr (does not throw) when the vault file is group/world readable", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue("");
+      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+
+      const result = await nativeAesStorage.load(".env.otplibx");
+
+      expect(result).toEqual({});
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("chmod 600 .env.otplibx"),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test("does not warn when the vault file is 0600", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue("");
+      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
+
+      await nativeAesStorage.load(".env.otplibx");
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test("does not check permissions on Windows", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      Object.defineProperty(process, "platform", { value: "win32" });
+      process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue("");
+      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+
+      await nativeAesStorage.load(".env.otplibx");
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/packages/otplib-cli/src/otplibx/storage/native-aes.test.ts
+++ b/packages/otplib-cli/src/otplibx/storage/native-aes.test.ts
@@ -8,6 +8,9 @@ import { nativeAesStorage } from "./native-aes.js";
 vi.mock("node:fs");
 vi.mock("node:crypto");
 
+const WRITE_FLAGS =
+  fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW;
+
 describe("native-aes storage", () => {
   const testKey = "a".repeat(64); // 64 hex chars = 32 bytes
   const testKeyBuffer = Buffer.from(testKey, "hex");
@@ -21,9 +24,13 @@ describe("native-aes storage", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     delete process.env.OTPLIBX_ENCRYPTION_KEY;
-    // Default to secure (owner-only) permissions on all statted files unless
-    // a test overrides this to simulate a group/world-readable file.
-    vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
+    // Default to secure (owner-only, non-symlink) permissions on all
+    // lstatted files unless a test overrides this to simulate a
+    // group/world-readable or symlinked file.
+    vi.mocked(fs.lstatSync).mockReturnValue({
+      mode: 0o600,
+      isSymbolicLink: () => false,
+    } as unknown as fs.Stats);
     vi.mocked(fs.openSync).mockReturnValue(FD);
   });
 
@@ -103,15 +110,15 @@ describe("native-aes storage", () => {
       await nativeAesStorage.init(".env.otplibx");
 
       // Should open and write the keys file, applying 0600 through the fd.
-      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", "w", 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(
+      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", WRITE_FLAGS, 0o600);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
         FD,
         expect.stringContaining("OTPLIBX_ENCRYPTION_KEY="),
       );
 
       // Should open and write the env file the same way.
-      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, "");
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", WRITE_FLAGS, 0o600);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, "");
 
       // Both files should be fchmod'd to 0600 before writing, even though the
       // mode option on openSync only takes effect on file creation.
@@ -130,8 +137,8 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.init(".env.otplibx");
 
-      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", "w", 0o600);
-      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", WRITE_FLAGS, 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", WRITE_FLAGS, 0o600);
       expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
     });
 
@@ -142,7 +149,7 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.init(".env.otplibx");
 
-      expect(fs.writeSync).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalled();
       expect(fs.fchmodSync).not.toHaveBeenCalled();
     });
   });
@@ -237,8 +244,8 @@ describe("native-aes storage", () => {
       await nativeAesStorage.set(".env.otplibx", "KEY", "value");
 
       expect(crypto.createCipheriv).toHaveBeenCalledWith("aes-256-gcm", testKeyBuffer, testIv);
-      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, expect.stringMatching(/KEY=.*encrypted:/));
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", WRITE_FLAGS, 0o600);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, expect.stringMatching(/KEY=.*encrypted:/));
       expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
     });
 
@@ -249,8 +256,8 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.set(".env.otplibx", "KEY", "");
 
-      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, "");
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", WRITE_FLAGS, 0o600);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, "");
     });
   });
 
@@ -269,8 +276,8 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.remove(".env.otplibx", "KEY1");
 
-      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, "KEY2=value2");
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", WRITE_FLAGS, 0o600);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, "KEY2=value2");
     });
   });
 
@@ -457,9 +464,12 @@ describe("native-aes storage", () => {
       await nativeAesStorage.init(".env.otplibx");
 
       expect(fs.readFileSync).toHaveBeenCalledWith(".env.keys", "utf8");
-      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", "w", 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, expect.stringContaining("OTHER_KEY=somevalue"));
-      expect(fs.writeSync).toHaveBeenCalledWith(
+      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", WRITE_FLAGS, 0o600);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        FD,
+        expect.stringContaining("OTHER_KEY=somevalue"),
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
         FD,
         expect.stringContaining("OTPLIBX_ENCRYPTION_KEY="),
       );
@@ -499,7 +509,10 @@ describe("native-aes storage", () => {
 
     test("throws when the .env.keys file is group/world readable (0644)", async () => {
       mockExistingKeyFile();
-      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o644,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
 
       try {
         await nativeAesStorage.load(".env.otplibx");
@@ -513,23 +526,46 @@ describe("native-aes storage", () => {
 
     test("succeeds when the .env.keys file is 0600", async () => {
       mockExistingKeyFile();
-      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o600,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
 
       const result = await nativeAesStorage.load(".env.otplibx");
 
       expect(result.KEY).toBe("plaintext");
     });
 
+    test("throws when the .env.keys file is a symlink, even if it reports 0600", async () => {
+      mockExistingKeyFile();
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o600,
+        isSymbolicLink: () => true,
+      } as unknown as fs.Stats);
+
+      try {
+        await nativeAesStorage.load(".env.otplibx");
+        expect.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(OtplibxStorageError);
+        expect((err as OtplibxStorageError).code).toBe(ErrorCodes.INSECURE_PERMISSIONS);
+        expect((err as OtplibxStorageError).message).toContain("symlink");
+      }
+    });
+
     test("does not check permissions on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
       mockExistingKeyFile();
       // If the permission check ran, this insecure mode would throw.
-      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o644,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
 
       const result = await nativeAesStorage.load(".env.otplibx");
 
       expect(result.KEY).toBe("plaintext");
-      expect(fs.statSync).not.toHaveBeenCalledWith(".env.keys");
+      expect(fs.lstatSync).not.toHaveBeenCalledWith(".env.keys");
     });
   });
 
@@ -539,7 +575,10 @@ describe("native-aes storage", () => {
       process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue("");
-      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o644,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
 
       const result = await nativeAesStorage.load(".env.otplibx");
 
@@ -551,12 +590,33 @@ describe("native-aes storage", () => {
       consoleErrorSpy.mockRestore();
     });
 
+    test("warns to stderr (does not throw) when the vault file is a symlink", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue("");
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o600,
+        isSymbolicLink: () => true,
+      } as unknown as fs.Stats);
+
+      const result = await nativeAesStorage.load(".env.otplibx");
+
+      expect(result).toEqual({});
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("symlink"));
+
+      consoleErrorSpy.mockRestore();
+    });
+
     test("does not warn when the vault file is 0600", async () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue("");
-      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o600,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
 
       await nativeAesStorage.load(".env.otplibx");
 
@@ -571,13 +631,38 @@ describe("native-aes storage", () => {
       process.env.OTPLIBX_ENCRYPTION_KEY = testKey;
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue("");
-      vi.mocked(fs.statSync).mockReturnValue({ mode: 0o644 } as fs.Stats);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o644,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
 
       await nativeAesStorage.load(".env.otplibx");
 
       expect(consoleErrorSpy).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("status permission enforcement", () => {
+    test("throws (rather than reporting as usable) when the .env.keys file is insecure", async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        const pathStr = p.toString();
+        return pathStr === ".env.otplibx" || pathStr === ".env.keys";
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(`OTPLIBX_ENCRYPTION_KEY=${testKey}`);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        mode: 0o644,
+        isSymbolicLink: () => false,
+      } as unknown as fs.Stats);
+
+      await expect(nativeAesStorage.status(".env.otplibx")).rejects.toThrow(OtplibxStorageError);
+
+      try {
+        await nativeAesStorage.status(".env.otplibx");
+      } catch (err) {
+        expect((err as OtplibxStorageError).code).toBe(ErrorCodes.INSECURE_PERMISSIONS);
+      }
     });
   });
 });

--- a/packages/otplib-cli/src/otplibx/storage/native-aes.test.ts
+++ b/packages/otplib-cli/src/otplibx/storage/native-aes.test.ts
@@ -16,12 +16,15 @@ describe("native-aes storage", () => {
 
   const originalPlatform = process.platform;
 
+  const FD = 42;
+
   beforeEach(() => {
     vi.resetAllMocks();
     delete process.env.OTPLIBX_ENCRYPTION_KEY;
     // Default to secure (owner-only) permissions on all statted files unless
     // a test overrides this to simulate a group/world-readable file.
     vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats);
+    vi.mocked(fs.openSync).mockReturnValue(FD);
   });
 
   afterEach(() => {
@@ -99,23 +102,21 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.init(".env.otplibx");
 
-      // Should write keys file
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        ".env.keys",
+      // Should open and write the keys file, applying 0600 through the fd.
+      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", "w", 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(
+        FD,
         expect.stringContaining("OTPLIBX_ENCRYPTION_KEY="),
-        { mode: 0o600, flag: "w" },
       );
 
-      // Should write env file
-      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "", {
-        mode: 0o600,
-        flag: "w",
-      });
+      // Should open and write the env file the same way.
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, "");
 
-      // Both files should be chmod'd to 0600 after writing, even though the
-      // mode option on writeFileSync only takes effect on file creation.
-      expect(fs.chmodSync).toHaveBeenCalledWith(".env.keys", 0o600);
-      expect(fs.chmodSync).toHaveBeenCalledWith(".env.otplibx", 0o600);
+      // Both files should be fchmod'd to 0600 before writing, even though the
+      // mode option on openSync only takes effect on file creation.
+      expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
+      expect(fs.closeSync).toHaveBeenCalledWith(FD);
     });
 
     test("chmods pre-existing files to 0600 even if they were 0644", async () => {
@@ -129,8 +130,9 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.init(".env.otplibx");
 
-      expect(fs.chmodSync).toHaveBeenCalledWith(".env.keys", 0o600);
-      expect(fs.chmodSync).toHaveBeenCalledWith(".env.otplibx", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", "w", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
+      expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
     });
 
     test("does not chmod on Windows", async () => {
@@ -140,8 +142,8 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.init(".env.otplibx");
 
-      expect(fs.writeFileSync).toHaveBeenCalled();
-      expect(fs.chmodSync).not.toHaveBeenCalled();
+      expect(fs.writeSync).toHaveBeenCalled();
+      expect(fs.fchmodSync).not.toHaveBeenCalled();
     });
   });
 
@@ -235,12 +237,9 @@ describe("native-aes storage", () => {
       await nativeAesStorage.set(".env.otplibx", "KEY", "value");
 
       expect(crypto.createCipheriv).toHaveBeenCalledWith("aes-256-gcm", testKeyBuffer, testIv);
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        ".env.otplibx",
-        expect.stringMatching(/KEY=.*encrypted:/),
-        { mode: 0o600, flag: "w" },
-      );
-      expect(fs.chmodSync).toHaveBeenCalledWith(".env.otplibx", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, expect.stringMatching(/KEY=.*encrypted:/));
+      expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
     });
 
     test("removes key when value is empty", async () => {
@@ -250,10 +249,8 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.set(".env.otplibx", "KEY", "");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "", {
-        mode: 0o600,
-        flag: "w",
-      });
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, "");
     });
   });
 
@@ -272,10 +269,8 @@ describe("native-aes storage", () => {
 
       await nativeAesStorage.remove(".env.otplibx", "KEY1");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(".env.otplibx", "KEY2=value2", {
-        mode: 0o600,
-        flag: "w",
-      });
+      expect(fs.openSync).toHaveBeenCalledWith(".env.otplibx", "w", 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, "KEY2=value2");
     });
   });
 
@@ -462,15 +457,11 @@ describe("native-aes storage", () => {
       await nativeAesStorage.init(".env.otplibx");
 
       expect(fs.readFileSync).toHaveBeenCalledWith(".env.keys", "utf8");
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        ".env.keys",
-        expect.stringContaining("OTHER_KEY=somevalue"),
-        { mode: 0o600, flag: "w" },
-      );
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        ".env.keys",
+      expect(fs.openSync).toHaveBeenCalledWith(".env.keys", "w", 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, expect.stringContaining("OTHER_KEY=somevalue"));
+      expect(fs.writeSync).toHaveBeenCalledWith(
+        FD,
         expect.stringContaining("OTPLIBX_ENCRYPTION_KEY="),
-        { mode: 0o600, flag: "w" },
       );
     });
   });

--- a/packages/otplib-cli/src/otplibx/storage/native-aes.ts
+++ b/packages/otplib-cli/src/otplibx/storage/native-aes.ts
@@ -102,35 +102,57 @@ function getKeysFilePath(envFilePath: string): string {
 }
 
 /**
- * Throw if `filePath` is readable/writable by the group or other bits
- * (i.e. anything beyond owner rwx). No-op on Windows, where POSIX mode
- * bits are not meaningful.
+ * Throw if `filePath` is a symlink, or is readable/writable by the group
+ * or other bits (i.e. anything beyond owner rwx). `lstatSync` (rather than
+ * `statSync`) is used deliberately so a symlink is inspected itself rather
+ * than followed — a symlink planted at `filePath` pointing at an
+ * attacker-controlled file would otherwise read as whatever mode that
+ * target happens to have, defeating the check. No-op on Windows, where
+ * POSIX mode bits are not meaningful.
+ *
+ * This only inspects `filePath` itself: a 0600 key file inside a
+ * world-writable directory can still be replaced or deleted by another
+ * user, since directory write permission — not the file's own mode —
+ * controls unlink/rename. Keep the containing directory private too.
  */
 function assertSecurePermissions(filePath: string): void {
   if (process.platform === "win32") {
     return;
   }
-  const { mode } = fs.statSync(filePath);
-  if ((mode & 0o077) !== 0) {
+  const stats = fs.lstatSync(filePath);
+  if (stats.isSymbolicLink()) {
     throw new OtplibxStorageError(
-      `Encryption key file is readable by group/other: ${filePath}. Run 'chmod 600 ${filePath}' and try again.`,
+      `Encryption key file is a symlink, which is not allowed: ${filePath}. Replace it with a regular file.`,
+      ErrorCodes.INSECURE_PERMISSIONS,
+    );
+  }
+  if ((stats.mode & 0o077) !== 0) {
+    throw new OtplibxStorageError(
+      `Encryption key file is readable by group/other: ${filePath}. Run 'chmod 600 ${filePath}' and try again, or set ${ENV_VAR_NAME} to bypass the file entirely.`,
       ErrorCodes.INSECURE_PERMISSIONS,
     );
   }
 }
 
 /**
- * Warn (without blocking) if `filePath` is readable/writable by the
- * group or other bits. Used for the vault file, which is ciphertext —
- * unlike the key file, an over-permissive vault is not fatal, but it's
- * still worth flagging so the user can tighten it. No-op on Windows.
+ * Warn (without blocking) if `filePath` is a symlink, or is readable/
+ * writable by the group or other bits. Used for the vault file, which is
+ * ciphertext — unlike the key file, an over-permissive or symlinked vault
+ * is not fatal, but it's still worth flagging so the user can tighten it.
+ * Uses `lstatSync` for the same reason as `assertSecurePermissions`: a
+ * symlink is reported as itself, not as whatever it points at. No-op on
+ * Windows.
  */
 function warnIfInsecurePermissions(filePath: string): void {
   if (process.platform === "win32") {
     return;
   }
-  const { mode } = fs.statSync(filePath);
-  if ((mode & 0o077) !== 0) {
+  const stats = fs.lstatSync(filePath);
+  if (stats.isSymbolicLink()) {
+    console.error(`Warning: ${filePath} is a symlink. Replace it with a regular file.`);
+    return;
+  }
+  if ((stats.mode & 0o077) !== 0) {
     console.error(
       `Warning: ${filePath} is readable by group/other. Run 'chmod 600 ${filePath}' to restrict access.`,
     );
@@ -171,18 +193,12 @@ export const nativeAesStorage: OtplibxStorage = {
     const envExists = fs.existsSync(filePath);
     const keysPath = getKeysFilePath(filePath);
     const keysExists = fs.existsSync(keysPath);
-    const envKeyExists = !!process.env[ENV_VAR_NAME];
 
-    let keySource: "env" | "file" | null = null;
-    if (envKeyExists) {
-      keySource = "env";
-    } else if (keysExists) {
-      const content = fs.readFileSync(keysPath, "utf8");
-      const { entries } = parseEnvFile(content);
-      if (entries.has(ENV_VAR_NAME)) {
-        keySource = "file";
-      }
-    }
+    // Routed through findKey() (the same lookup load()/set() use) so status
+    // is subject to the same permission check on .env.keys — otherwise a
+    // key file with loose permissions would report as usable here while
+    // every other command refuses to read it.
+    const keySource = findKey(filePath)?.source ?? null;
 
     return {
       initialized: envExists && keySource !== null,

--- a/packages/otplib-cli/src/otplibx/storage/native-aes.ts
+++ b/packages/otplib-cli/src/otplibx/storage/native-aes.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { parseEnvFile, serializeEnvFile } from "./env-parser.js";
 import { ErrorCodes, OtplibxStorageError } from "./errors.js";
+import { writeSecretFile } from "../../shared/secure-file.js";
 
 import type { OtplibxStorage, StorageStatus } from "./types.js";
 
@@ -101,6 +102,42 @@ function getKeysFilePath(envFilePath: string): string {
 }
 
 /**
+ * Throw if `filePath` is readable/writable by the group or other bits
+ * (i.e. anything beyond owner rwx). No-op on Windows, where POSIX mode
+ * bits are not meaningful.
+ */
+function assertSecurePermissions(filePath: string): void {
+  if (process.platform === "win32") {
+    return;
+  }
+  const { mode } = fs.statSync(filePath);
+  if ((mode & 0o077) !== 0) {
+    throw new OtplibxStorageError(
+      `Encryption key file is readable by group/other: ${filePath}. Run 'chmod 600 ${filePath}' and try again.`,
+      ErrorCodes.INSECURE_PERMISSIONS,
+    );
+  }
+}
+
+/**
+ * Warn (without blocking) if `filePath` is readable/writable by the
+ * group or other bits. Used for the vault file, which is ciphertext —
+ * unlike the key file, an over-permissive vault is not fatal, but it's
+ * still worth flagging so the user can tighten it. No-op on Windows.
+ */
+function warnIfInsecurePermissions(filePath: string): void {
+  if (process.platform === "win32") {
+    return;
+  }
+  const { mode } = fs.statSync(filePath);
+  if ((mode & 0o077) !== 0) {
+    console.error(
+      `Warning: ${filePath} is readable by group/other. Run 'chmod 600 ${filePath}' to restrict access.`,
+    );
+  }
+}
+
+/**
  * Find the encryption key from environment variable or .env.keys file
  */
 function findKey(envFilePath: string): { key: Buffer; source: "env" | "file" } | null {
@@ -113,6 +150,8 @@ function findKey(envFilePath: string): { key: Buffer; source: "env" | "file" } |
   // Then, check .env.keys file
   const keysPath = getKeysFilePath(envFilePath);
   if (fs.existsSync(keysPath)) {
+    assertSecurePermissions(keysPath);
+
     const content = fs.readFileSync(keysPath, "utf8");
     const { entries } = parseEnvFile(content);
     const fileKey = entries.get(ENV_VAR_NAME);
@@ -176,16 +215,18 @@ export const nativeAesStorage: OtplibxStorage = {
     existingEntries.entries.set(ENV_VAR_NAME, key);
     const newKeysContent = serializeEnvFile(keysContent, existingEntries.entries);
 
-    fs.writeFileSync(keysPath, newKeysContent + "\n", { mode: 0o600 });
+    writeSecretFile(keysPath, newKeysContent + "\n");
 
     // Create the empty env file with restricted permissions
-    fs.writeFileSync(filePath, "", { mode: 0o600 });
+    writeSecretFile(filePath, "");
   },
 
   async load(filePath: string): Promise<Record<string, string>> {
     if (!fs.existsSync(filePath)) {
       throw new OtplibxStorageError(`File not found: ${filePath}`, ErrorCodes.FILE_NOT_FOUND);
     }
+
+    warnIfInsecurePermissions(filePath);
 
     const keyResult = findKey(filePath);
     if (!keyResult) {
@@ -231,7 +272,7 @@ export const nativeAesStorage: OtplibxStorage = {
     }
 
     const newContent = serializeEnvFile(content, entries);
-    fs.writeFileSync(filePath, newContent, { mode: 0o600 });
+    writeSecretFile(filePath, newContent);
   },
 
   async remove(filePath: string, key: string): Promise<void> {
@@ -244,7 +285,7 @@ export const nativeAesStorage: OtplibxStorage = {
     entries.delete(key);
 
     const newContent = serializeEnvFile(content, entries);
-    fs.writeFileSync(filePath, newContent, { mode: 0o600 });
+    writeSecretFile(filePath, newContent);
   },
 };
 

--- a/packages/otplib-cli/src/shared/secure-file.real-fs.test.ts
+++ b/packages/otplib-cli/src/shared/secure-file.real-fs.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { writeSecretFile } from "./secure-file.js";
+
+// Deliberately does NOT mock node:fs — secure-file.test.ts verifies the call
+// sequence against mocks, but that leaves the actual resulting permission
+// bits (the entire point of the module) unverified. These tests exercise
+// the real filesystem.
+describe("secure-file (real fs)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "otplib-secure-file-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("creates a new file with 0600 permissions", () => {
+    const filePath = path.join(dir, "secret");
+
+    writeSecretFile(filePath, "content");
+
+    expect(fs.readFileSync(filePath, "utf8")).toBe("content");
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+
+  test("tightens an existing 0644 file to 0600 and overwrites its content", () => {
+    const filePath = path.join(dir, "secret");
+    fs.writeFileSync(filePath, "stale", { mode: 0o644 });
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o644);
+
+    writeSecretFile(filePath, "fresh");
+
+    expect(fs.readFileSync(filePath, "utf8")).toBe("fresh");
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+
+  test("appends to an existing file while keeping 0600 permissions", () => {
+    const filePath = path.join(dir, "secret");
+    fs.writeFileSync(filePath, "first\n", { mode: 0o644 });
+
+    writeSecretFile(filePath, "second\n", "a");
+
+    expect(fs.readFileSync(filePath, "utf8")).toBe("first\nsecond\n");
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+
+  test("refuses to write through a symlink", () => {
+    const targetPath = path.join(dir, "attacker-owned");
+    fs.writeFileSync(targetPath, "untouched", { mode: 0o600 });
+    const linkPath = path.join(dir, "secret");
+    fs.symlinkSync(targetPath, linkPath);
+
+    expect(() => writeSecretFile(linkPath, "content")).toThrow(/symlink/i);
+
+    expect(fs.readFileSync(targetPath, "utf8")).toBe("untouched");
+  });
+});

--- a/packages/otplib-cli/src/shared/secure-file.test.ts
+++ b/packages/otplib-cli/src/shared/secure-file.test.ts
@@ -5,6 +5,10 @@ import { writeSecretFile } from "./secure-file.js";
 
 vi.mock("node:fs");
 
+const { O_WRONLY, O_CREAT, O_TRUNC, O_APPEND, O_NOFOLLOW } = fs.constants;
+const WRITE_FLAGS = O_WRONLY | O_CREAT | O_TRUNC;
+const APPEND_FLAGS = O_WRONLY | O_CREAT | O_APPEND;
+
 describe("secure-file", () => {
   const originalPlatform = process.platform;
   const FD = 42;
@@ -22,14 +26,14 @@ describe("secure-file", () => {
     test("opens, fchmods, writes and closes in order, defaulting to overwrite", () => {
       writeSecretFile("/tmp/secret", "content");
 
-      expect(fs.openSync).toHaveBeenCalledWith("/tmp/secret", "w", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith("/tmp/secret", WRITE_FLAGS | O_NOFOLLOW, 0o600);
       expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, "content");
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, "content");
       expect(fs.closeSync).toHaveBeenCalledWith(FD);
 
       const openOrder = vi.mocked(fs.openSync).mock.invocationCallOrder[0];
       const fchmodOrder = vi.mocked(fs.fchmodSync).mock.invocationCallOrder[0];
-      const writeOrder = vi.mocked(fs.writeSync).mock.invocationCallOrder[0];
+      const writeOrder = vi.mocked(fs.writeFileSync).mock.invocationCallOrder[0];
       const closeOrder = vi.mocked(fs.closeSync).mock.invocationCallOrder[0];
 
       expect(openOrder).toBeLessThan(fchmodOrder);
@@ -40,20 +44,20 @@ describe("secure-file", () => {
     test("supports append flag", () => {
       writeSecretFile("/tmp/secret", "more\n", "a");
 
-      expect(fs.openSync).toHaveBeenCalledWith("/tmp/secret", "a", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith("/tmp/secret", APPEND_FLAGS | O_NOFOLLOW, 0o600);
       expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, "more\n");
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, "more\n");
       expect(fs.closeSync).toHaveBeenCalledWith(FD);
     });
 
-    test("does not chmod on Windows, but still writes and closes", () => {
+    test("does not chmod or set O_NOFOLLOW on Windows, but still writes and closes", () => {
       Object.defineProperty(process, "platform", { value: "win32" });
 
       writeSecretFile("C:\\secret", "content");
 
-      expect(fs.openSync).toHaveBeenCalledWith("C:\\secret", "w", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith("C:\\secret", WRITE_FLAGS, 0o600);
       expect(fs.fchmodSync).not.toHaveBeenCalled();
-      expect(fs.writeSync).toHaveBeenCalledWith(FD, "content");
+      expect(fs.writeFileSync).toHaveBeenCalledWith(FD, "content");
       expect(fs.closeSync).toHaveBeenCalledWith(FD);
     });
 
@@ -65,8 +69,30 @@ describe("secure-file", () => {
 
       expect(() => writeSecretFile("/tmp/secret", "content")).toThrow(error);
 
-      expect(fs.writeSync).not.toHaveBeenCalled();
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
       expect(fs.closeSync).toHaveBeenCalledWith(FD);
+    });
+
+    test("refuses to write through a symlink (ELOOP from the O_NOFOLLOW open)", () => {
+      const error = Object.assign(new Error("ELOOP"), { code: "ELOOP" });
+      vi.mocked(fs.openSync).mockImplementation(() => {
+        throw error;
+      });
+
+      expect(() => writeSecretFile("/tmp/secret", "content")).toThrow(/symlink/i);
+
+      expect(fs.fchmodSync).not.toHaveBeenCalled();
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+      expect(fs.closeSync).not.toHaveBeenCalled();
+    });
+
+    test("rethrows other open errors unchanged", () => {
+      const error = Object.assign(new Error("EACCES"), { code: "EACCES" });
+      vi.mocked(fs.openSync).mockImplementation(() => {
+        throw error;
+      });
+
+      expect(() => writeSecretFile("/tmp/secret", "content")).toThrow(error);
     });
   });
 });

--- a/packages/otplib-cli/src/shared/secure-file.test.ts
+++ b/packages/otplib-cli/src/shared/secure-file.test.ts
@@ -1,68 +1,72 @@
 import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { chmodSecure, writeSecretFile } from "./secure-file.js";
+import { writeSecretFile } from "./secure-file.js";
 
 vi.mock("node:fs");
 
 describe("secure-file", () => {
   const originalPlatform = process.platform;
+  const FD = 42;
 
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(fs.openSync).mockReturnValue(FD);
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
   });
 
-  describe("chmodSecure", () => {
-    test("chmods the file to 0600 on POSIX platforms", () => {
-      chmodSecure("/tmp/secret");
-
-      expect(fs.chmodSync).toHaveBeenCalledWith("/tmp/secret", 0o600);
-    });
-
-    test("is a no-op on Windows", () => {
-      Object.defineProperty(process, "platform", { value: "win32" });
-
-      chmodSecure("C:\\secret");
-
-      expect(fs.chmodSync).not.toHaveBeenCalled();
-    });
-  });
-
   describe("writeSecretFile", () => {
-    test("writes with mode 0600 and defaults to overwrite", () => {
+    test("opens, fchmods, writes and closes in order, defaulting to overwrite", () => {
       writeSecretFile("/tmp/secret", "content");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/secret", "content", {
-        mode: 0o600,
-        flag: "w",
-      });
-      expect(fs.chmodSync).toHaveBeenCalledWith("/tmp/secret", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith("/tmp/secret", "w", 0o600);
+      expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, "content");
+      expect(fs.closeSync).toHaveBeenCalledWith(FD);
+
+      const openOrder = vi.mocked(fs.openSync).mock.invocationCallOrder[0];
+      const fchmodOrder = vi.mocked(fs.fchmodSync).mock.invocationCallOrder[0];
+      const writeOrder = vi.mocked(fs.writeSync).mock.invocationCallOrder[0];
+      const closeOrder = vi.mocked(fs.closeSync).mock.invocationCallOrder[0];
+
+      expect(openOrder).toBeLessThan(fchmodOrder);
+      expect(fchmodOrder).toBeLessThan(writeOrder);
+      expect(writeOrder).toBeLessThan(closeOrder);
     });
 
     test("supports append flag", () => {
       writeSecretFile("/tmp/secret", "more\n", "a");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/secret", "more\n", {
-        mode: 0o600,
-        flag: "a",
-      });
-      expect(fs.chmodSync).toHaveBeenCalledWith("/tmp/secret", 0o600);
+      expect(fs.openSync).toHaveBeenCalledWith("/tmp/secret", "a", 0o600);
+      expect(fs.fchmodSync).toHaveBeenCalledWith(FD, 0o600);
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, "more\n");
+      expect(fs.closeSync).toHaveBeenCalledWith(FD);
     });
 
-    test("does not chmod on Windows even after writing", () => {
+    test("does not chmod on Windows, but still writes and closes", () => {
       Object.defineProperty(process, "platform", { value: "win32" });
 
       writeSecretFile("C:\\secret", "content");
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith("C:\\secret", "content", {
-        mode: 0o600,
-        flag: "w",
+      expect(fs.openSync).toHaveBeenCalledWith("C:\\secret", "w", 0o600);
+      expect(fs.fchmodSync).not.toHaveBeenCalled();
+      expect(fs.writeSync).toHaveBeenCalledWith(FD, "content");
+      expect(fs.closeSync).toHaveBeenCalledWith(FD);
+    });
+
+    test("closes the descriptor and rethrows without writing when fchmod fails", () => {
+      const error = new Error("fchmod failed");
+      vi.mocked(fs.fchmodSync).mockImplementation(() => {
+        throw error;
       });
-      expect(fs.chmodSync).not.toHaveBeenCalled();
+
+      expect(() => writeSecretFile("/tmp/secret", "content")).toThrow(error);
+
+      expect(fs.writeSync).not.toHaveBeenCalled();
+      expect(fs.closeSync).toHaveBeenCalledWith(FD);
     });
   });
 });

--- a/packages/otplib-cli/src/shared/secure-file.test.ts
+++ b/packages/otplib-cli/src/shared/secure-file.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { chmodSecure, writeSecretFile } from "./secure-file.js";
+
+vi.mock("node:fs");
+
+describe("secure-file", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  describe("chmodSecure", () => {
+    test("chmods the file to 0600 on POSIX platforms", () => {
+      chmodSecure("/tmp/secret");
+
+      expect(fs.chmodSync).toHaveBeenCalledWith("/tmp/secret", 0o600);
+    });
+
+    test("is a no-op on Windows", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      chmodSecure("C:\\secret");
+
+      expect(fs.chmodSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("writeSecretFile", () => {
+    test("writes with mode 0600 and defaults to overwrite", () => {
+      writeSecretFile("/tmp/secret", "content");
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/secret", "content", {
+        mode: 0o600,
+        flag: "w",
+      });
+      expect(fs.chmodSync).toHaveBeenCalledWith("/tmp/secret", 0o600);
+    });
+
+    test("supports append flag", () => {
+      writeSecretFile("/tmp/secret", "more\n", "a");
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith("/tmp/secret", "more\n", {
+        mode: 0o600,
+        flag: "a",
+      });
+      expect(fs.chmodSync).toHaveBeenCalledWith("/tmp/secret", 0o600);
+    });
+
+    test("does not chmod on Windows even after writing", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      writeSecretFile("C:\\secret", "content");
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith("C:\\secret", "content", {
+        mode: 0o600,
+        flag: "w",
+      });
+      expect(fs.chmodSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/otplib-cli/src/shared/secure-file.ts
+++ b/packages/otplib-cli/src/shared/secure-file.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs";
 
+const OPEN_FLAGS: Record<"w" | "a", number> = {
+  w: fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC,
+  a: fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND,
+};
+
 /**
  * Write `content` to `filePath` with 0600 permissions applied through the
  * file descriptor before any content is written, so a broader-permission
@@ -17,18 +22,36 @@ import fs from "node:fs";
  * file's permissions are corrected before any new bytes land.
  *
  * `flag` mirrors `fs.writeFileSync`'s `flag` option: `"w"` (default)
- * overwrites the file, `"a"` appends to it.
+ * overwrites the file, `"a"` appends to it. The write itself goes through
+ * `fs.writeFileSync(fd, ...)` rather than a single `fs.writeSync` call, so a
+ * short underlying write (which `writeSync` does not retry) can't silently
+ * truncate the secret.
  *
- * No-op for the chmod step on Windows, where POSIX permission bits are
- * not meaningful.
+ * On POSIX platforms the open also passes `O_NOFOLLOW`, so a symlink planted
+ * at `filePath` by another party causes the open to fail (`ELOOP`) instead
+ * of writing the secret through to whatever the link points at. No-op for
+ * both the chmod and the symlink check on Windows, where POSIX permission
+ * bits and `O_NOFOLLOW` are not meaningful.
  */
 export function writeSecretFile(filePath: string, content: string, flag: "w" | "a" = "w"): void {
-  const fd = fs.openSync(filePath, flag, 0o600);
+  const isWindows = process.platform === "win32";
+  const openFlags = isWindows ? OPEN_FLAGS[flag] : OPEN_FLAGS[flag] | fs.constants.O_NOFOLLOW;
+
+  let fd: number;
   try {
-    if (process.platform !== "win32") {
+    fd = fs.openSync(filePath, openFlags, 0o600);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") {
+      throw new Error(`Refusing to write through a symlink: ${filePath}`);
+    }
+    throw err;
+  }
+
+  try {
+    if (!isWindows) {
       fs.fchmodSync(fd, 0o600);
     }
-    fs.writeSync(fd, content);
+    fs.writeFileSync(fd, content);
   } finally {
     fs.closeSync(fd);
   }

--- a/packages/otplib-cli/src/shared/secure-file.ts
+++ b/packages/otplib-cli/src/shared/secure-file.ts
@@ -1,29 +1,35 @@
 import fs from "node:fs";
 
 /**
- * Restrict a file to owner-only read/write (0600).
+ * Write `content` to `filePath` with 0600 permissions applied through the
+ * file descriptor before any content is written, so a broader-permission
+ * window is never observable.
  *
- * `fs.writeFileSync`'s `mode` option is only applied when the file is
- * newly created — an existing file keeps whatever mode it already had.
- * Calling this after every write closes that gap.
+ * The sequence is: open the file (creating it with mode 0600 when new),
+ * fchmod the descriptor to 0600 on POSIX platforms, then write and close.
+ * If the fchmod call throws, the descriptor is closed and the error is
+ * rethrown before anything is written — a failed hardening step must not
+ * leave the secret exposed.
  *
- * No-op on Windows, where POSIX permission bits are not meaningful.
- */
-export function chmodSecure(filePath: string): void {
-  if (process.platform === "win32") {
-    return;
-  }
-  fs.chmodSync(filePath, 0o600);
-}
-
-/**
- * Write `content` to `filePath` and enforce 0600 permissions on the
- * resulting file, even if it already existed with broader permissions.
+ * Note: opening an existing file with flag `"w"` truncates it before the
+ * fchmod runs. That is acceptable — truncation only destroys the previous
+ * (already-written) content, it does not expose the new secret, and the
+ * file's permissions are corrected before any new bytes land.
  *
  * `flag` mirrors `fs.writeFileSync`'s `flag` option: `"w"` (default)
  * overwrites the file, `"a"` appends to it.
+ *
+ * No-op for the chmod step on Windows, where POSIX permission bits are
+ * not meaningful.
  */
 export function writeSecretFile(filePath: string, content: string, flag: "w" | "a" = "w"): void {
-  fs.writeFileSync(filePath, content, { mode: 0o600, flag });
-  chmodSecure(filePath);
+  const fd = fs.openSync(filePath, flag, 0o600);
+  try {
+    if (process.platform !== "win32") {
+      fs.fchmodSync(fd, 0o600);
+    }
+    fs.writeSync(fd, content);
+  } finally {
+    fs.closeSync(fd);
+  }
 }

--- a/packages/otplib-cli/src/shared/secure-file.ts
+++ b/packages/otplib-cli/src/shared/secure-file.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+
+/**
+ * Restrict a file to owner-only read/write (0600).
+ *
+ * `fs.writeFileSync`'s `mode` option is only applied when the file is
+ * newly created — an existing file keeps whatever mode it already had.
+ * Calling this after every write closes that gap.
+ *
+ * No-op on Windows, where POSIX permission bits are not meaningful.
+ */
+export function chmodSecure(filePath: string): void {
+  if (process.platform === "win32") {
+    return;
+  }
+  fs.chmodSync(filePath, 0o600);
+}
+
+/**
+ * Write `content` to `filePath` and enforce 0600 permissions on the
+ * resulting file, even if it already existed with broader permissions.
+ *
+ * `flag` mirrors `fs.writeFileSync`'s `flag` option: `"w"` (default)
+ * overwrites the file, `"a"` appends to it.
+ */
+export function writeSecretFile(filePath: string, content: string, flag: "w" | "a" = "w"): void {
+  fs.writeFileSync(filePath, content, { mode: 0o600, flag });
+  chmodSecure(filePath);
+}


### PR DESCRIPTION
## Summary

Two `otplibx` vault hardening issues surfaced by a repo audit.

**Key and vault files were committable.** `otplibx init` writes the AES master key to `.env.keys` next to the vault (default `.env.otplibx` in the working directory). Neither name matched the repo's `.env`, `.env.local` or `.env.*.local` ignore patterns, so running `init` inside a checkout left key and ciphertext side by side, unignored. Both names are now in `.gitignore`, and the CLI docs and README say to keep them out of version control.

**`mode: 0o600` only applied on file creation.** Node applies the `mode` option only when creating the file, so a key or vault file that already existed as 0644 stayed world-readable and nothing checked. A new `writeSecretFile` helper in `shared/secure-file.ts` now opens the descriptor without truncation, applies 0600 through `fchmodSync`, then truncates and writes the content, closing in a `finally`. If the chmod fails nothing is truncated or written, so an existing key or vault file keeps its contents. An earlier revision opened with `O_TRUNC` first, which emptied the file on a chmod failure such as `EPERM`. All five write sites use the helper, and the `--save-uid` append path drops its manual open/write/close for it. The Windows no-op covers only the chmod. The permission and symlink guarantees are POSIX-only and the docs now say so. The docs also no longer claim the key can skip disk entirely, since `init` always writes `.env.keys`; they describe moving the value into `OTPLIBX_ENCRYPTION_KEY` and deleting the file instead.

**Loose key file now refuses to load.** `findKey` stats `.env.keys` on non-Windows platforms and throws a new `INSECURE_PERMISSIONS` error, telling the user to `chmod 600`, if group or other bits are set. The message contains no key material. A loose vault file only warns to stderr, since it holds AES-GCM ciphertext rather than the key, and blocking reads there would trade availability for little risk reduction.

## Semver

Patch, with one behavioural edge to note in the changelog: an existing `.env.keys` left at 0644 or broader will fail to load with `INSECURE_PERMISSIONS` until it is chmod'd, which could affect unattended scripts using a loose key file.

## Test plan

- [x] Call order pinned as open, fchmod, ftruncate, write, close; when fchmod throws nothing is truncated or written, the descriptor is still closed, and a real-filesystem regression proves the previous contents survive
- [x] 0644 key file throws; 0644 vault file warns without throwing; Windows path skipped
- [x] `pnpm fix && pnpm typecheck && pnpm test:ci`, otplib-cli at 100% coverage
- [x] otplib-cli bundle 8.1 KB against a 13 KB limit
